### PR TITLE
docs: fix overflow issue with the content

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -2,9 +2,16 @@
 <html lang="en">
 	<head>
 		<meta charset="utf-8" />
-		<!-- <link rel="icon" href="%sveltekit.assets%/favicon.png" /> -->
-		<link href="favicon-light-mode.png" rel="icon" media="(prefers-color-scheme: light)" />
-		<link href="favicon-dark-mode.png" rel="icon" media="(prefers-color-scheme: dark)" />
+		<link
+			href="%sveltekit.assets%/favicon-light-mode.png"
+			rel="icon"
+			media="(prefers-color-scheme: light)"
+		/>
+		<link
+			href="%sveltekit.assets%/favicon-dark-mode.png"
+			rel="icon"
+			media="(prefers-color-scheme: dark)"
+		/>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		%sveltekit.head%
 	</head>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -14,12 +14,12 @@
 <SiteHeader />
 <main class="min-h-[calc(100vh-64px)]">
 	<div class="mx-auto px-4 sm:px-6 lg:px-8 max-w-7xl">
-		<div class="grid lg:grid-cols-10 lg:gap-10">
+		<div class="lg:grid lg:grid-cols-10 lg:gap-10">
 			<div class="lg:col-span-2">
 				<SidebarNav items={navigation.sidebar} />
 			</div>
 			<div class="lg:col-span-8">
-				<div class="grid lg:grid-cols-10 lg:gap-8">
+				<div class="lg:grid lg:grid-cols-10 lg:gap-8">
 					<div class="lg:col-span-8">
 						<slot />
 					</div>


### PR DESCRIPTION
I noticed on mobile (I'm always on my phone 😄 ) an overflow on the main content. I also noticed that the logo was not used properly as a favicon in the HTML attributes.

![image](https://github.com/huntabyte/bits-ui/assets/46305144/88536aa8-7643-4926-a7c6-a7994fc02453)
