### PR TITLE
Fix: Bug preventing avatar `src` from clearing

### DIFF
--- a/.changeset/olive-hairs-love.md
+++ b/.changeset/olive-hairs-love.md
@@ -1,0 +1,5 @@
+---
+"bits-ui": patch
+---
+
+- Fix: Bug preventing avatar `src` from clearing

--- a/src/lib/bits/avatar/components/AvatarImage.svelte
+++ b/src/lib/bits/avatar/components/AvatarImage.svelte
@@ -8,7 +8,7 @@
 	export let alt: $$Props["alt"] = undefined;
 	export let asChild = false;
 
-	const image = ctx.getImage(src).elements.image;
+	$: image = ctx.getImage(src).elements.image;
 </script>
 
 {#if asChild}

--- a/src/lib/bits/avatar/ctx.ts
+++ b/src/lib/bits/avatar/ctx.ts
@@ -20,7 +20,9 @@ function set(props: CreateAvatarProps) {
 
 function getImage(src: string | undefined | null = "") {
 	const avatar = getContext<AvatarReturn>(NAME);
-	if (src) {
+	if (!src) {
+		avatar.options.src.set("");
+	} else {
 		avatar.options.src.set(src);
 	}
 	return avatar;


### PR DESCRIPTION
Closes: #88 