### PR TITLE
Improve types

### DIFF
--- a/.changeset/short-tomatoes-ring.md
+++ b/.changeset/short-tomatoes-ring.md
@@ -1,0 +1,5 @@
+---
+"bits-ui": patch
+---
+
+Improve prop and `onChange` types

--- a/src/lib/bits/alert-dialog/types.ts
+++ b/src/lib/bits/alert-dialog/types.ts
@@ -14,8 +14,8 @@ import type { CustomEventHandler } from "$lib/index.js";
 
 type Props = Expand<
 	OmitOpen<Omit<CreateDialogProps, "role">> & {
-		open?: CreateDialogProps["defaultOpen"] & {};
-		onOpenChange?: OnChangeFn<CreateDialogProps["defaultOpen"]>;
+		open?: boolean & {};
+		onOpenChange?: OnChangeFn<boolean>;
 	}
 >;
 

--- a/src/lib/bits/checkbox/types.ts
+++ b/src/lib/bits/checkbox/types.ts
@@ -11,8 +11,8 @@ import type { HTMLButtonAttributes, HTMLInputAttributes } from "svelte/elements"
 
 type Props = Expand<
 	OmitChecked<CreateCheckboxProps> & {
-		checked?: CreateCheckboxProps["defaultChecked"] & {};
-		onCheckedChange?: OnChangeFn<CreateCheckboxProps["defaultChecked"]>;
+		checked?: boolean | "indeterminate";
+		onCheckedChange?: OnChangeFn<boolean | "indeterminate">;
 	} & AsChild
 > &
 	HTMLButtonAttributes;

--- a/src/lib/bits/collapsible/types.ts
+++ b/src/lib/bits/collapsible/types.ts
@@ -13,8 +13,8 @@ import type { HTMLButtonAttributes } from "svelte/elements";
 
 type Props = Expand<
 	OmitOpen<CreateCollapsibleProps> & {
-		open?: CreateCollapsibleProps["defaultOpen"] & {};
-		onOpenChange?: OnChangeFn<CreateCollapsibleProps["defaultOpen"]> & {};
+		open?: boolean;
+		onOpenChange?: OnChangeFn<boolean>;
 	}
 > &
 	AsChild &

--- a/src/lib/bits/context-menu/types.ts
+++ b/src/lib/bits/context-menu/types.ts
@@ -20,15 +20,15 @@ import type {
 
 type Props = Expand<
 	OmitOpen<CreateContextMenuProps> & {
-		open?: CreateContextMenuProps["defaultOpen"] & {};
-		onOpenChange?: OnChangeFn<CreateContextMenuProps["defaultOpen"]>;
+		open?: boolean;
+		onOpenChange?: OnChangeFn<boolean>;
 	}
 >;
 
 type CheckboxItemProps = Expand<
 	OmitChecked<CreateContextMenuCheckboxItemProps> & {
-		checked?: CreateContextMenuCheckboxItemProps["defaultChecked"] & {};
-		onCheckedChange?: OnChangeFn<CreateContextMenuCheckboxItemProps["defaultChecked"]>;
+		checked?: boolean | "indeterminate";
+		onCheckedChange?: OnChangeFn<boolean | "indeterminate">;
 	} & AsChild
 > &
 	HTMLDivAttributes;

--- a/src/lib/bits/dialog/types.ts
+++ b/src/lib/bits/dialog/types.ts
@@ -15,7 +15,7 @@ import type { CustomEventHandler } from "$lib/index.js";
 type Props = Expand<
 	OmitOpen<Omit<CreateDialogProps, "role">> & {
 		open?: CreateDialogProps["defaultOpen"] & {};
-		onOpenChange?: OnChangeFn<boolean | undefined>;
+		onOpenChange?: OnChangeFn<boolean>;
 	}
 >;
 

--- a/src/lib/bits/dropdown-menu/types.ts
+++ b/src/lib/bits/dropdown-menu/types.ts
@@ -21,15 +21,15 @@ import type { HTMLButtonAttributes } from "svelte/elements";
 
 type Props = Expand<
 	OmitOpen<CreateDropdownMenuProps> & {
-		open?: CreateDropdownMenuProps["defaultOpen"] & {};
-		onOpenChange?: OnChangeFn<CreateDropdownMenuProps["defaultOpen"]>;
+		open?: boolean;
+		onOpenChange?: OnChangeFn<boolean>;
 	}
 >;
 
 type CheckboxItemProps = Expand<
 	OmitChecked<CreateDropdownMenuCheckboxItemProps> & {
-		checked?: CreateDropdownMenuCheckboxItemProps["defaultChecked"] & {};
-		onCheckedChange?: OnChangeFn<CreateDropdownMenuCheckboxItemProps["defaultChecked"]>;
+		checked?: boolean | "indeterminate";
+		onCheckedChange?: OnChangeFn<boolean | "indeterminate">;
 	} & AsChild
 > &
 	HTMLDivAttributes;

--- a/src/lib/bits/link-preview/types.ts
+++ b/src/lib/bits/link-preview/types.ts
@@ -13,8 +13,8 @@ import type { HTMLAnchorAttributes } from "svelte/elements";
 
 type Props = Expand<
 	OmitOpen<CreateLinkPreviewProps> & {
-		open?: CreateLinkPreviewProps["defaultOpen"];
-		onOpenChange?: OnChangeFn<CreateLinkPreviewProps["defaultOpen"]>;
+		open?: boolean;
+		onOpenChange?: OnChangeFn<boolean>;
 	}
 >;
 

--- a/src/lib/bits/menubar/types.ts
+++ b/src/lib/bits/menubar/types.ts
@@ -24,15 +24,15 @@ type Props = Expand<CreateMenubarProps & AsChild> & HTMLDivAttributes;
 
 type MenuProps = Expand<
 	OmitOpen<CreateMenubarMenuProps> & {
-		open?: CreateMenubarMenuProps["defaultOpen"] & {};
-		onOpenChange?: OnChangeFn<CreateMenubarMenuProps["defaultOpen"]>;
+		open?: boolean;
+		onOpenChange?: OnChangeFn<boolean>;
 	}
 >;
 
 type CheckboxItemProps = Expand<
 	OmitChecked<CreateMenuCheckboxItemProps> & {
-		checked?: CreateMenuCheckboxItemProps["defaultChecked"] & {};
-		onCheckedChange?: OnChangeFn<CreateMenuCheckboxItemProps["defaultChecked"]>;
+		checked?: boolean | "indeterminate";
+		onCheckedChange?: OnChangeFn<boolean | "indeterminate">;
 		disabled?: boolean;
 	} & AsChild
 > &

--- a/src/lib/bits/popover/types.ts
+++ b/src/lib/bits/popover/types.ts
@@ -13,8 +13,8 @@ import type { HTMLButtonAttributes } from "svelte/elements";
 
 type Props = Expand<
 	OmitOpen<CreatePopoverProps> & {
-		open?: CreatePopoverProps["defaultOpen"];
-		onOpenChange?: OnChangeFn<CreatePopoverProps["defaultOpen"]>;
+		open?: boolean;
+		onOpenChange?: OnChangeFn<boolean>;
 	}
 >;
 

--- a/src/lib/bits/select/types.ts
+++ b/src/lib/bits/select/types.ts
@@ -20,8 +20,8 @@ type Props = Expand<
 	OmitOpen<Omit<CreateSelectProps, "selected" | "defaultSelected" | "onSelectedChange">> & {
 		selected?: CreateSelectProps["defaultSelected"] & {};
 		onSelectedChange?: OnChangeFn<CreateSelectProps["defaultSelected"]>;
-		open?: CreateSelectProps["defaultOpen"] & {};
-		onOpenChange?: OnChangeFn<CreateSelectProps["defaultOpen"]>;
+		open?: boolean & {};
+		onOpenChange?: OnChangeFn<boolean>;
 	}
 >;
 

--- a/src/lib/bits/switch/types.ts
+++ b/src/lib/bits/switch/types.ts
@@ -11,8 +11,8 @@ import type { CustomEventHandler } from "$lib/index.js";
 
 type Props = Expand<
 	OmitChecked<CreateSwitchProps> & {
-		checked?: CreateSwitchProps["defaultChecked"] & {};
-		onCheckedChange?: OnChangeFn<CreateSwitchProps["defaultChecked"]>;
+		checked?: boolean;
+		onCheckedChange?: OnChangeFn<boolean>;
 	} & AsChild
 > &
 	HTMLButtonAttributes;

--- a/src/lib/bits/toggle/types.ts
+++ b/src/lib/bits/toggle/types.ts
@@ -5,8 +5,8 @@ import type { CustomEventHandler } from "$lib/index.js";
 
 type Props = Expand<
 	OmitPressed<CreateToggleProps> & {
-		pressed?: CreateToggleProps["defaultPressed"];
-		onPressedChange?: OnChangeFn<CreateToggleProps["defaultPressed"]>;
+		pressed?: boolean;
+		onPressedChange?: OnChangeFn<boolean>;
 	} & AsChild
 > &
 	HTMLButtonAttributes;

--- a/src/lib/bits/tooltip/types.ts
+++ b/src/lib/bits/tooltip/types.ts
@@ -13,8 +13,8 @@ import type { CustomEventHandler } from "$lib";
 
 type Props = Expand<
 	OmitOpen<CreateTooltipProps> & {
-		open?: CreateTooltipProps["defaultOpen"] & {};
-		onOpenChange?: OnChangeFn<CreateTooltipProps["defaultOpen"]>;
+		open?: boolean & {};
+		onOpenChange?: OnChangeFn<boolean>;
 	}
 >;
 


### PR DESCRIPTION
This update addresses annoying type issues with some of the `onChange` functions, where the value passed could possibly be `undefined`, even if impossible. 

Some values could still possibly be undefined, such as the radio groups, etc.,  but most of them cannot.