### PR TITLE
add type="button" to all components using button element

### DIFF
--- a/.changeset/proud-laws-jump.md
+++ b/.changeset/proud-laws-jump.md
@@ -1,0 +1,5 @@
+---
+"bits-ui": patch
+---
+
+add default type="button" to all components using button element

--- a/src/lib/bits/accordion/components/AccordionTrigger.svelte
+++ b/src/lib/bits/accordion/components/AccordionTrigger.svelte
@@ -20,6 +20,7 @@
 {:else}
 	<button
 		use:melt={builder}
+		type="button"
 		{...$$restProps}
 		{...attrs}
 		on:m-keydown={dispatch}

--- a/src/lib/bits/alert-dialog/components/AlertDialogAction.svelte
+++ b/src/lib/bits/alert-dialog/components/AlertDialogAction.svelte
@@ -22,6 +22,7 @@
 {:else}
 	<button
 		use:melt={builder}
+		type="button"
 		{...$$restProps}
 		{...attrs}
 		on:m-click={dispatch}

--- a/src/lib/bits/alert-dialog/components/AlertDialogCancel.svelte
+++ b/src/lib/bits/alert-dialog/components/AlertDialogCancel.svelte
@@ -21,6 +21,7 @@
 {:else}
 	<button
 		use:melt={builder}
+		type="button"
 		{...$$restProps}
 		{...attrs}
 		on:m-click={dispatch}

--- a/src/lib/bits/alert-dialog/components/AlertDialogTrigger.svelte
+++ b/src/lib/bits/alert-dialog/components/AlertDialogTrigger.svelte
@@ -21,6 +21,7 @@
 {:else}
 	<button
 		use:melt={builder}
+		type="button"
 		on:m-click={dispatch}
 		on:m-keydown={dispatch}
 		{...$$restProps}

--- a/src/lib/bits/checkbox/components/Checkbox.svelte
+++ b/src/lib/bits/checkbox/components/Checkbox.svelte
@@ -51,6 +51,7 @@
 {:else}
 	<button
 		use:melt={builder}
+		type="button"
 		{...$$restProps}
 		{...attrs}
 		on:m-click={dispatch}

--- a/src/lib/bits/collapsible/components/CollapsibleTrigger.svelte
+++ b/src/lib/bits/collapsible/components/CollapsibleTrigger.svelte
@@ -19,7 +19,7 @@
 {#if asChild}
 	<slot {builder} {attrs} />
 {:else}
-	<button use:melt={builder} {...$$restProps} {...attrs} on:m-click={dispatch}>
+	<button use:melt={builder} type="button" {...$$restProps} {...attrs} on:m-click={dispatch}>
 		<slot {builder} {attrs} />
 	</button>
 {/if}

--- a/src/lib/bits/dialog/components/DialogClose.svelte
+++ b/src/lib/bits/dialog/components/DialogClose.svelte
@@ -21,6 +21,7 @@
 {:else}
 	<button
 		use:melt={builder}
+		type="button"
 		{...$$restProps}
 		{...attrs}
 		on:m-click={dispatch}

--- a/src/lib/bits/dialog/components/DialogTrigger.svelte
+++ b/src/lib/bits/dialog/components/DialogTrigger.svelte
@@ -21,6 +21,7 @@
 {:else}
 	<button
 		use:melt={builder}
+		type="button"
 		{...$$restProps}
 		{...attrs}
 		on:m-click={dispatch}

--- a/src/lib/bits/dropdown-menu/components/DropdownMenuTrigger.svelte
+++ b/src/lib/bits/dropdown-menu/components/DropdownMenuTrigger.svelte
@@ -21,6 +21,7 @@
 {:else}
 	<button
 		use:melt={builder}
+		type="button"
 		{...$$restProps}
 		{...attrs}
 		on:m-keydown={dispatch}

--- a/src/lib/bits/menubar/components/MenubarTrigger.svelte
+++ b/src/lib/bits/menubar/components/MenubarTrigger.svelte
@@ -20,6 +20,7 @@
 {:else}
 	<button
 		use:melt={builder}
+		type="button"
 		{...$$restProps}
 		{...attrs}
 		on:m-click={dispatch}

--- a/src/lib/bits/popover/components/PopoverClose.svelte
+++ b/src/lib/bits/popover/components/PopoverClose.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
 	import { melt } from "@melt-ui/svelte";
 	import { getCtx, getAttrs } from "../ctx.js";
-	import type { TriggerEvents, TriggerProps } from "../types.js";
+	import type { CloseProps, CloseEvents } from "../types.js";
 	import { createDispatcher } from "$lib/internal/events.js";
 
-	type $$Props = TriggerProps;
-	type $$Events = TriggerEvents;
+	type $$Props = CloseProps;
+	type $$Events = CloseEvents;
 	export let asChild = false;
 	const {
 		elements: { close }
@@ -20,6 +20,7 @@
 {:else}
 	<button
 		use:melt={builder}
+		type="button"
 		{...$$restProps}
 		{...attrs}
 		on:m-click={dispatch}

--- a/src/lib/bits/popover/components/PopoverTrigger.svelte
+++ b/src/lib/bits/popover/components/PopoverTrigger.svelte
@@ -20,6 +20,7 @@
 {:else}
 	<button
 		use:melt={builder}
+		type="button"
 		{...$$restProps}
 		{...attrs}
 		on:m-click={dispatch}

--- a/src/lib/bits/popover/types.ts
+++ b/src/lib/bits/popover/types.ts
@@ -25,7 +25,7 @@ type ContentProps<
 > = Expand<TransitionProps<T, In, Out> & AsChild> & HTMLDivAttributes;
 
 type TriggerProps = AsChild & HTMLButtonAttributes;
-type CloseProps = AsChild & HTMLButtonAttributes;
+type CloseProps = TriggerProps;
 
 type ArrowProps = Expand<
 	{

--- a/src/lib/bits/radio-group/components/RadioGroupItem.svelte
+++ b/src/lib/bits/radio-group/components/RadioGroupItem.svelte
@@ -23,6 +23,7 @@
 {:else}
 	<button
 		use:melt={builder}
+		type="button"
 		{...$$restProps}
 		{...attrs}
 		on:m-click={dispatch}

--- a/src/lib/bits/select/components/SelectTrigger.svelte
+++ b/src/lib/bits/select/components/SelectTrigger.svelte
@@ -20,6 +20,7 @@
 {:else}
 	<button
 		use:melt={builder}
+		type="button"
 		{...$$restProps}
 		{...attrs}
 		on:m-click={dispatch}

--- a/src/lib/bits/switch/components/Switch.svelte
+++ b/src/lib/bits/switch/components/Switch.svelte
@@ -47,6 +47,7 @@
 {:else}
 	<button
 		use:melt={builder}
+		type="button"
 		{...$$restProps}
 		{...attrs}
 		on:m-click={dispatch}

--- a/src/lib/bits/tabs/components/TabsTrigger.svelte
+++ b/src/lib/bits/tabs/components/TabsTrigger.svelte
@@ -24,6 +24,7 @@
 {:else}
 	<button
 		use:melt={builder}
+		type="button"
 		{...$$restProps}
 		{...attrs}
 		on:m-click={dispatch}

--- a/src/lib/bits/tabs/types.ts
+++ b/src/lib/bits/tabs/types.ts
@@ -7,6 +7,7 @@ import type {
 	OmitValue,
 	OnChangeFn
 } from "$lib/internal/index.js";
+import type { HTMLButtonAttributes } from "svelte/elements";
 import type { CustomEventHandler } from "$lib/index.js";
 
 type Props = Expand<
@@ -25,7 +26,7 @@ type ContentProps = Expand<
 > &
 	HTMLDivAttributes;
 
-type TriggerProps = Expand<ObjectVariation<TabsTriggerProps> & AsChild> & HTMLDivAttributes;
+type TriggerProps = Expand<ObjectVariation<TabsTriggerProps> & AsChild> & HTMLButtonAttributes;
 
 type ListProps = AsChild & HTMLDivAttributes;
 

--- a/src/lib/bits/toggle/components/Toggle.svelte
+++ b/src/lib/bits/toggle/components/Toggle.svelte
@@ -40,6 +40,7 @@
 {:else}
 	<button
 		use:melt={builder}
+		type="button"
 		{...$$restProps}
 		{...attrs}
 		on:m-click={dispatch}

--- a/src/lib/bits/tooltip/components/TooltipTrigger.svelte
+++ b/src/lib/bits/tooltip/components/TooltipTrigger.svelte
@@ -21,6 +21,7 @@
 {:else}
 	<button
 		use:melt={builder}
+		type="button"
 		{...$$restProps}
 		{...attrs}
 		on:m-blur={dispatch}


### PR DESCRIPTION
Using SelectTrigger shadcn/svelte with forms causes form submit. This happens, because button by default has `type="submit"`.

I think it's good idea to set `type="button"` instead, to prevent unwanted submits.
Here's implementation which allows to change it by developer, but maybe it should not be possible to changed at all?