### PR TITLE
Sync AlertDialog close behaviour with documentation

### DIFF
--- a/src/lib/bits/alert-dialog/components/AlertDialog.svelte
+++ b/src/lib/bits/alert-dialog/components/AlertDialog.svelte
@@ -9,8 +9,8 @@
 	type $$Props = Props;
 
 	export let preventScroll: $$Props["preventScroll"] = undefined;
-	export let closeOnEscape: $$Props["closeOnEscape"] = undefined;
-	export let closeOnOutsideClick: $$Props["closeOnOutsideClick"] = false;
+	export let closeOnEscape: $$Props["closeOnEscape"] = true;
+	export let closeOnOutsideClick: $$Props["closeOnOutsideClick"] = true;
 	export let portal: $$Props["portal"] = undefined;
 	export let forceVisible: $$Props["forceVisible"] = true;
 	export let open: $$Props["open"] = undefined;


### PR DESCRIPTION
Documentation states that AlertDialog default config for both `closeOnEscape` and `closeOnOutsideClick` is `true`.
However the defaults currently are `false`.

https://www.bits-ui.com/docs/components/alert-dialog

Let me know if this is expected and the documentation needs to be updated instead of code.