### PR TITLE
fix: id synchronization

### DIFF
--- a/.changeset/tasty-lobsters-obey.md
+++ b/.changeset/tasty-lobsters-obey.md
@@ -1,0 +1,5 @@
+---
+"bits-ui": patch
+---
+
+fix: id synchronization

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
 	"types": "./dist/index.d.ts",
 	"type": "module",
 	"dependencies": {
-		"@melt-ui/svelte": "0.60.1",
+		"@melt-ui/svelte": "0.61.1",
 		"nanoid": "^5.0.3"
 	},
 	"peerDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,8 +6,8 @@ settings:
 
 dependencies:
   '@melt-ui/svelte':
-    specifier: 0.60.1
-    version: 0.60.1(svelte@4.2.2)
+    specifier: 0.61.1
+    version: 0.61.1(svelte@4.2.2)
   nanoid:
     specifier: ^5.0.3
     version: 5.0.3
@@ -21,7 +21,7 @@ devDependencies:
     version: 0.16.5(svelte@4.2.2)
   '@melt-ui/pp':
     specifier: ^0.1.2
-    version: 0.1.2(@melt-ui/svelte@0.60.1)(svelte@4.2.2)
+    version: 0.1.2(@melt-ui/svelte@0.61.1)(svelte@4.2.2)
   '@playwright/test':
     specifier: ^1.28.1
     version: 1.36.2
@@ -923,6 +923,11 @@ packages:
       vfile-message: 2.0.4
     dev: true
 
+  /@internationalized/date@3.5.0:
+    resolution: {integrity: sha512-nw0Q+oRkizBWMioseI8+2TeUPEyopJVz5YxoYVzR0W1v+2YytiYah7s/ot35F149q/xAg4F1gT/6eTd+tsUpFQ==}
+    dependencies:
+      '@swc/helpers': 0.5.3
+
   /@jest/expect-utils@29.7.0:
     resolution: {integrity: sha512-GlsNBWiFQFCVi9QVSx7f5AgMeLxe9YCCs5PuP2O2LdjDAA8Jh9eX7lA1Jq/xdXw3Wb3hyvlFNfZIfcRetSzYcA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -1060,24 +1065,25 @@ packages:
       - supports-color
     dev: true
 
-  /@melt-ui/pp@0.1.2(@melt-ui/svelte@0.60.1)(svelte@4.2.2):
+  /@melt-ui/pp@0.1.2(@melt-ui/svelte@0.61.1)(svelte@4.2.2):
     resolution: {integrity: sha512-GZeqp7UWLNZUC2dJpREnZrWMR88vy27WO7C3cIBz4KW3/CFD19FjNkd3VbSRfcRryrMkdnEs9nu2VUa8/0u58w==}
     engines: {pnpm: '>=8.6.3'}
     peerDependencies:
       '@melt-ui/svelte': '>= 0.29.0'
       svelte: ^3.55.0 || ^4.0.0
     dependencies:
-      '@melt-ui/svelte': 0.60.1(svelte@4.2.2)
+      '@melt-ui/svelte': 0.61.1(svelte@4.2.2)
       svelte: 4.2.2
     dev: true
 
-  /@melt-ui/svelte@0.60.1(svelte@4.2.2):
-    resolution: {integrity: sha512-mjQEHhXkM5TbgNYVenVNXLXUnV1Ttx2fBTgugflNIhddWP+dEArBrpfsb4AVsSoGfiql5nSFf/zmrGRLKjZGBg==}
+  /@melt-ui/svelte@0.61.1(svelte@4.2.2):
+    resolution: {integrity: sha512-xG/rRK77yfzAWm0/KrB+NrJ3qzBALv7B3OoHGyLSfFXIGum+CzklxtDH8gNSuCA6ENfuPnY7pwy390+LNqvdig==}
     peerDependencies:
       svelte: '>=3 <5'
     dependencies:
       '@floating-ui/core': 1.4.1
       '@floating-ui/dom': 1.5.1
+      '@internationalized/date': 3.5.0
       dequal: 2.0.3
       focus-trap: 7.5.2
       nanoid: 4.0.2
@@ -1496,6 +1502,11 @@ packages:
     transitivePeerDependencies:
       - encoding
     dev: true
+
+  /@swc/helpers@0.5.3:
+    resolution: {integrity: sha512-FaruWX6KdudYloq1AHD/4nU+UsMTdNE8CKyrseXWEcgjDAbvkwJg2QGPAnfIJLIWsjZOSPLOAykK6fuYp4vp4A==}
+    dependencies:
+      tslib: 2.6.2
 
   /@tailwindcss/typography@0.5.10(tailwindcss@3.3.5):
     resolution: {integrity: sha512-Pe8BuPJQJd3FfRnm6H0ulKIGoMEQS+Vq01R6M5aCrFB/ccR/shT+0kXLjouGC1gFLm9hopTFN+DMP0pfwRWzPw==}
@@ -7058,7 +7069,6 @@ packages:
 
   /tslib@2.6.2:
     resolution: {integrity: sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==}
-    dev: true
 
   /tty-table@4.2.1:
     resolution: {integrity: sha512-xz0uKo+KakCQ+Dxj1D/tKn2FSyreSYWzdkL/BYhgN6oMW808g8QRMuh1atAV9fjTPbWBjfbkKQpI/5rEcnAc7g==}

--- a/src/lib/bits/accordion/components/Accordion.svelte
+++ b/src/lib/bits/accordion/components/Accordion.svelte
@@ -9,14 +9,13 @@
 	export let multiple: $$Props["multiple"] = false as Multiple;
 	export let value: $$Props["value"] = undefined;
 	export let onValueChange: $$Props["onValueChange"] = undefined;
-	export let disabled = false;
-	export let asChild = false;
+	export let disabled: $$Props["disabled"] = false;
+	export let asChild: $$Props["asChild"] = false;
 
 	const {
 		elements: { root },
 		states: { value: localValue },
-		updateOption,
-		ids
+		updateOption
 	} = setCtx({
 		multiple,
 		disabled,
@@ -43,9 +42,9 @@
 </script>
 
 {#if asChild}
-	<slot {builder} {attrs} {ids} />
+	<slot {builder} {attrs} />
 {:else}
 	<div use:melt={builder} {...$$restProps} {...attrs}>
-		<slot {builder} {attrs} {ids} />
+		<slot {builder} {attrs} />
 	</div>
 {/if}

--- a/src/lib/bits/accordion/components/AccordionContent.svelte
+++ b/src/lib/bits/accordion/components/AccordionContent.svelte
@@ -19,7 +19,7 @@
 	export let outTransition: $$Props["outTransition"] = undefined;
 	export let outTransitionConfig: $$Props["outTransitionConfig"] = undefined;
 
-	export let asChild = false;
+	export let asChild: $$Props["asChild"] = false;
 
 	const { content, isSelected, props } = getContent();
 

--- a/src/lib/bits/accordion/components/AccordionHeader.svelte
+++ b/src/lib/bits/accordion/components/AccordionHeader.svelte
@@ -5,7 +5,7 @@
 
 	type $$Props = HeaderProps;
 	export let level = 3;
-	export let asChild = false;
+	export let asChild: $$Props["asChild"] = false;
 	const {
 		elements: { heading: header }
 	} = getCtx();

--- a/src/lib/bits/accordion/components/AccordionItem.svelte
+++ b/src/lib/bits/accordion/components/AccordionItem.svelte
@@ -6,7 +6,7 @@
 
 	export let value: $$Props["value"];
 	export let disabled: $$Props["disabled"] = undefined;
-	export let asChild = false;
+	export let asChild: $$Props["asChild"] = false;
 	const { item, props } = setItem({ value, disabled });
 
 	$: builder = $item(props);

--- a/src/lib/bits/alert-dialog/components/AlertDialogAction.svelte
+++ b/src/lib/bits/alert-dialog/components/AlertDialogAction.svelte
@@ -6,7 +6,7 @@
 
 	type $$Props = ActionProps;
 	type $$Events = ActionEvents;
-	export let asChild = false;
+	export let asChild: $$Props["asChild"] = false;
 	const {
 		elements: { close }
 	} = getCtx();

--- a/src/lib/bits/alert-dialog/components/AlertDialogCancel.svelte
+++ b/src/lib/bits/alert-dialog/components/AlertDialogCancel.svelte
@@ -6,7 +6,7 @@
 
 	type $$Props = CancelProps;
 	type $$Events = CancelEvents;
-	export let asChild = false;
+	export let asChild: $$Props["asChild"] = false;
 	const {
 		elements: { close }
 	} = getCtx();

--- a/src/lib/bits/alert-dialog/components/AlertDialogContent.svelte
+++ b/src/lib/bits/alert-dialog/components/AlertDialogContent.svelte
@@ -16,13 +16,18 @@
 	export let inTransitionConfig: $$Props["inTransitionConfig"] = undefined;
 	export let outTransition: $$Props["outTransition"] = undefined;
 	export let outTransitionConfig: $$Props["outTransitionConfig"] = undefined;
-
-	export let asChild = false;
+	export let id: $$Props["id"] = undefined;
+	export let asChild: $$Props["asChild"] = false;
 
 	const {
 		elements: { content },
-		states: { open }
+		states: { open },
+		ids
 	} = getCtx();
+
+	$: if (id) {
+		ids.content.set(id);
+	}
 
 	$: builder = $content;
 	const attrs = getAttrs("content");

--- a/src/lib/bits/alert-dialog/components/AlertDialogDescription.svelte
+++ b/src/lib/bits/alert-dialog/components/AlertDialogDescription.svelte
@@ -4,10 +4,17 @@
 	import type { DescriptionProps } from "../types.js";
 
 	type $$Props = DescriptionProps;
-	export let asChild = false;
+	export let asChild: $$Props["asChild"] = false;
+	export let id: $$Props["id"] = undefined;
+
 	const {
-		elements: { description }
+		elements: { description },
+		ids
 	} = getCtx();
+
+	$: if (id) {
+		ids.description.set(id);
+	}
 
 	$: builder = $description;
 	const attrs = getAttrs("description");

--- a/src/lib/bits/alert-dialog/components/AlertDialogOverlay.svelte
+++ b/src/lib/bits/alert-dialog/components/AlertDialogOverlay.svelte
@@ -17,7 +17,7 @@
 	export let outTransition: $$Props["outTransition"] = undefined;
 	export let outTransitionConfig: $$Props["outTransitionConfig"] = undefined;
 
-	export let asChild = false;
+	export let asChild: $$Props["asChild"] = false;
 	const {
 		elements: { overlay },
 		states: { open }

--- a/src/lib/bits/alert-dialog/components/AlertDialogPortal.svelte
+++ b/src/lib/bits/alert-dialog/components/AlertDialogPortal.svelte
@@ -4,7 +4,7 @@
 	import type { PortalProps } from "../types.js";
 
 	type $$Props = PortalProps;
-	export let asChild = false;
+	export let asChild: $$Props["asChild"] = false;
 	const {
 		elements: { portalled }
 	} = getCtx();

--- a/src/lib/bits/alert-dialog/components/AlertDialogTitle.svelte
+++ b/src/lib/bits/alert-dialog/components/AlertDialogTitle.svelte
@@ -4,11 +4,18 @@
 	import type { TitleProps } from "../types.js";
 
 	type $$Props = TitleProps;
-	export let level: TitleProps["level"] = "h2";
-	export let asChild = false;
+	export let level: $$Props["level"] = "h2";
+	export let asChild: $$Props["asChild"] = false;
+	export let id: $$Props["id"] = undefined;
+
 	const {
-		elements: { title }
+		elements: { title },
+		ids
 	} = getCtx();
+
+	$: if (id) {
+		ids.title.set(id);
+	}
 
 	$: builder = $title;
 	const attrs = getAttrs("title");

--- a/src/lib/bits/alert-dialog/components/AlertDialogTrigger.svelte
+++ b/src/lib/bits/alert-dialog/components/AlertDialogTrigger.svelte
@@ -6,7 +6,7 @@
 
 	type $$Props = TriggerProps;
 	type $$Events = TriggerEvents;
-	export let asChild = false;
+	export let asChild: $$Props["asChild"] = false;
 	const {
 		elements: { trigger }
 	} = getCtx();

--- a/src/lib/bits/avatar/components/Avatar.svelte
+++ b/src/lib/bits/avatar/components/Avatar.svelte
@@ -6,7 +6,7 @@
 	export let delayMs: $$Props["delayMs"] = undefined;
 	export let loadingStatus: $$Props["loadingStatus"] = undefined;
 	export let onLoadingStatusChange: $$Props["onLoadingStatusChange"] = undefined;
-	export let asChild = false;
+	export let asChild: $$Props["asChild"] = false;
 
 	const {
 		states: { loadingStatus: localLoadingStatus },

--- a/src/lib/bits/avatar/components/AvatarFallback.svelte
+++ b/src/lib/bits/avatar/components/AvatarFallback.svelte
@@ -4,7 +4,7 @@
 	import type { FallbackProps } from "../types.js";
 
 	type $$Props = FallbackProps;
-	export let asChild = false;
+	export let asChild: $$Props["asChild"] = false;
 	const {
 		elements: { fallback }
 	} = getCtx();

--- a/src/lib/bits/avatar/components/AvatarImage.svelte
+++ b/src/lib/bits/avatar/components/AvatarImage.svelte
@@ -6,7 +6,7 @@
 	type $$Props = ImageProps;
 	export let src: $$Props["src"] = undefined;
 	export let alt: $$Props["alt"] = undefined;
-	export let asChild = false;
+	export let asChild: $$Props["asChild"] = false;
 
 	$: image = getImage(src).elements.image;
 	$: builder = $image;

--- a/src/lib/bits/checkbox/components/Checkbox.svelte
+++ b/src/lib/bits/checkbox/components/Checkbox.svelte
@@ -12,7 +12,7 @@
 	export let required: $$Props["required"] = undefined;
 	export let value: $$Props["value"] = undefined;
 	export let onCheckedChange: $$Props["onCheckedChange"] = undefined;
-	export let asChild = false;
+	export let asChild: $$Props["asChild"] = false;
 
 	const {
 		elements: { root },

--- a/src/lib/bits/collapsible/components/Collapsible.svelte
+++ b/src/lib/bits/collapsible/components/Collapsible.svelte
@@ -8,7 +8,7 @@
 	export let disabled: $$Props["disabled"] = undefined;
 	export let open: $$Props["open"] = undefined;
 	export let onOpenChange: $$Props["onOpenChange"] = undefined;
-	export let asChild = false;
+	export let asChild: $$Props["asChild"] = false;
 
 	const {
 		elements: { root },

--- a/src/lib/bits/collapsible/components/CollapsibleContent.svelte
+++ b/src/lib/bits/collapsible/components/CollapsibleContent.svelte
@@ -15,7 +15,7 @@
 	export let inTransitionConfig: $$Props["inTransitionConfig"] = undefined;
 	export let outTransition: $$Props["outTransition"] = undefined;
 	export let outTransitionConfig: $$Props["outTransitionConfig"] = undefined;
-	export let asChild = false;
+	export let asChild: $$Props["asChild"] = false;
 
 	const {
 		elements: { content },

--- a/src/lib/bits/collapsible/components/CollapsibleTrigger.svelte
+++ b/src/lib/bits/collapsible/components/CollapsibleTrigger.svelte
@@ -7,7 +7,7 @@
 	type $$Props = TriggerProps;
 	type $$Events = TriggerEvents;
 
-	export let asChild = false;
+	export let asChild: $$Props["asChild"] = false;
 	const {
 		elements: { trigger }
 	} = getCtx();

--- a/src/lib/bits/context-menu/components/ContextMenuArrow.svelte
+++ b/src/lib/bits/context-menu/components/ContextMenuArrow.svelte
@@ -6,7 +6,7 @@
 	type $$Props = ArrowProps;
 
 	export let size = 8;
-	export let asChild = false;
+	export let asChild: $$Props["asChild"] = false;
 
 	const {
 		elements: { arrow }

--- a/src/lib/bits/context-menu/components/ContextMenuCheckboxItem.svelte
+++ b/src/lib/bits/context-menu/components/ContextMenuCheckboxItem.svelte
@@ -9,7 +9,7 @@
 	export let checked: $$Props["checked"] = undefined;
 	export let disabled: $$Props["disabled"] = undefined;
 	export let onCheckedChange: $$Props["onCheckedChange"] = undefined;
-	export let asChild = false;
+	export let asChild: $$Props["asChild"] = false;
 	const {
 		elements: { checkboxItem },
 		states: { checked: localChecked },

--- a/src/lib/bits/context-menu/components/ContextMenuContent.svelte
+++ b/src/lib/bits/context-menu/components/ContextMenuContent.svelte
@@ -19,14 +19,21 @@
 	export let inTransitionConfig: $$Props["inTransitionConfig"] = undefined;
 	export let outTransition: $$Props["outTransition"] = undefined;
 	export let outTransitionConfig: $$Props["outTransitionConfig"] = undefined;
+	export let asChild: $$Props["asChild"] = false;
+	export let id: $$Props["id"] = undefined;
 
-	export let asChild = false;
 	const {
 		elements: { menu },
-		states: { open }
+		states: { open },
+		ids
 	} = getContent(sideOffset);
 
 	const dispatch = createDispatcher();
+
+	$: if (id) {
+		ids.menu.set(id);
+	}
+
 	$: builder = $menu;
 	const attrs = getAttrs("content");
 </script>

--- a/src/lib/bits/context-menu/components/ContextMenuGroup.svelte
+++ b/src/lib/bits/context-menu/components/ContextMenuGroup.svelte
@@ -3,7 +3,7 @@
 	import { setGroup, getAttrs } from "../ctx.js";
 	import type { GroupProps } from "../types.js";
 	type $$Props = GroupProps;
-	export let asChild = false;
+	export let asChild: $$Props["asChild"] = false;
 	const { group, id } = setGroup();
 	$: builder = $group(id);
 	const attrs = getAttrs("group");

--- a/src/lib/bits/context-menu/components/ContextMenuLabel.svelte
+++ b/src/lib/bits/context-menu/components/ContextMenuLabel.svelte
@@ -3,7 +3,7 @@
 	import { getGroupLabel, getAttrs } from "../ctx.js";
 	import type { LabelProps } from "../types.js";
 	type $$Props = LabelProps;
-	export let asChild = false;
+	export let asChild: $$Props["asChild"] = false;
 	const { groupLabel, id } = getGroupLabel();
 	$: builder = $groupLabel(id);
 	const attrs = getAttrs("label");

--- a/src/lib/bits/context-menu/components/ContextMenuRadioGroup.svelte
+++ b/src/lib/bits/context-menu/components/ContextMenuRadioGroup.svelte
@@ -6,7 +6,7 @@
 	type $$Props = RadioGroupProps;
 	export let value: $$Props["value"] = undefined;
 	export let onValueChange: $$Props["onValueChange"] = undefined;
-	export let asChild = false;
+	export let asChild: $$Props["asChild"] = false;
 
 	const {
 		elements: { radioGroup },

--- a/src/lib/bits/context-menu/components/ContextMenuRadioItem.svelte
+++ b/src/lib/bits/context-menu/components/ContextMenuRadioItem.svelte
@@ -8,7 +8,7 @@
 	type $$Events = RadioItemEvents;
 	export let value: $$Props["value"];
 	export let disabled = false;
-	export let asChild = false;
+	export let asChild: $$Props["asChild"] = false;
 	const {
 		elements: { radioItem }
 	} = setRadioItem(value);

--- a/src/lib/bits/context-menu/components/ContextMenuSeparator.svelte
+++ b/src/lib/bits/context-menu/components/ContextMenuSeparator.svelte
@@ -4,7 +4,7 @@
 	import type { SeparatorProps } from "../types.js";
 
 	type $$Props = SeparatorProps;
-	export let asChild = false;
+	export let asChild: $$Props["asChild"] = false;
 	const {
 		elements: { separator }
 	} = getCtx();

--- a/src/lib/bits/context-menu/components/ContextMenuSubContent.svelte
+++ b/src/lib/bits/context-menu/components/ContextMenuSubContent.svelte
@@ -16,14 +16,20 @@
 	export let inTransitionConfig: $$Props["inTransitionConfig"] = undefined;
 	export let outTransition: $$Props["outTransition"] = undefined;
 	export let outTransitionConfig: $$Props["outTransitionConfig"] = undefined;
-	export let asChild = false;
+	export let asChild: $$Props["asChild"] = false;
+	export let id: $$Props["id"] = undefined;
 
 	const {
 		elements: { subMenu },
-		states: { subOpen }
+		states: { subOpen },
+		ids
 	} = getSubContent();
 
 	$: builder = $subMenu;
+
+	$: if (id) {
+		ids.menu.set(id);
+	}
 
 	const dispatch = createDispatcher();
 	const attrs = getAttrs("sub-content");

--- a/src/lib/bits/context-menu/components/ContextMenuSubTrigger.svelte
+++ b/src/lib/bits/context-menu/components/ContextMenuSubTrigger.svelte
@@ -9,13 +9,20 @@
 		disabled?: boolean;
 	};
 	type $$Events = SubTriggerEvents;
-	export let disabled = false;
-	export let asChild = false;
+	export let disabled: $$Props["disabled"] = false;
+	export let asChild: $$Props["asChild"] = false;
+	export let id: $$Props["id"] = undefined;
 
 	const {
-		elements: { subTrigger }
+		elements: { subTrigger },
+		ids
 	} = getSubMenuCtx();
 	const dispatch = createDispatcher();
+
+	$: if (id) {
+		ids.trigger.set(id);
+	}
+
 	$: builder = $subTrigger;
 	$: attrs = { ...getAttrs("sub-trigger"), ...disabledAttrs(disabled) };
 </script>

--- a/src/lib/bits/context-menu/components/ContextMenuTrigger.svelte
+++ b/src/lib/bits/context-menu/components/ContextMenuTrigger.svelte
@@ -6,11 +6,18 @@
 
 	type $$Props = TriggerProps;
 	type $$Events = TriggerEvents;
-	export let asChild = false;
+	export let asChild: $$Props["asChild"] = false;
+	export let id: $$Props["id"] = undefined;
 	const {
-		elements: { trigger }
+		elements: { trigger },
+		ids
 	} = getCtx();
+
 	const dispatch = createDispatcher();
+
+	$: if (id) {
+		ids.trigger.set(id);
+	}
 	$: builder = $trigger;
 	const attrs = getAttrs("trigger");
 </script>

--- a/src/lib/bits/dialog/components/DialogClose.svelte
+++ b/src/lib/bits/dialog/components/DialogClose.svelte
@@ -6,7 +6,7 @@
 
 	type $$Props = CloseProps;
 	type $$Events = CloseEvents;
-	export let asChild = false;
+	export let asChild: $$Props["asChild"] = false;
 	const {
 		elements: { close }
 	} = getCtx();

--- a/src/lib/bits/dialog/components/DialogContent.svelte
+++ b/src/lib/bits/dialog/components/DialogContent.svelte
@@ -16,13 +16,18 @@
 	export let inTransitionConfig: $$Props["inTransitionConfig"] = undefined;
 	export let outTransition: $$Props["outTransition"] = undefined;
 	export let outTransitionConfig: $$Props["outTransitionConfig"] = undefined;
-
-	export let asChild = false;
+	export let asChild: $$Props["asChild"] = false;
+	export let id: $$Props["id"] = undefined;
 
 	const {
 		elements: { content },
-		states: { open }
+		states: { open },
+		ids
 	} = getCtx();
+
+	$: if (id) {
+		ids.content.set(id);
+	}
 
 	$: builder = $content;
 	const attrs = getAttrs("content");

--- a/src/lib/bits/dialog/components/DialogDescription.svelte
+++ b/src/lib/bits/dialog/components/DialogDescription.svelte
@@ -4,10 +4,17 @@
 	import type { DescriptionProps } from "../types.js";
 
 	type $$Props = DescriptionProps;
-	export let asChild = false;
+	export let asChild: $$Props["asChild"] = false;
+	export let id: $$Props["id"] = undefined;
+
 	const {
-		elements: { description }
+		elements: { description },
+		ids
 	} = getCtx();
+
+	$: if (id) {
+		ids.description.set(id);
+	}
 	$: builder = $description;
 	const attrs = getAttrs("description");
 </script>

--- a/src/lib/bits/dialog/components/DialogOverlay.svelte
+++ b/src/lib/bits/dialog/components/DialogOverlay.svelte
@@ -17,7 +17,7 @@
 	export let outTransition: $$Props["outTransition"] = undefined;
 	export let outTransitionConfig: $$Props["outTransitionConfig"] = undefined;
 
-	export let asChild = false;
+	export let asChild: $$Props["asChild"] = false;
 	const {
 		elements: { overlay },
 		states: { open }

--- a/src/lib/bits/dialog/components/DialogPortal.svelte
+++ b/src/lib/bits/dialog/components/DialogPortal.svelte
@@ -4,7 +4,7 @@
 	import type { PortalProps } from "../types.js";
 
 	type $$Props = PortalProps;
-	export let asChild = false;
+	export let asChild: $$Props["asChild"] = false;
 	const {
 		elements: { portalled }
 	} = getCtx();

--- a/src/lib/bits/dialog/components/DialogTitle.svelte
+++ b/src/lib/bits/dialog/components/DialogTitle.svelte
@@ -4,11 +4,17 @@
 	import type { TitleProps } from "../types.js";
 
 	type $$Props = TitleProps;
-	export let level: TitleProps["level"] = "h2";
-	export let asChild = false;
+	export let level: $$Props["level"] = "h2";
+	export let asChild: $$Props["asChild"] = false;
+	export let id: $$Props["id"] = undefined;
 	const {
-		elements: { title }
+		elements: { title },
+		ids
 	} = getCtx();
+
+	$: if (id) {
+		ids.title.set(id);
+	}
 	$: builder = $title;
 	const attrs = getAttrs("title");
 </script>

--- a/src/lib/bits/dialog/components/DialogTrigger.svelte
+++ b/src/lib/bits/dialog/components/DialogTrigger.svelte
@@ -6,7 +6,7 @@
 
 	type $$Props = TriggerProps;
 	type $$Events = TriggerEvents;
-	export let asChild = false;
+	export let asChild: $$Props["asChild"] = false;
 	const {
 		elements: { trigger }
 	} = getCtx();

--- a/src/lib/bits/dropdown-menu/components/DropdownMenuArrow.svelte
+++ b/src/lib/bits/dropdown-menu/components/DropdownMenuArrow.svelte
@@ -6,7 +6,7 @@
 	type $$Props = ArrowProps;
 
 	export let size = 8;
-	export let asChild = false;
+	export let asChild: $$Props["asChild"] = false;
 
 	const {
 		elements: { arrow }

--- a/src/lib/bits/dropdown-menu/components/DropdownMenuContent.svelte
+++ b/src/lib/bits/dropdown-menu/components/DropdownMenuContent.svelte
@@ -22,16 +22,20 @@
 	export let outTransition: $$Props["outTransition"] = undefined;
 	export let outTransitionConfig: $$Props["outTransitionConfig"] = undefined;
 
-	export let asChild = false;
+	export let asChild: $$Props["asChild"] = false;
+	export let id: $$Props["id"] = undefined;
 
 	const {
 		elements: { menu },
-		states: { open }
+		states: { open },
+		ids
 	} = getContent(sideOffset);
 
+	$: if (id) {
+		ids.menu.set(id);
+	}
 	$: builder = $menu;
 	const attrs = getAttrs("content");
-
 	const dispatch = createDispatcher();
 </script>
 

--- a/src/lib/bits/dropdown-menu/components/DropdownMenuGroup.svelte
+++ b/src/lib/bits/dropdown-menu/components/DropdownMenuGroup.svelte
@@ -3,7 +3,7 @@
 	import { setGroupCtx, getAttrs } from "../ctx.js";
 	import type { GroupProps } from "../types.js";
 	type $$Props = GroupProps;
-	export let asChild = false;
+	export let asChild: $$Props["asChild"] = false;
 
 	const { group, id } = setGroupCtx();
 	$: builder = $group(id);

--- a/src/lib/bits/dropdown-menu/components/DropdownMenuItem.svelte
+++ b/src/lib/bits/dropdown-menu/components/DropdownMenuItem.svelte
@@ -7,7 +7,7 @@
 	type $$Props = ItemProps;
 	type $$Events = ItemEvents;
 	export let href: $$Props["href"] = undefined;
-	export let asChild = false;
+	export let asChild: $$Props["asChild"] = false;
 	export let disabled = false;
 
 	const {

--- a/src/lib/bits/dropdown-menu/components/DropdownMenuLabel.svelte
+++ b/src/lib/bits/dropdown-menu/components/DropdownMenuLabel.svelte
@@ -3,7 +3,7 @@
 	import { getGroupLabel, getAttrs } from "../ctx.js";
 	import type { LabelProps } from "../types.js";
 	type $$Props = LabelProps;
-	export let asChild = false;
+	export let asChild: $$Props["asChild"] = false;
 
 	const { groupLabel, id } = getGroupLabel();
 	$: builder = $groupLabel(id);

--- a/src/lib/bits/dropdown-menu/components/DropdownMenuRadioGroup.svelte
+++ b/src/lib/bits/dropdown-menu/components/DropdownMenuRadioGroup.svelte
@@ -6,7 +6,7 @@
 	type $$Props = RadioGroupProps;
 	export let value: $$Props["value"] = undefined;
 	export let onValueChange: $$Props["onValueChange"] = undefined;
-	export let asChild = false;
+	export let asChild: $$Props["asChild"] = false;
 
 	const {
 		elements: { radioGroup },

--- a/src/lib/bits/dropdown-menu/components/DropdownMenuRadioItem.svelte
+++ b/src/lib/bits/dropdown-menu/components/DropdownMenuRadioItem.svelte
@@ -8,7 +8,7 @@
 	type $$Events = RadioItemEvents;
 	export let value: $$Props["value"];
 	export let disabled = false;
-	export let asChild = false;
+	export let asChild: $$Props["asChild"] = false;
 
 	const {
 		elements: { radioItem }

--- a/src/lib/bits/dropdown-menu/components/DropdownMenuSeparator.svelte
+++ b/src/lib/bits/dropdown-menu/components/DropdownMenuSeparator.svelte
@@ -4,7 +4,7 @@
 	import type { SeparatorProps } from "../types.js";
 
 	type $$Props = SeparatorProps;
-	export let asChild = false;
+	export let asChild: $$Props["asChild"] = false;
 	const {
 		elements: { separator }
 	} = getCtx();

--- a/src/lib/bits/dropdown-menu/components/DropdownMenuSubContent.svelte
+++ b/src/lib/bits/dropdown-menu/components/DropdownMenuSubContent.svelte
@@ -18,15 +18,20 @@
 
 	export let outTransition: $$Props["outTransition"] = undefined;
 	export let outTransitionConfig: $$Props["outTransitionConfig"] = undefined;
-	export let asChild = false;
+	export let asChild: $$Props["asChild"] = false;
+	export let id: $$Props["id"] = undefined;
 
 	const {
 		elements: { subMenu },
-		states: { subOpen }
+		states: { subOpen },
+		ids
 	} = getSubContent();
 
 	const dispatch = createDispatcher();
 
+	$: if (id) {
+		ids.menu.set(id);
+	}
 	$: builder = $subMenu;
 	const attrs = getAttrs("sub-content");
 </script>

--- a/src/lib/bits/dropdown-menu/components/DropdownMenuSubTrigger.svelte
+++ b/src/lib/bits/dropdown-menu/components/DropdownMenuSubTrigger.svelte
@@ -9,12 +9,20 @@
 		disabled?: boolean;
 	};
 	type $$Events = SubTriggerEvents;
-	export let disabled = false;
-	export let asChild = false;
+	export let disabled: $$Props["disabled"] = false;
+	export let asChild: $$Props["asChild"] = false;
+	export let id: $$Props["id"] = undefined;
+
 	const {
-		elements: { subTrigger }
+		elements: { subTrigger },
+		ids
 	} = getSubTrigger();
 	const dispatch = createDispatcher();
+
+	$: if (id) {
+		ids.trigger.set(id);
+	}
+
 	$: builder = $subTrigger;
 	$: attrs = { ...getAttrs("sub-trigger"), ...disabledAttrs(disabled) };
 </script>

--- a/src/lib/bits/dropdown-menu/components/DropdownMenuTrigger.svelte
+++ b/src/lib/bits/dropdown-menu/components/DropdownMenuTrigger.svelte
@@ -6,12 +6,17 @@
 
 	type $$Props = TriggerProps;
 	type $$Events = TriggerEvents;
-	export let asChild = false;
+	export let asChild: $$Props["asChild"] = false;
+	export let id: $$Props["id"] = undefined;
 	const {
-		elements: { trigger }
+		elements: { trigger },
+		ids
 	} = getCtx();
 	const dispatch = createDispatcher();
 
+	$: if (id) {
+		ids.trigger.set(id);
+	}
 	$: builder = $trigger;
 	const attrs = getAttrs("trigger");
 </script>

--- a/src/lib/bits/label/components/Label.svelte
+++ b/src/lib/bits/label/components/Label.svelte
@@ -6,7 +6,7 @@
 
 	type $$Props = Props;
 	type $$Events = Events;
-	export let asChild = false;
+	export let asChild: $$Props["asChild"] = false;
 	const {
 		elements: { root }
 	} = createLabel();

--- a/src/lib/bits/link-preview/components/LinkPreviewArrow.svelte
+++ b/src/lib/bits/link-preview/components/LinkPreviewArrow.svelte
@@ -5,7 +5,7 @@
 
 	type $$Props = ArrowProps;
 
-	export let asChild = false;
+	export let asChild: $$Props["asChild"] = false;
 	export let size = 8;
 	const {
 		elements: { arrow }

--- a/src/lib/bits/link-preview/components/LinkPreviewContent.svelte
+++ b/src/lib/bits/link-preview/components/LinkPreviewContent.svelte
@@ -18,12 +18,18 @@
 	export let outTransition: $$Props["outTransition"] = undefined;
 	export let outTransitionConfig: $$Props["outTransitionConfig"] = undefined;
 
-	export let asChild = false;
+	export let asChild: $$Props["asChild"] = false;
+	export let id: $$Props["id"] = undefined;
 
 	const {
 		elements: { content },
-		states: { open }
+		states: { open },
+		ids
 	} = getCtx();
+
+	$: if (id) {
+		ids.content.set(id);
+	}
 
 	$: builder = $content;
 	const attrs = getAttrs("content");

--- a/src/lib/bits/link-preview/components/LinkPreviewTrigger.svelte
+++ b/src/lib/bits/link-preview/components/LinkPreviewTrigger.svelte
@@ -6,11 +6,19 @@
 
 	type $$Props = TriggerProps;
 	type $$Events = TriggerEvents;
-	export let asChild = false;
+	export let asChild: $$Props["asChild"] = false;
+	export let id: $$Props["id"] = undefined;
+
 	const {
-		elements: { trigger }
+		elements: { trigger },
+		ids
 	} = getCtx();
+
 	const dispatch = createDispatcher();
+
+	$: if (id) {
+		ids.trigger.set(id);
+	}
 
 	$: builder = $trigger;
 	const attrs = getAttrs("trigger");

--- a/src/lib/bits/menubar/components/Menubar.svelte
+++ b/src/lib/bits/menubar/components/Menubar.svelte
@@ -6,9 +6,10 @@
 
 	type $$Props = Props;
 
-	export let loop = true;
-	export let closeOnEscape = true;
-	export let asChild = false;
+	export let loop: $$Props["loop"] = true;
+	export let closeOnEscape: $$Props["closeOnEscape"] = true;
+	export let asChild: $$Props["asChild"] = false;
+	export let id: $$Props["id"] = undefined;
 
 	const {
 		elements: { menubar },
@@ -19,6 +20,10 @@
 	const idValues = derived([ids.menubar], ([$menubarId]) => ({
 		menubar: $menubarId
 	}));
+
+	$: if (id) {
+		ids.menubar.set(id);
+	}
 
 	$: updateOption("loop", loop);
 	$: updateOption("closeOnEscape", closeOnEscape);

--- a/src/lib/bits/menubar/components/MenubarArrow.svelte
+++ b/src/lib/bits/menubar/components/MenubarArrow.svelte
@@ -6,7 +6,7 @@
 	type $$Props = ArrowProps;
 
 	export let size = 8;
-	export let asChild = false;
+	export let asChild: $$Props["asChild"] = false;
 	const {
 		elements: { arrow }
 	} = setArrow(size);

--- a/src/lib/bits/menubar/components/MenubarCheckboxItem.svelte
+++ b/src/lib/bits/menubar/components/MenubarCheckboxItem.svelte
@@ -9,7 +9,7 @@
 	export let checked: $$Props["checked"] = undefined;
 	export let onCheckedChange: $$Props["onCheckedChange"] = undefined;
 	export let disabled: $$Props["disabled"] = undefined;
-	export let asChild = false;
+	export let asChild: $$Props["asChild"] = false;
 
 	const {
 		elements: { checkboxItem },

--- a/src/lib/bits/menubar/components/MenubarContent.svelte
+++ b/src/lib/bits/menubar/components/MenubarContent.svelte
@@ -20,14 +20,18 @@
 	export let outTransition: $$Props["outTransition"] = undefined;
 	export let outTransitionConfig: $$Props["outTransitionConfig"] = undefined;
 
-	export let asChild = false;
+	export let asChild: $$Props["asChild"] = false;
+	export let id: $$Props["id"] = undefined;
 	const {
 		elements: { menu },
-		states: { open }
+		states: { open },
+		ids
 	} = getContent(sideOffset);
 
 	const dispatch = createDispatcher();
-
+	$: if (id) {
+		ids.menu.set(id);
+	}
 	$: builder = $menu;
 	const attrs = getAttrs("content");
 </script>

--- a/src/lib/bits/menubar/components/MenubarGroup.svelte
+++ b/src/lib/bits/menubar/components/MenubarGroup.svelte
@@ -4,7 +4,7 @@
 	import type { GroupProps } from "../types.js";
 	type $$Props = GroupProps;
 
-	export let asChild = false;
+	export let asChild: $$Props["asChild"] = false;
 	const { group, id } = setGroupCtx();
 	$: builder = $group(id);
 	const attrs = getAttrs("group");

--- a/src/lib/bits/menubar/components/MenubarItem.svelte
+++ b/src/lib/bits/menubar/components/MenubarItem.svelte
@@ -7,7 +7,7 @@
 
 	type $$Props = ItemProps;
 	type $$Events = ItemEvents;
-	export let asChild = false;
+	export let asChild: $$Props["asChild"] = false;
 	export let disabled = false;
 	const {
 		elements: { item }

--- a/src/lib/bits/menubar/components/MenubarLabel.svelte
+++ b/src/lib/bits/menubar/components/MenubarLabel.svelte
@@ -3,7 +3,7 @@
 	import { getGroupLabel, getAttrs } from "../ctx.js";
 	import type { LabelProps } from "../types.js";
 	type $$Props = LabelProps;
-	export let asChild = false;
+	export let asChild: $$Props["asChild"] = false;
 	const { groupLabel, id } = getGroupLabel();
 
 	$: builder = $groupLabel(id);

--- a/src/lib/bits/menubar/components/MenubarRadioGroup.svelte
+++ b/src/lib/bits/menubar/components/MenubarRadioGroup.svelte
@@ -6,7 +6,7 @@
 	type $$Props = RadioGroupProps;
 	export let value: $$Props["value"] = undefined;
 	export let onValueChange: $$Props["onValueChange"] = undefined;
-	export let asChild = false;
+	export let asChild: $$Props["asChild"] = false;
 
 	const {
 		elements: { radioGroup },

--- a/src/lib/bits/menubar/components/MenubarRadioItem.svelte
+++ b/src/lib/bits/menubar/components/MenubarRadioItem.svelte
@@ -8,7 +8,7 @@
 	type $$Events = RadioItemEvents;
 	export let value: $$Props["value"];
 	export let disabled = false;
-	export let asChild = false;
+	export let asChild: $$Props["asChild"] = false;
 	const {
 		elements: { radioItem }
 	} = setRadioItemCtx(value);

--- a/src/lib/bits/menubar/components/MenubarSeparator.svelte
+++ b/src/lib/bits/menubar/components/MenubarSeparator.svelte
@@ -4,7 +4,7 @@
 	import type { SeparatorProps } from "../types.js";
 
 	type $$Props = SeparatorProps;
-	export let asChild = false;
+	export let asChild: $$Props["asChild"] = false;
 	const {
 		elements: { separator }
 	} = getMenuCtx();

--- a/src/lib/bits/menubar/components/MenubarSubContent.svelte
+++ b/src/lib/bits/menubar/components/MenubarSubContent.svelte
@@ -12,22 +12,26 @@
 
 	export let transition: $$Props["transition"] = undefined;
 	export let transitionConfig: $$Props["transitionConfig"] = undefined;
-
 	export let inTransition: $$Props["inTransition"] = undefined;
 	export let inTransitionConfig: $$Props["inTransitionConfig"] = undefined;
-
 	export let outTransition: $$Props["outTransition"] = undefined;
 	export let outTransitionConfig: $$Props["outTransitionConfig"] = undefined;
-
-	export let asChild = false;
+	export let asChild: $$Props["asChild"] = false;
+	export let id: $$Props["id"] = undefined;
 
 	const {
 		elements: { subMenu },
-		states: { subOpen }
+		states: { subOpen },
+		ids
 	} = getSubMenuCtx();
 
 	const dispatch = createDispatcher();
+
+	$: if (id) {
+		ids.menu.set(id);
+	}
 	$: builder = $subMenu;
+
 	const attrs = getAttrs("sub-content");
 </script>
 

--- a/src/lib/bits/menubar/components/MenubarSubTrigger.svelte
+++ b/src/lib/bits/menubar/components/MenubarSubTrigger.svelte
@@ -7,12 +7,20 @@
 
 	type $$Props = SubTriggerProps;
 	type $$Events = SubTriggerEvents;
-	export let disabled = false;
-	export let asChild = false;
+	export let disabled: $$Props["disabled"] = false;
+	export let asChild: $$Props["asChild"] = false;
+	export let id: $$Props["id"] = undefined;
+
 	const {
-		elements: { subTrigger }
+		elements: { subTrigger },
+		ids
 	} = getSubMenuCtx();
+
 	const dispatch = createDispatcher();
+
+	$: if (id) {
+		ids.trigger.set(id);
+	}
 	$: builder = $subTrigger;
 	$: attrs = { ...getAttrs("sub-trigger"), ...disabledAttrs(disabled) };
 </script>

--- a/src/lib/bits/menubar/components/MenubarTrigger.svelte
+++ b/src/lib/bits/menubar/components/MenubarTrigger.svelte
@@ -6,11 +6,18 @@
 
 	type $$Props = TriggerProps;
 	type $$Events = TriggerEvents;
-	export let asChild = false;
+	export let asChild: $$Props["asChild"] = false;
+	export let id: $$Props["id"] = undefined;
+
 	const {
-		elements: { trigger }
+		elements: { trigger },
+		ids
 	} = getMenuCtx();
+
 	const dispatch = createDispatcher();
+	$: if (id) {
+		ids.trigger.set(id);
+	}
 	$: builder = $trigger;
 	const attrs = getAttrs("trigger");
 </script>

--- a/src/lib/bits/popover/components/PopoverArrow.svelte
+++ b/src/lib/bits/popover/components/PopoverArrow.svelte
@@ -5,7 +5,7 @@
 
 	type $$Props = ArrowProps;
 
-	export let asChild = false;
+	export let asChild: $$Props["asChild"] = false;
 	export let size = 8;
 	const {
 		elements: { arrow }

--- a/src/lib/bits/popover/components/PopoverClose.svelte
+++ b/src/lib/bits/popover/components/PopoverClose.svelte
@@ -6,7 +6,7 @@
 
 	type $$Props = CloseProps;
 	type $$Events = CloseEvents;
-	export let asChild = false;
+	export let asChild: $$Props["asChild"] = false;
 	const {
 		elements: { close }
 	} = getCtx();

--- a/src/lib/bits/popover/components/PopoverContent.svelte
+++ b/src/lib/bits/popover/components/PopoverContent.svelte
@@ -16,13 +16,18 @@
 	export let inTransitionConfig: $$Props["inTransitionConfig"] = undefined;
 	export let outTransition: $$Props["outTransition"] = undefined;
 	export let outTransitionConfig: $$Props["outTransitionConfig"] = undefined;
-
-	export let asChild = false;
+	export let asChild: $$Props["asChild"] = false;
+	export let id: $$Props["id"] = undefined;
 
 	const {
 		elements: { content },
-		states: { open }
+		states: { open },
+		ids
 	} = getCtx();
+
+	$: if (id) {
+		ids.content.set(id);
+	}
 
 	$: builder = $content;
 	const attrs = getAttrs("content");

--- a/src/lib/bits/popover/components/PopoverTrigger.svelte
+++ b/src/lib/bits/popover/components/PopoverTrigger.svelte
@@ -6,11 +6,18 @@
 
 	type $$Props = TriggerProps;
 	type $$Events = TriggerEvents;
-	export let asChild = false;
+	export let asChild: $$Props["asChild"] = false;
+	export let id: $$Props["id"] = undefined;
 	const {
-		elements: { trigger }
+		elements: { trigger },
+		ids
 	} = getCtx();
 	const dispatch = createDispatcher();
+
+	$: if (id) {
+		ids.trigger.set(id);
+	}
+
 	$: builder = $trigger;
 	const attrs = getAttrs("trigger");
 </script>

--- a/src/lib/bits/progress/components/Progress.svelte
+++ b/src/lib/bits/progress/components/Progress.svelte
@@ -8,7 +8,7 @@
 	export let max: $$Props["max"] = undefined;
 	export let value: $$Props["value"] = undefined;
 	export let onValueChange: $$Props["onValueChange"] = undefined;
-	export let asChild = false;
+	export let asChild: $$Props["asChild"] = false;
 
 	const {
 		elements: { root },

--- a/src/lib/bits/radio-group/components/RadioGroup.svelte
+++ b/src/lib/bits/radio-group/components/RadioGroup.svelte
@@ -10,7 +10,7 @@
 	export let onValueChange: $$Props["onValueChange"] = undefined;
 	export let loop: $$Props["loop"] = undefined;
 	export let orientation: $$Props["orientation"] = undefined;
-	export let asChild = false;
+	export let asChild: $$Props["asChild"] = false;
 
 	const {
 		elements: { root },

--- a/src/lib/bits/radio-group/components/RadioGroupInput.svelte
+++ b/src/lib/bits/radio-group/components/RadioGroupInput.svelte
@@ -4,7 +4,7 @@
 	import { getCtx, getAttrs } from "../ctx.js";
 
 	type $$Props = InputProps;
-	export let asChild = false;
+	export let asChild: $$Props["asChild"] = false;
 	const {
 		elements: { hiddenInput }
 	} = getCtx();

--- a/src/lib/bits/radio-group/components/RadioGroupItem.svelte
+++ b/src/lib/bits/radio-group/components/RadioGroupItem.svelte
@@ -8,7 +8,7 @@
 	type $$Events = ItemEvents;
 	export let value: $$Props["value"];
 	export let disabled = false;
-	export let asChild = false;
+	export let asChild: $$Props["asChild"] = false;
 	const {
 		elements: { item }
 	} = setItemCtx(value);

--- a/src/lib/bits/select/components/SelectArrow.svelte
+++ b/src/lib/bits/select/components/SelectArrow.svelte
@@ -5,7 +5,7 @@
 
 	type $$Props = ArrowProps;
 
-	export let asChild = false;
+	export let asChild: $$Props["asChild"] = false;
 	export let size = 8;
 
 	const {

--- a/src/lib/bits/select/components/SelectContent.svelte
+++ b/src/lib/bits/select/components/SelectContent.svelte
@@ -19,13 +19,20 @@
 	export let outTransition: $$Props["outTransition"] = undefined;
 	export let outTransitionConfig: $$Props["outTransitionConfig"] = undefined;
 
-	export let asChild = false;
+	export let asChild: $$Props["asChild"] = false;
+	export let id: $$Props["id"] = undefined;
 	const {
 		elements: { menu },
-		states: { open }
+		states: { open },
+		ids
 	} = getCtx();
 	const dispatch = createDispatcher();
 	$: builder = $menu;
+
+	$: if (id) {
+		ids.menu.set(id);
+	}
+
 	const attrs = getAttrs("content");
 </script>
 

--- a/src/lib/bits/select/components/SelectGroup.svelte
+++ b/src/lib/bits/select/components/SelectGroup.svelte
@@ -4,7 +4,7 @@
 	import type { GroupProps } from "../types.js";
 
 	type $$Props = GroupProps;
-	export let asChild = false;
+	export let asChild: $$Props["asChild"] = false;
 	const { group, id } = setGroupCtx();
 	$: builder = $group(id);
 	const attrs = getAttrs("group");

--- a/src/lib/bits/select/components/SelectInput.svelte
+++ b/src/lib/bits/select/components/SelectInput.svelte
@@ -4,7 +4,7 @@
 	import type { InputProps } from "../types.js";
 
 	type $$Props = InputProps;
-	export let asChild = false;
+	export let asChild: $$Props["asChild"] = false;
 	const {
 		elements: { hiddenInput },
 		options: { disabled }

--- a/src/lib/bits/select/components/SelectItem.svelte
+++ b/src/lib/bits/select/components/SelectItem.svelte
@@ -10,7 +10,7 @@
 	export let value: $$Props["value"];
 	export let disabled: $$Props["disabled"] = undefined;
 	export let label: $$Props["label"] = undefined;
-	export let asChild = false;
+	export let asChild: $$Props["asChild"] = false;
 	const {
 		elements: { option: item }
 	} = setItemCtx(value);

--- a/src/lib/bits/select/components/SelectLabel.svelte
+++ b/src/lib/bits/select/components/SelectLabel.svelte
@@ -1,13 +1,21 @@
 <script lang="ts">
 	import { melt } from "@melt-ui/svelte";
-	import { getGroupLabel, getAttrs } from "../ctx.js";
+	import { getGroupLabel, getAttrs, getCtx } from "../ctx.js";
 	import type { LabelEvents, LabelProps } from "../types.js";
 
 	type $$Props = LabelProps;
 	type $$Events = LabelEvents;
-	export let asChild = false;
-	const { groupLabel, id } = getGroupLabel();
-	$: builder = $groupLabel(id);
+	export let asChild: $$Props["asChild"] = false;
+	export let id: $$Props["id"] = undefined;
+
+	const { ids } = getCtx();
+	const { groupLabel, id: groupId } = getGroupLabel();
+
+	$: if (id) {
+		ids.label.set(id);
+	}
+
+	$: builder = $groupLabel(groupId);
 	const attrs = getAttrs("label");
 </script>
 

--- a/src/lib/bits/select/components/SelectTrigger.svelte
+++ b/src/lib/bits/select/components/SelectTrigger.svelte
@@ -6,10 +6,18 @@
 
 	type $$Props = TriggerProps;
 	type $$Events = TriggerEvents;
-	export let asChild = false;
+	export let asChild: $$Props["asChild"] = false;
 	const {
-		elements: { trigger }
+		elements: { trigger },
+		ids
 	} = getCtx();
+
+	export let id: $$Props["id"] = undefined;
+
+	$: if (id) {
+		ids.trigger.set(id);
+	}
+
 	const dispatch = createDispatcher();
 	$: builder = $trigger;
 	const attrs = getAttrs("trigger");

--- a/src/lib/bits/select/components/SelectValue.svelte
+++ b/src/lib/bits/select/components/SelectValue.svelte
@@ -4,7 +4,7 @@
 
 	type $$Props = ValueProps;
 	export let placeholder = "";
-	export let asChild = false;
+	export let asChild: $$Props["asChild"] = false;
 	const {
 		states: { selectedLabel }
 	} = getCtx();

--- a/src/lib/bits/separator/components/Separator.svelte
+++ b/src/lib/bits/separator/components/Separator.svelte
@@ -6,7 +6,7 @@
 	type $$Props = Props;
 	export let orientation: $$Props["orientation"] = "horizontal";
 	export let decorative = true;
-	export let asChild = false;
+	export let asChild: $$Props["asChild"] = false;
 
 	const {
 		elements: { root },

--- a/src/lib/bits/slider/components/Slider.svelte
+++ b/src/lib/bits/slider/components/Slider.svelte
@@ -17,8 +17,7 @@
 	const {
 		elements: { root },
 		states: { value: localValue, ticks },
-		updateOption,
-		ids
+		updateOption
 	} = setCtx({
 		disabled,
 		min,
@@ -47,9 +46,9 @@
 </script>
 
 {#if asChild}
-	<slot {builder} {attrs} {ids} ticks={$ticks} />
+	<slot {builder} {attrs} ticks={$ticks} />
 {:else}
 	<span use:melt={builder} {...$$restProps} {...attrs}>
-		<slot {builder} {attrs} {ids} ticks={$ticks} />
+		<slot {builder} {attrs} ticks={$ticks} />
 	</span>
 {/if}

--- a/src/lib/bits/slider/components/Slider.svelte
+++ b/src/lib/bits/slider/components/Slider.svelte
@@ -12,7 +12,7 @@
 	export let orientation: $$Props["orientation"] = undefined;
 	export let value: $$Props["value"] = undefined;
 	export let onValueChange: $$Props["onValueChange"] = undefined;
-	export let asChild = false;
+	export let asChild: $$Props["asChild"] = false;
 
 	const {
 		elements: { root },

--- a/src/lib/bits/slider/components/SliderRange.svelte
+++ b/src/lib/bits/slider/components/SliderRange.svelte
@@ -4,7 +4,7 @@
 	import type { RangeProps } from "../types.js";
 
 	type $$Props = RangeProps;
-	export let asChild = false;
+	export let asChild: $$Props["asChild"] = false;
 	const {
 		elements: { range }
 	} = getCtx();

--- a/src/lib/bits/slider/components/SliderThumb.svelte
+++ b/src/lib/bits/slider/components/SliderThumb.svelte
@@ -6,7 +6,7 @@
 
 	type $$Props = ThumbProps;
 	type $$Events = ThumbEvents;
-	export let asChild = false;
+	export let asChild: $$Props["asChild"] = false;
 	const {
 		elements: { thumb }
 	} = getCtx();
@@ -16,7 +16,7 @@
 </script>
 
 {#if asChild}
-	<slot {builder} />
+	<slot {builder} {attrs} />
 {:else}
 	<span use:melt={builder} {...$$restProps} {...attrs} on:m-keydown={dispatch} />
 {/if}

--- a/src/lib/bits/slider/components/SliderTick.svelte
+++ b/src/lib/bits/slider/components/SliderTick.svelte
@@ -4,7 +4,7 @@
 	import type { TickProps } from "../types.js";
 
 	type $$Props = TickProps;
-	export let asChild = false;
+	export let asChild: $$Props["asChild"] = false;
 	const {
 		elements: { tick }
 	} = getCtx();

--- a/src/lib/bits/switch/components/Switch.svelte
+++ b/src/lib/bits/switch/components/Switch.svelte
@@ -14,7 +14,7 @@
 	export let value: $$Props["value"] = undefined;
 	export let includeInput: $$Props["includeInput"] = true;
 	export let required: $$Props["required"] = undefined;
-	export let asChild = false;
+	export let asChild: $$Props["asChild"] = false;
 	export let inputAttrs: $$Props["inputAttrs"] = undefined;
 
 	const {

--- a/src/lib/bits/switch/components/SwitchThumb.svelte
+++ b/src/lib/bits/switch/components/SwitchThumb.svelte
@@ -3,7 +3,7 @@
 	import type { ThumbProps } from "../types.js";
 
 	type $$Props = ThumbProps;
-	export let asChild = false;
+	export let asChild: $$Props["asChild"] = false;
 	const {
 		states: { checked }
 	} = getCtx();

--- a/src/lib/bits/tabs/components/Tabs.svelte
+++ b/src/lib/bits/tabs/components/Tabs.svelte
@@ -10,7 +10,7 @@
 	export let autoSet: $$Props["autoSet"] = undefined;
 	export let value: $$Props["value"] = undefined;
 	export let onValueChange: $$Props["onValueChange"] = undefined;
-	export let asChild = false;
+	export let asChild: $$Props["asChild"] = false;
 
 	const {
 		elements: { root },

--- a/src/lib/bits/tabs/components/TabsContent.svelte
+++ b/src/lib/bits/tabs/components/TabsContent.svelte
@@ -5,7 +5,7 @@
 
 	type $$Props = ContentProps;
 	export let value: $$Props["value"];
-	export let asChild = false;
+	export let asChild: $$Props["asChild"] = false;
 	const {
 		elements: { content }
 	} = getCtx();

--- a/src/lib/bits/tabs/components/TabsList.svelte
+++ b/src/lib/bits/tabs/components/TabsList.svelte
@@ -4,7 +4,7 @@
 	import type { ListProps } from "../types.js";
 	type $$Props = ListProps;
 
-	export let asChild = false;
+	export let asChild: $$Props["asChild"] = false;
 	const {
 		elements: { list }
 	} = getCtx();

--- a/src/lib/bits/tabs/components/TabsTrigger.svelte
+++ b/src/lib/bits/tabs/components/TabsTrigger.svelte
@@ -8,7 +8,7 @@
 
 	export let value: $$Props["value"];
 	export let disabled: $$Props["disabled"] = undefined;
-	export let asChild = false;
+	export let asChild: $$Props["asChild"] = false;
 
 	const {
 		elements: { trigger }

--- a/src/lib/bits/toggle-group/components/ToggleGroup.svelte
+++ b/src/lib/bits/toggle-group/components/ToggleGroup.svelte
@@ -13,7 +13,7 @@
 	export let value: $$Props["value"] = undefined;
 	export let orientation: $$Props["orientation"] = undefined;
 	export let onValueChange: $$Props["onValueChange"] = undefined;
-	export let asChild = false;
+	export let asChild: $$Props["asChild"] = false;
 
 	const {
 		elements: { root },

--- a/src/lib/bits/toggle/components/Toggle.svelte
+++ b/src/lib/bits/toggle/components/Toggle.svelte
@@ -9,7 +9,7 @@
 	export let disabled: $$Props["disabled"] = undefined;
 	export let pressed: $$Props["pressed"] = undefined;
 	export let onPressedChange: $$Props["onPressedChange"] = undefined;
-	export let asChild = false;
+	export let asChild: $$Props["asChild"] = false;
 	const {
 		elements: { root },
 		states: { pressed: localPressed },

--- a/src/lib/bits/tooltip/components/TooltipArrow.svelte
+++ b/src/lib/bits/tooltip/components/TooltipArrow.svelte
@@ -5,7 +5,7 @@
 
 	type $$Props = ArrowProps;
 	export let size = 8;
-	export let asChild = false;
+	export let asChild: $$Props["asChild"] = false;
 
 	const {
 		elements: { arrow }

--- a/src/lib/bits/tooltip/components/TooltipContent.svelte
+++ b/src/lib/bits/tooltip/components/TooltipContent.svelte
@@ -18,16 +18,20 @@
 	export let outTransition: $$Props["outTransition"] = undefined;
 	export let outTransitionConfig: $$Props["outTransitionConfig"] = undefined;
 
-	export let asChild = false;
-	export let sideOffset = 4;
+	export let asChild: $$Props["asChild"] = false;
+	export let sideOffset: $$Props["sideOffset"] = 4;
+	export let id: $$Props["id"] = undefined;
 
 	const {
 		elements: { content },
-		states: { open }
+		states: { open },
+		ids
 	} = getCtx(sideOffset);
 
 	const dispatch = createDispatcher();
-
+	$: if (id) {
+		ids.content.set(id);
+	}
 	$: builder = $content;
 	const attrs = getAttrs("content");
 </script>

--- a/src/lib/bits/tooltip/components/TooltipTrigger.svelte
+++ b/src/lib/bits/tooltip/components/TooltipTrigger.svelte
@@ -6,13 +6,21 @@
 
 	type $$Props = TriggerProps;
 	type $$Events = TriggerEvents;
-	export let asChild = false;
+	export let asChild: $$Props["asChild"] = false;
+	export let id: $$Props["id"] = undefined;
+
 	const {
-		elements: { trigger }
+		elements: { trigger },
+		ids
 	} = getCtx();
+
 	const dispatch = createDispatcher();
 
+	$: if (id) {
+		ids.trigger.set(id);
+	}
 	$: builder = $trigger;
+
 	const attrs = getAttrs("trigger");
 </script>
 

--- a/src/lib/internal/attrs.ts
+++ b/src/lib/internal/attrs.ts
@@ -11,6 +11,6 @@ export function createBitAttrs<T extends readonly string[]>(bit: Bit, parts: T) 
 	return (part: T[number]) => attrs[part];
 }
 
-export function disabledAttrs(disabled: boolean) {
+export function disabledAttrs(disabled: boolean | undefined | null) {
 	return disabled ? { "aria-disabled": true, "data-disabled": "" } : {};
 }


### PR DESCRIPTION
Now, when an `id` is passed to a component, the internal ID store will be overwritten to that ID, making it easy to use custom ids on an as-needed basis without internal Melt conflicts.