### PR TITLE
feat: allow setting AlertDialog openFocus & closeFocus props

### DIFF
--- a/.changeset/wise-plants-ring.md
+++ b/.changeset/wise-plants-ring.md
@@ -1,0 +1,5 @@
+---
+"bits-ui": patch
+---
+
+feat: allow setting AlertDialog openFocus & closeFocus props

--- a/src/lib/bits/alert-dialog/components/AlertDialog.svelte
+++ b/src/lib/bits/alert-dialog/components/AlertDialog.svelte
@@ -12,6 +12,8 @@
 	export let forceVisible: $$Props["forceVisible"] = true;
 	export let open: $$Props["open"] = undefined;
 	export let onOpenChange: $$Props["onOpenChange"] = undefined;
+	export let openFocus: $$Props["openFocus"] = undefined;
+	export let closeFocus: $$Props["closeFocus"] = undefined;
 
 	const {
 		states: { open: localOpen },
@@ -49,6 +51,8 @@
 	$: updateOption("closeOnOutsideClick", closeOnOutsideClick);
 	$: updateOption("portal", portal);
 	$: updateOption("forceVisible", forceVisible);
+	$: updateOption("openFocus", openFocus);
+	$: updateOption("closeFocus", closeFocus);
 </script>
 
 <slot ids={$idValues} />


### PR DESCRIPTION
[Just like `Dialog` allows setting the `openFocus` and `closeFocus` props ourselves](https://github.com/huntabyte/bits-ui/blob/main/src/lib/bits/dialog/components/Dialog.svelte#L15-L16), I think it would make sense that `AlertDialog` allow these props as well.