### PR TITLE
fix: set AlertDialog openFocus & closeFocus props in ctx

### DIFF
--- a/src/lib/bits/alert-dialog/components/AlertDialog.svelte
+++ b/src/lib/bits/alert-dialog/components/AlertDialog.svelte
@@ -26,6 +26,8 @@
 		portal,
 		forceVisible,
 		defaultOpen: open,
+		openFocus,
+		closeFocus,
 		onOpenChange: ({ next }) => {
 			if (open !== next) {
 				onOpenChange?.(next);


### PR DESCRIPTION
Follow-up PR of https://github.com/huntabyte/bits-ui/pull/167, both props should also be set into the ctx [the same way it's done in the `Dialog` component](https://github.com/huntabyte/bits-ui/blob/main/src/lib/bits/dialog/components/Dialog.svelte#L29-L30).

Sorry for missing this in the original PR 🙂 