### PR TITLE
breaking: rename `Date` to `Day` in Calendar components 

### DIFF
--- a/.changeset/brown-kangaroos-warn.md
+++ b/.changeset/brown-kangaroos-warn.md
@@ -1,0 +1,5 @@
+---
+"bits-ui": minor
+---
+
+breaking: rename `Date` to `Day` in Calendar components 

--- a/content/components/calendar.md
+++ b/content/components/calendar.md
@@ -44,7 +44,7 @@ description: Displays dates and days of the week, facilitating date-related inte
 					<Calendar.GridRow>
 						{#each weekDates as date}
 							<Calendar.Cell {date}>
-								<Calendar.Date {date} month={month.value} />
+								<Calendar.Day {date} month={month.value} />
 							</Calendar.Cell>
 						{/each}
 					</Calendar.GridRow>

--- a/content/components/date-picker.md
+++ b/content/components/date-picker.md
@@ -54,7 +54,7 @@ description: Facilitates the selection of dates through an input and calendar-ba
 							<DatePicker.GridRow>
 								{#each weekDates as date}
 									<DatePicker.Cell {date}>
-										<DatePicker.Date {date} month={month.value} />
+										<DatePicker.Day {date} month={month.value} />
 									</DatePicker.Cell>
 								{/each}
 							</DatePicker.GridRow>

--- a/content/components/date-range-picker.md
+++ b/content/components/date-range-picker.md
@@ -54,7 +54,7 @@ description: Facilitates the selection of date ranges through an input and calen
 							<DateRangePicker.GridRow>
 								{#each weekDates as date}
 									<DateRangePicker.Cell {date}>
-										<DateRangePicker.Date {date} month={month.value} />
+										<DateRangePicker.Day {date} month={month.value} />
 									</DateRangePicker.Cell>
 								{/each}
 							</DateRangePicker.GridRow>

--- a/content/components/range-calendar.md
+++ b/content/components/range-calendar.md
@@ -43,7 +43,7 @@ description: Presents a calendar view tailored for selecting date ranges.
 					<RangeCalendar.GridRow>
 						{#each weekDates as date}
 							<RangeCalendar.Cell {date}>
-								<RangeCalendar.Date {date} month={month.value} />
+								<RangeCalendar.Day {date} month={month.value} />
 							</RangeCalendar.Cell>
 						{/each}
 					</RangeCalendar.GridRow>

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
 	"type": "module",
 	"dependencies": {
 		"@internationalized/date": "^3.5.0",
-		"@melt-ui/svelte": "0.64.4",
+		"@melt-ui/svelte": "0.64.5",
 		"nanoid": "^5.0.4"
 	},
 	"peerDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ dependencies:
     specifier: ^3.5.0
     version: 3.5.0
   '@melt-ui/svelte':
-    specifier: 0.64.4
-    version: 0.64.4(svelte@4.2.3)
+    specifier: 0.64.5
+    version: 0.64.5(svelte@4.2.3)
   nanoid:
     specifier: ^5.0.4
     version: 5.0.4
@@ -24,7 +24,7 @@ devDependencies:
     version: 0.16.5(svelte@4.2.3)
   '@melt-ui/pp':
     specifier: ^0.1.4
-    version: 0.1.4(@melt-ui/svelte@0.64.4)(svelte@4.2.3)
+    version: 0.1.4(@melt-ui/svelte@0.64.5)(svelte@4.2.3)
   '@playwright/test':
     specifier: ^1.28.1
     version: 1.36.2
@@ -1064,20 +1064,20 @@ packages:
       - supports-color
     dev: true
 
-  /@melt-ui/pp@0.1.4(@melt-ui/svelte@0.64.4)(svelte@4.2.3):
+  /@melt-ui/pp@0.1.4(@melt-ui/svelte@0.64.5)(svelte@4.2.3):
     resolution: {integrity: sha512-zR+Kl3CZJPJBHW8V7YcdQCMI/dVcnW9Ct3yGbVaIywYVStVRS7F9uEDOea3xLLT2WTGodQePzPlUn53yKFu87g==}
     engines: {pnpm: '>=8.6.3'}
     peerDependencies:
       '@melt-ui/svelte': '>= 0.29.0'
       svelte: ^3.55.0 || ^4.0.0 || ^5.0.0-next.1
     dependencies:
-      '@melt-ui/svelte': 0.64.4(svelte@4.2.3)
+      '@melt-ui/svelte': 0.64.5(svelte@4.2.3)
       estree-walker: 3.0.3
       svelte: 4.2.3
     dev: true
 
-  /@melt-ui/svelte@0.64.4(svelte@4.2.3):
-    resolution: {integrity: sha512-QwqIXd7hGR8a5NML91rTNOilN9FPyPe8zWnmZbqEynCvdlCueLXrvlANEfKMYLd/vJuQpoi5u1jFdqSDMmFFMg==}
+  /@melt-ui/svelte@0.64.5(svelte@4.2.3):
+    resolution: {integrity: sha512-nPQA2guLuLitpZ6A968eWyGMC2riTKLq4R26hPRLdzP/JHCpd9yvddgMwil8JKbUKjT2dC3i358vUqeUOGxknA==}
     peerDependencies:
       svelte: '>=3 <5'
     dependencies:

--- a/src/components/demos/calendar-demo.svelte
+++ b/src/components/demos/calendar-demo.svelte
@@ -52,7 +52,7 @@
 									{date}
 									class="relative !p-0 text-center text-sm sq-10"
 								>
-									<Calendar.Date
+									<Calendar.Day
 										{date}
 										month={month.value}
 										class="group relative inline-flex items-center justify-center whitespace-nowrap rounded-9px border border-transparent bg-transparent p-0 text-sm font-normal text-foreground sq-10 hover:border-foreground data-[disabled]:pointer-events-none data-[outside-month]:pointer-events-none data-[selected]:bg-foreground data-[selected]:font-medium data-[disabled]:text-foreground/30 data-[selected]:text-background data-[unavailable]:text-muted-foreground data-[unavailable]:line-through"
@@ -61,7 +61,7 @@
 											class="absolute top-[5px] hidden rounded-full bg-foreground sq-1 group-data-[today]:block group-data-[selected]:bg-background"
 										/>
 										{date.day}
-									</Calendar.Date>
+									</Calendar.Day>
 								</Calendar.Cell>
 							{/each}
 						</Calendar.GridRow>

--- a/src/components/demos/date-picker-demo.svelte
+++ b/src/components/demos/date-picker-demo.svelte
@@ -74,7 +74,7 @@
 												{date}
 												class="relative !p-0 text-center text-sm sq-10"
 											>
-												<DatePicker.Date
+												<DatePicker.Day
 													{date}
 													month={month.value}
 													class="group relative inline-flex items-center justify-center whitespace-nowrap rounded-9px border border-transparent bg-transparent p-0 text-sm font-normal text-foreground transition-all sq-10 hover:border-foreground data-[disabled]:pointer-events-none data-[outside-month]:pointer-events-none data-[selected]:bg-foreground data-[selected]:font-medium data-[disabled]:text-foreground/30 data-[selected]:text-background data-[unavailable]:text-muted-foreground data-[unavailable]:line-through"
@@ -83,7 +83,7 @@
 														class="absolute top-[5px] hidden rounded-full bg-foreground transition-all sq-1 group-data-[today]:block group-data-[selected]:bg-background"
 													/>
 													{date.day}
-												</DatePicker.Date>
+												</DatePicker.Day>
 											</DatePicker.Cell>
 										{/each}
 									</DatePicker.GridRow>

--- a/src/components/demos/date-range-picker-demo.svelte
+++ b/src/components/demos/date-range-picker-demo.svelte
@@ -95,7 +95,7 @@
 												{date}
 												class="relative m-0 !p-0 text-center text-sm sq-10"
 											>
-												<DateRangePicker.Date
+												<DateRangePicker.Day
 													{date}
 													month={month.value}
 													class={cn(
@@ -106,7 +106,7 @@
 														class="absolute top-[5px] hidden rounded-full bg-foreground transition-all sq-1 group-data-[today]:block group-data-[selected]:bg-background"
 													/>
 													{date.day}
-												</DateRangePicker.Date>
+												</DateRangePicker.Day>
 											</DateRangePicker.Cell>
 										{/each}
 									</DateRangePicker.GridRow>

--- a/src/components/demos/range-calendar-demo.svelte
+++ b/src/components/demos/range-calendar-demo.svelte
@@ -48,7 +48,7 @@
 									{date}
 									class="relative m-0 !p-0 text-center text-sm sq-10"
 								>
-									<RangeCalendar.Date
+									<RangeCalendar.Day
 										{date}
 										month={month.value}
 										class={cn(
@@ -59,7 +59,7 @@
 											class="absolute top-[5px] hidden rounded-full bg-foreground transition-all sq-1 group-data-[today]:block group-data-[selected]:bg-background"
 										/>
 										{date.day}
-									</RangeCalendar.Date>
+									</RangeCalendar.Day>
 								</RangeCalendar.Cell>
 							{/each}
 						</RangeCalendar.GridRow>

--- a/src/content/api-reference/calendar.ts
+++ b/src/content/api-reference/calendar.ts
@@ -238,8 +238,8 @@ export const day: APISchema<Calendar.DayProps> = {
 			description: "Present on the element when the date is focused."
 		},
 		{
-			name: "calendar-date",
-			description: "Present on the date element."
+			name: "calendar-day",
+			description: "Present on the day element."
 		}
 	]
 };

--- a/src/content/api-reference/calendar.ts
+++ b/src/content/api-reference/calendar.ts
@@ -175,9 +175,9 @@ export const cell: APISchema<Calendar.CellProps> = {
 	]
 };
 
-export const date: APISchema<Calendar.DateProps> = {
-	title: "Date",
-	description: "A date in the calendar grid.",
+export const day: APISchema<Calendar.DayProps> = {
+	title: "Day",
+	description: "A day in the calendar grid.",
 	props: {
 		asChild,
 		date: {
@@ -404,7 +404,7 @@ export const calendar = [
 	nextButton,
 	prevButton,
 	cell,
-	date,
+	day,
 	grid,
 	gridBody,
 	gridHead,

--- a/src/content/api-reference/date-picker.ts
+++ b/src/content/api-reference/date-picker.ts
@@ -20,7 +20,7 @@ import {
 	heading,
 	nextButton,
 	prevButton,
-	date,
+	day,
 	grid
 } from "./calendar";
 import { content, trigger } from "./popover";
@@ -310,5 +310,5 @@ export const datePicker = [
 	headCell,
 	gridBody,
 	cell,
-	date
+	day
 ];

--- a/src/content/api-reference/date-range-picker.ts
+++ b/src/content/api-reference/date-range-picker.ts
@@ -20,7 +20,7 @@ import {
 	heading,
 	nextButton,
 	prevButton,
-	date,
+	day,
 	grid
 } from "./range-calendar";
 import { content, trigger } from "./popover";
@@ -309,5 +309,5 @@ export const dateRangePicker = [
 	headCell,
 	gridBody,
 	cell,
-	date
+	day
 ];

--- a/src/content/api-reference/range-calendar.ts
+++ b/src/content/api-reference/range-calendar.ts
@@ -174,9 +174,9 @@ export const cell: APISchema<RangeCalendar.CellProps> = {
 	]
 };
 
-export const date: APISchema<RangeCalendar.DateProps> = {
-	title: "Date",
-	description: "A date in the calendar grid.",
+export const day: APISchema<RangeCalendar.DayProps> = {
+	title: "Day",
+	description: "A day in the calendar grid.",
 	props: {
 		asChild,
 		date: {
@@ -386,7 +386,7 @@ export const rangeCalendar = [
 	nextButton,
 	prevButton,
 	cell,
-	date,
+	day,
 	grid,
 	gridBody,
 	gridHead,

--- a/src/content/api-reference/range-calendar.ts
+++ b/src/content/api-reference/range-calendar.ts
@@ -250,8 +250,8 @@ export const day: APISchema<RangeCalendar.DayProps> = {
 			description: "Present on the element when the date is focused."
 		},
 		{
-			name: "calendar-date",
-			description: "Present on the date element."
+			name: "calendar-day",
+			description: "Present on the day element."
 		}
 	]
 };

--- a/src/lib/bits/calendar/_export.types.ts
+++ b/src/lib/bits/calendar/_export.types.ts
@@ -10,10 +10,10 @@ export type {
 	HeadCellProps as CalendarHeadCellProps,
 	GridHeadProps as CalendarGridHeadProps,
 	HeaderProps as CalendarHeaderProps,
-	DateProps as CalendarDateProps,
+	DayProps as CalendarDayProps,
 	//
 	Events as CalendarEvents,
 	PrevButtonEvents as CalendarPrevButtonEvents,
 	NextButtonEvents as CalendarNextButtonEvents,
-	DateEvents as CalendarDateEvents
+	DayEvents as CalendarDayEvents
 } from "./types.js";

--- a/src/lib/bits/calendar/_types.ts
+++ b/src/lib/bits/calendar/_types.ts
@@ -79,7 +79,7 @@ type GridBodyProps = AsChild;
 
 type GridRowProps = AsChild;
 
-type BaseDateProps = Expand<
+type BaseDayProps = Expand<
 	{
 		/**
 		 * The date value of the cell.
@@ -93,9 +93,9 @@ type BaseDateProps = Expand<
 	} & AsChild
 >;
 
-type CellProps = Expand<Omit<BaseDateProps, "month">>;
+type CellProps = Expand<Omit<BaseDayProps, "month">>;
 
-type DateProps = Expand<BaseDateProps>;
+type DayProps = Expand<BaseDayProps>;
 
 export type {
 	Props,
@@ -109,5 +109,5 @@ export type {
 	GridBodyProps,
 	GridRowProps,
 	CellProps,
-	DateProps
+	DayProps
 };

--- a/src/lib/bits/calendar/components/calendar-day.svelte
+++ b/src/lib/bits/calendar/components/calendar-day.svelte
@@ -16,7 +16,7 @@
 		helpers: { isDateDisabled, isDateUnavailable, isDateSelected }
 	} = getCtx();
 
-	const attrs = getAttrs("date");
+	const attrs = getAttrs("day");
 	const dispatch = createDispatcher();
 
 	$: builder = $cell(date, month);

--- a/src/lib/bits/calendar/components/calendar-day.svelte
+++ b/src/lib/bits/calendar/components/calendar-day.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
 	import { melt } from "@melt-ui/svelte";
 	import { getCtx, getAttrs } from "../ctx.js";
-	import type { DateEvents, DateProps } from "../types.js";
+	import type { DayEvents, DayProps } from "../types.js";
 	import { createDispatcher } from "$lib/internal/events.js";
 
-	type $$Props = DateProps;
-	type $$Events = DateEvents;
+	type $$Props = DayProps;
+	type $$Events = DayEvents;
 
 	export let date: $$Props["date"];
 	export let month: $$Props["month"];
@@ -13,7 +13,7 @@
 
 	const {
 		elements: { cell },
-		helpers: { isDateDisabled, isDateUnavailable }
+		helpers: { isDateDisabled, isDateUnavailable, isDateSelected }
 	} = getCtx();
 
 	const attrs = getAttrs("date");
@@ -25,20 +25,15 @@
 	$: slotProps = {
 		builder,
 		disabled: $isDateDisabled(date),
-		unavailable: $isDateUnavailable(date)
+		unavailable: $isDateUnavailable(date),
+		selected: $isDateSelected(date)
 	};
 </script>
 
 {#if asChild}
 	<slot {...slotProps} />
 {:else}
-	<div
-		use:melt={builder}
-		{...$$restProps}
-		on:m-click={dispatch}
-		on:m-focusin={dispatch}
-		on:m-mouseenter={dispatch}
-	>
+	<div use:melt={builder} {...$$restProps} on:m-click={dispatch}>
 		<slot {...slotProps}>
 			{date.day}
 		</slot>

--- a/src/lib/bits/calendar/ctx.ts
+++ b/src/lib/bits/calendar/ctx.ts
@@ -13,7 +13,7 @@ const PARTS = [
 	"next-button",
 	"heading",
 	"grid",
-	"date",
+	"day",
 	"header",
 	"grid-head",
 	"head-cell",

--- a/src/lib/bits/calendar/index.ts
+++ b/src/lib/bits/calendar/index.ts
@@ -1,5 +1,5 @@
 export { default as Root } from "./components/calendar.svelte";
-export { default as Date } from "./components/calendar-date.svelte";
+export { default as Day } from "./components/calendar-day.svelte";
 export { default as Grid } from "./components/calendar-grid.svelte";
 export { default as GridBody } from "./components/calendar-grid-body.svelte";
 export { default as Cell } from "./components/calendar-cell.svelte";

--- a/src/lib/bits/calendar/types.ts
+++ b/src/lib/bits/calendar/types.ts
@@ -32,7 +32,7 @@ type GridRowProps = I.GridRowProps & HTMLAttributes<HTMLTableRowElement>;
 
 type CellProps = I.CellProps & HTMLTdAttributes;
 
-type DateProps = I.DateProps & HTMLDivAttributes;
+type DayProps = I.DayProps & HTMLDivAttributes;
 
 /**
  * Events
@@ -46,7 +46,7 @@ type PrevButtonEvents = ButtonEvents;
 
 type NextButtonEvents = ButtonEvents;
 
-type DateEvents = {
+type DayEvents = {
 	click: CustomEventHandler<MouseEvent, HTMLDivElement>;
 };
 
@@ -66,10 +66,10 @@ export type {
 	HeadCellProps,
 	GridHeadProps,
 	HeaderProps,
-	DateProps,
+	DayProps,
 	//
 	Events,
 	PrevButtonEvents,
 	NextButtonEvents,
-	DateEvents
+	DayEvents
 };

--- a/src/lib/bits/date-picker/_export.types.ts
+++ b/src/lib/bits/date-picker/_export.types.ts
@@ -6,7 +6,7 @@ export type {
 	InputProps as DatePickerInputProps,
 	SegmentProps as DatePickerSegmentProps,
 	CellProps as DatePickerCellProps,
-	DateProps as DatePickerDateProps,
+	DayProps as DatePickerDayProps,
 	GridBodyProps as DatePickerGridBodyProps,
 	GridHeadProps as DatePickerGridHeadProps,
 	GridRowProps as DatePickerGridRowProps,
@@ -26,7 +26,7 @@ export type {
 	CloseEvents as DatePickerCloseEvents,
 	TriggerEvents as DatePickerTriggerEvents,
 	CalendarEvents as DatePickerCalendarEvents,
-	DateEvents as DatePickerDateEvents,
+	DayEvents as DatePickerDayEvents,
 	PrevButtonEvents as DatePickerPrevButtonEvents,
 	NextButtonEvents as DatePickerNextButtonEvents,
 	SegmentEvents as DatePickerSegmentEvents

--- a/src/lib/bits/date-picker/components/date-picker-day.svelte
+++ b/src/lib/bits/date-picker/components/date-picker-day.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
 	import { melt } from "@melt-ui/svelte";
-	import { getCtx, getAttrs } from "../ctx.js";
-	import type { DateEvents, DateProps } from "../types.js";
+	import { getCtx, getCalendarAttrs } from "../ctx.js";
+	import type { DayEvents, DayProps } from "../types.js";
 	import { createDispatcher } from "$lib/internal/events.js";
 
-	type $$Props = DateProps;
-	type $$Events = DateEvents;
+	type $$Props = DayProps;
+	type $$Events = DayEvents;
 
 	export let date: $$Props["date"];
 	export let month: $$Props["month"];
@@ -15,12 +15,12 @@
 		elements: { cell },
 		helpers: { isDateDisabled, isDateUnavailable, isDateSelected }
 	} = getCtx();
-	const attrs = getAttrs("date");
+
+	const attrs = getCalendarAttrs("date");
+	const dispatch = createDispatcher();
 
 	$: builder = $cell(date, month);
-
 	$: Object.assign(builder, attrs);
-	const dispatch = createDispatcher();
 
 	$: slotProps = {
 		builder,

--- a/src/lib/bits/date-picker/components/date-picker-day.svelte
+++ b/src/lib/bits/date-picker/components/date-picker-day.svelte
@@ -16,7 +16,7 @@
 		helpers: { isDateDisabled, isDateUnavailable, isDateSelected }
 	} = getCtx();
 
-	const attrs = getCalendarAttrs("date");
+	const attrs = getCalendarAttrs("day");
 	const dispatch = createDispatcher();
 
 	$: builder = $cell(date, month);

--- a/src/lib/bits/date-picker/index.ts
+++ b/src/lib/bits/date-picker/index.ts
@@ -14,7 +14,7 @@ export { default as GridRow } from "$lib/bits/calendar/components/calendar-grid-
 export { default as HeadCell } from "$lib/bits/calendar/components/calendar-head-cell.svelte";
 export { default as Header } from "$lib/bits/calendar/components/calendar-header.svelte";
 export { default as Cell } from "./components/date-picker-cell.svelte";
-export { default as Date } from "./components/date-picker-date.svelte";
+export { default as Day } from "./components/date-picker-day.svelte";
 export { default as Grid } from "./components/date-picker-grid.svelte";
 
 export { default as Heading } from "./components/date-picker-heading.svelte";

--- a/src/lib/bits/date-picker/types.ts
+++ b/src/lib/bits/date-picker/types.ts
@@ -2,7 +2,7 @@ import type { HTMLDivAttributes, HTMLSpanAttributes } from "$lib/internal/index.
 import type * as I from "./_types.js";
 import type {
 	CellProps,
-	DateProps,
+	DayProps,
 	GridBodyProps,
 	GridHeadProps,
 	GridRowProps,
@@ -13,7 +13,7 @@ import type {
 	NextButtonProps,
 	PrevButtonProps,
 	Events as CalendarEvents,
-	DateEvents,
+	DayEvents,
 	PrevButtonEvents,
 	NextButtonEvents
 } from "../calendar/types.js";
@@ -42,7 +42,7 @@ export type {
 	InputProps,
 	SegmentProps,
 	CellProps,
-	DateProps,
+	DayProps,
 	GridBodyProps,
 	GridHeadProps,
 	GridRowProps,
@@ -62,7 +62,7 @@ export type {
 	CloseEvents,
 	TriggerEvents,
 	CalendarEvents,
-	DateEvents,
+	DayEvents,
 	PrevButtonEvents,
 	NextButtonEvents,
 	SegmentEvents

--- a/src/lib/bits/date-range-picker/_export.types.ts
+++ b/src/lib/bits/date-range-picker/_export.types.ts
@@ -6,7 +6,7 @@ export type {
 	InputProps as DateRangePickerInputProps,
 	SegmentProps as DateRangePickerSegmentProps,
 	CellProps as DateRangePickerCellProps,
-	DateProps as DateRangePickerDateProps,
+	DayProps as DateRangePickerDayProps,
 	GridBodyProps as DateRangePickerGridBodyProps,
 	GridHeadProps as DateRangePickerGridHeadProps,
 	GridRowProps as DateRangePickerGridRowProps,
@@ -26,7 +26,7 @@ export type {
 	CloseEvents as DateRangePickerCloseEvents,
 	TriggerEvents as DateRangePickerTriggerEvents,
 	CalendarEvents as DateRangePickerCalendarEvents,
-	DateEvents as DateRangePickerDateEvents,
+	DayEvents as DateRangePickerDayEvents,
 	PrevButtonEvents as DateRangePickerPrevButtonEvents,
 	NextButtonEvents as DateRangePickerNextButtonEvents,
 	SegmentEvents as DateRangePickerSegmentEvents

--- a/src/lib/bits/date-range-picker/components/date-range-picker-day.svelte
+++ b/src/lib/bits/date-range-picker/components/date-range-picker-day.svelte
@@ -14,7 +14,7 @@
 		helpers: { isDateDisabled, isDateUnavailable }
 	} = getCtx();
 
-	const attrs = getCalendarAttrs("date");
+	const attrs = getCalendarAttrs("day");
 
 	$: builder = $cell(date, month);
 	$: Object.assign(builder, attrs);

--- a/src/lib/bits/date-range-picker/components/date-range-picker-day.svelte
+++ b/src/lib/bits/date-range-picker/components/date-range-picker-day.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
 	import { melt } from "@melt-ui/svelte";
 	import { getCtx, getCalendarAttrs } from "../ctx.js";
-	import type { DateProps } from "../types.js";
+	import type { DayProps } from "../types.js";
 
-	type $$Props = DateProps;
+	type $$Props = DayProps;
 
 	export let date: $$Props["date"];
 	export let month: $$Props["month"];

--- a/src/lib/bits/date-range-picker/components/date-range-picker.svelte
+++ b/src/lib/bits/date-range-picker/components/date-range-picker.svelte
@@ -32,7 +32,9 @@
 		states: {
 			value: localValue,
 			placeholder: localPlaceholder,
-			isInvalid: localIsInvalid
+			isInvalid: localIsInvalid,
+			startValue,
+			endValue
 		},
 		updateOption,
 		ids
@@ -202,7 +204,9 @@
 
 	$: slotProps = {
 		isInvalid: $localIsInvalid,
-		ids: $idValues
+		ids: $idValues,
+		startValue: $startValue,
+		endValue: $endValue
 	};
 </script>
 

--- a/src/lib/bits/date-range-picker/index.ts
+++ b/src/lib/bits/date-range-picker/index.ts
@@ -1,6 +1,6 @@
 export { default as Arrow } from "./components/date-range-picker-arrow.svelte";
 export { default as Cell } from "./components/date-range-picker-cell.svelte";
-export { default as Date } from "./components/date-range-picker-date.svelte";
+export { default as Day } from "./components/date-range-picker-day.svelte";
 export { default as Heading } from "./components/date-range-picker-heading.svelte";
 export { default as NextButton } from "./components/date-range-picker-next-button.svelte";
 export { default as PrevButton } from "./components/date-range-picker-prev-button.svelte";

--- a/src/lib/bits/date-range-picker/types.ts
+++ b/src/lib/bits/date-range-picker/types.ts
@@ -2,7 +2,7 @@ import type { HTMLDivAttributes, HTMLSpanAttributes } from "$lib/internal/index.
 import type * as I from "./_types.js";
 import type {
 	CellProps,
-	DateProps,
+	DayProps,
 	GridBodyProps,
 	GridHeadProps,
 	GridRowProps,
@@ -14,7 +14,7 @@ import type {
 	PrevButtonProps,
 	NextButtonEvents,
 	PrevButtonEvents,
-	DateEvents,
+	DayEvents,
 	Events as CalendarEvents
 } from "$lib/bits/range-calendar/types.js";
 import type {
@@ -42,7 +42,7 @@ export type {
 	InputProps,
 	SegmentProps,
 	CellProps,
-	DateProps,
+	DayProps,
 	GridBodyProps,
 	GridHeadProps,
 	GridRowProps,
@@ -61,7 +61,7 @@ export type {
 	TriggerEvents,
 	NextButtonEvents,
 	PrevButtonEvents,
-	DateEvents,
+	DayEvents,
 	CalendarEvents,
 	SegmentEvents
 };

--- a/src/lib/bits/range-calendar/_export.types.ts
+++ b/src/lib/bits/range-calendar/_export.types.ts
@@ -10,10 +10,10 @@ export type {
 	GridBodyProps as RangeCalendarGridBodyProps,
 	CellProps as RangeCalendarCellProps,
 	GridRowProps as RangeCalendarGridRowProps,
-	DateProps as RangeCalendarDateProps,
+	DayProps as RangeCalendarDayProps,
 	//
 	Events as RangeCalendarEvents,
 	PrevButtonEvents as RangeCalendarPrevButtonEvents,
 	NextButtonEvents as RangeCalendarNextButtonEvents,
-	DateEvents as RangeCalendarDateEvents
+	DayEvents as RangeCalendarDayEvents
 } from "./types.js";

--- a/src/lib/bits/range-calendar/_types.ts
+++ b/src/lib/bits/range-calendar/_types.ts
@@ -77,7 +77,7 @@ type GridBodyProps = AsChild;
 
 type GridRowProps = AsChild;
 
-type BaseDateProps = Expand<
+type BaseDayProps = Expand<
 	{
 		/**
 		 * The date value of the cell.
@@ -91,9 +91,9 @@ type BaseDateProps = Expand<
 	} & AsChild
 >;
 
-type CellProps = Expand<Omit<BaseDateProps, "month">>;
+type CellProps = Expand<Omit<BaseDayProps, "month">>;
 
-type DateProps = Expand<BaseDateProps>;
+type DayProps = Expand<BaseDayProps>;
 
 export type {
 	Props,
@@ -107,5 +107,5 @@ export type {
 	GridBodyProps,
 	GridRowProps,
 	CellProps,
-	DateProps
+	DayProps
 };

--- a/src/lib/bits/range-calendar/components/range-calendar-day.svelte
+++ b/src/lib/bits/range-calendar/components/range-calendar-day.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
 	import { melt } from "@melt-ui/svelte";
-	import { getCtx, getCalendarAttrs } from "../ctx.js";
-	import type { DateEvents, DateProps } from "../types.js";
+	import { getCtx, getAttrs } from "../ctx.js";
+	import type { DayEvents, DayProps } from "../types.js";
 	import { createDispatcher } from "$lib/internal/events.js";
 
-	type $$Props = DateProps;
-	type $$Events = DateEvents;
+	type $$Props = DayProps;
+	type $$Events = DayEvents;
 
 	export let date: $$Props["date"];
 	export let month: $$Props["month"];
@@ -13,10 +13,10 @@
 
 	const {
 		elements: { cell },
-		helpers: { isDateDisabled, isDateUnavailable, isDateSelected }
+		helpers: { isDateDisabled, isDateUnavailable }
 	} = getCtx();
 
-	const attrs = getCalendarAttrs("date");
+	const attrs = getAttrs("date");
 	const dispatch = createDispatcher();
 
 	$: builder = $cell(date, month);
@@ -25,15 +25,20 @@
 	$: slotProps = {
 		builder,
 		disabled: $isDateDisabled(date),
-		unavailable: $isDateUnavailable(date),
-		selected: $isDateSelected(date)
+		unavailable: $isDateUnavailable(date)
 	};
 </script>
 
 {#if asChild}
 	<slot {...slotProps} />
 {:else}
-	<div use:melt={builder} {...$$restProps} on:m-click={dispatch}>
+	<div
+		use:melt={builder}
+		{...$$restProps}
+		on:m-click={dispatch}
+		on:m-focusin={dispatch}
+		on:m-mouseenter={dispatch}
+	>
 		<slot {...slotProps}>
 			{date.day}
 		</slot>

--- a/src/lib/bits/range-calendar/components/range-calendar-day.svelte
+++ b/src/lib/bits/range-calendar/components/range-calendar-day.svelte
@@ -16,7 +16,7 @@
 		helpers: { isDateDisabled, isDateUnavailable }
 	} = getCtx();
 
-	const attrs = getAttrs("date");
+	const attrs = getAttrs("day");
 	const dispatch = createDispatcher();
 
 	$: builder = $cell(date, month);

--- a/src/lib/bits/range-calendar/components/range-calendar.svelte
+++ b/src/lib/bits/range-calendar/components/range-calendar.svelte
@@ -43,7 +43,9 @@
 			value: localValue,
 			placeholder: localPlaceholder,
 			months,
-			weekdays
+			weekdays,
+			startValue,
+			endValue
 		},
 		updateOption,
 		ids
@@ -109,7 +111,9 @@
 	$: slotProps = {
 		builder,
 		months: $months,
-		weekdays: $weekdays
+		weekdays: $weekdays,
+		startValue: $startValue,
+		endValue: $endValue
 	};
 </script>
 

--- a/src/lib/bits/range-calendar/ctx.ts
+++ b/src/lib/bits/range-calendar/ctx.ts
@@ -13,7 +13,7 @@ const PARTS = [
 	"next-button",
 	"heading",
 	"grid",
-	"date",
+	"day",
 	"header",
 	"grid-head",
 	"head-cell",

--- a/src/lib/bits/range-calendar/index.ts
+++ b/src/lib/bits/range-calendar/index.ts
@@ -1,5 +1,5 @@
 export { default as Root } from "./components/range-calendar.svelte";
-export { default as Date } from "./components/range-calendar-date.svelte";
+export { default as Day } from "./components/range-calendar-day.svelte";
 export { default as Grid } from "./components/range-calendar-grid.svelte";
 export { default as GridBody } from "./components/range-calendar-grid-body.svelte";
 export { default as Cell } from "./components/range-calendar-cell.svelte";

--- a/src/lib/bits/range-calendar/types.ts
+++ b/src/lib/bits/range-calendar/types.ts
@@ -31,7 +31,7 @@ type GridRowProps = I.GridRowProps & HTMLAttributes<HTMLTableRowElement>;
 
 type CellProps = I.CellProps & HTMLTdAttributes;
 
-type DateProps = I.DateProps & HTMLDivAttributes;
+type DayProps = I.DayProps & HTMLDivAttributes;
 
 /**
  * Events
@@ -45,7 +45,7 @@ type PrevButtonEvents = ButtonEvents;
 
 type NextButtonEvents = ButtonEvents;
 
-type DateEvents = {
+type DayEvents = {
 	click: CustomEventHandler<MouseEvent, HTMLDivElement>;
 	focusin: CustomEventHandler<FocusEvent, HTMLDivElement>;
 	mouseenter: CustomEventHandler<MouseEvent, HTMLDivElement>;
@@ -67,10 +67,10 @@ export type {
 	HeadCellProps,
 	GridHeadProps,
 	HeaderProps,
-	DateProps,
+	DayProps,
 	//
 	Events,
 	PrevButtonEvents,
 	NextButtonEvents,
-	DateEvents
+	DayEvents
 };

--- a/src/tests/calendar/CalendarMultiTest.svelte
+++ b/src/tests/calendar/CalendarMultiTest.svelte
@@ -42,13 +42,13 @@
 							<Calendar.GridRow data-testid="grid-row-{m}-{i}" data-week>
 								{#each weekDates as date, d}
 									<Calendar.Cell {date} data-testid="cell-{date.month}-{d}">
-										<Calendar.Date
+										<Calendar.Day
 											{date}
 											month={month.value}
 											data-testid="date-{date.month}-{date.day}"
 										>
 											{date.day}
-										</Calendar.Date>
+										</Calendar.Day>
 									</Calendar.Cell>
 								{/each}
 							</Calendar.GridRow>

--- a/src/tests/calendar/CalendarTest.svelte
+++ b/src/tests/calendar/CalendarTest.svelte
@@ -57,13 +57,13 @@
 							<Calendar.GridRow data-testid="grid-row-{m}-{i}" data-week>
 								{#each weekDates as date, d}
 									<Calendar.Cell {date} data-testid="cell-{date.month}-{d}">
-										<Calendar.Date
+										<Calendar.Day
 											{date}
 											month={month.value}
 											data-testid="date-{date.month}-{date.day}"
 										>
 											{date.day}
-										</Calendar.Date>
+										</Calendar.Day>
 									</Calendar.Cell>
 								{/each}
 							</Calendar.GridRow>

--- a/src/tests/range-calendar/RangeCalendarTest.svelte
+++ b/src/tests/range-calendar/RangeCalendarTest.svelte
@@ -49,13 +49,13 @@
 										{date}
 										data-testid="cell-{date.month}-{d}"
 									>
-										<RangeCalendar.Date
+										<RangeCalendar.Day
 											{date}
 											month={month.value}
 											data-testid="date-{date.month}-{date.day}"
 										>
 											{date.day}
-										</RangeCalendar.Date>
+										</RangeCalendar.Day>
 									</RangeCalendar.Cell>
 								{/each}
 							</RangeCalendar.GridRow>


### PR DESCRIPTION
After using the new calendar components a bit more, I've notice that `Calendar.Date` and its props are too close in name to the `CalendarDate` class from `@internationalized/date` which this project uses.

So to prevent confusion in documentation, discussion, etc. around the components, the `.Date` components have been renamed to `.Day`, which makes a bit more sense IMO.

### Migration
- `Calendar.Date` -> `Calendar.Day`
- `RangeCalendar.Date` -> `RangeCalendar.Day`
- `DatePicker.Date` -> `DatePicker.Day`
- `DateRangePicker.Date` -> `DateRangePicker.Day`