### PR TITLE
doc: fix typo in Tooltip code fragment example

### DIFF
--- a/content/components/tooltip.md
+++ b/content/components/tooltip.md
@@ -21,7 +21,7 @@ description: Provides additional information or context when users hover over or
 	import { Tooltip } from 'bits-ui';
 </script>
 
-<ToolTip.Root>
+<Tooltip.Root>
 	<Tooltip.Trigger />
 	<Tooltip.Content>
 		<Tooltip.Arrow />


### PR DESCRIPTION
fix typo in Tooltip code fragment example - change from `ToolTip` to `Tooltip`