### PR TITLE
fix: Set aspect ratio prop optional

### DIFF
--- a/.changeset/aspect-ratio-default-value.md
+++ b/.changeset/aspect-ratio-default-value.md
@@ -1,0 +1,5 @@
+---
+"bits-ui": patch
+---
+
+fix: Set aspect ratio prop optional as default value is setted

--- a/src/lib/bits/aspect-ratio/_types.ts
+++ b/src/lib/bits/aspect-ratio/_types.ts
@@ -5,7 +5,7 @@
  */
 
 type Props = Expand<{
-	ratio: number;
+	ratio?: number;
 }>;
 
 export type { Props };

--- a/src/lib/bits/aspect-ratio/components/aspect-ratio.svelte
+++ b/src/lib/bits/aspect-ratio/components/aspect-ratio.svelte
@@ -12,7 +12,7 @@
 <div
 	style:position="relative"
 	style:width="100%"
-	style:padding-bottom="{100 / ratio}%"
+	style:padding-bottom="{ratio ? 100 / ratio : 0}%"
 >
 	<div
 		style:position="absolute"


### PR DESCRIPTION
![image](https://github.com/huntabyte/bits-ui/assets/31659424/e15340a3-c339-45ff-a572-fec546c9350c)
When not defining the AspectRatio ratio prop it will throw an error and in docs is defined as optional.
`type Props = Expand<{
	ratio: number;
}>;`
In _types.ts the prop is defined as needed. Just changed it to optional.