### PR TITLE
feat: expose el prop for DOM manipulation

### DIFF
--- a/.changeset/selfish-eels-promise.md
+++ b/.changeset/selfish-eels-promise.md
@@ -1,5 +1,5 @@
 ---
-"bits-ui": patch
+"bits-ui": minor
 ---
 
-expose el prop for DOM manipulation
+Expose `el` prop for all components to allow binding & interacting with the underlying element  

--- a/.changeset/selfish-eels-promise.md
+++ b/.changeset/selfish-eels-promise.md
@@ -1,0 +1,5 @@
+---
+"bits-ui": patch
+---
+
+expose el prop for DOM manipulation

--- a/src/content/api-reference/accordion.ts
+++ b/src/content/api-reference/accordion.ts
@@ -1,8 +1,8 @@
 import type { APISchema } from "@/types";
 import * as C from "@/content/constants.js";
-import { union, enums, asChild, transitionProps } from "@/content/api-reference/helpers.js";
+import { union, enums, transitionProps } from "@/content/api-reference/helpers.js";
 import type * as Accordion from "$lib/bits/accordion/_types.js";
-import { builderAndAttrsSlotProps } from "./helpers";
+import { builderAndAttrsSlotProps, domElProps } from "./helpers";
 
 const root: APISchema<Accordion.Props<false>> = {
 	title: "Root",
@@ -32,7 +32,7 @@ const root: APISchema<Accordion.Props<false>> = {
 			},
 			description: "A callback function called when the active accordion item value changes."
 		},
-		asChild
+		...domElProps("HTMLDivElement")
 	},
 	slotProps: {
 		...builderAndAttrsSlotProps
@@ -66,7 +66,7 @@ const item: APISchema<Accordion.ItemProps> = {
 			type: "boolean",
 			description: "Whether or not the accordion item is disabled."
 		},
-		asChild
+		...domElProps("HTMLDivElement")
 	},
 	slotProps: {
 		...builderAndAttrsSlotProps
@@ -93,7 +93,7 @@ const item: APISchema<Accordion.ItemProps> = {
 const trigger: APISchema<Accordion.TriggerProps> = {
 	title: "Trigger",
 	description: "The accordion item trigger, which opens and closes the accordion item.",
-	props: { asChild },
+	props: { ...domElProps("HTMLButtonElement") },
 	slotProps: { ...builderAndAttrsSlotProps },
 	dataAttributes: [
 		{
@@ -120,7 +120,7 @@ const trigger: APISchema<Accordion.TriggerProps> = {
 const content: APISchema<Accordion.ContentProps> = {
 	title: "Content",
 	description: "The accordion item content, which is displayed when the item is open.",
-	props: { ...transitionProps, asChild },
+	props: { ...transitionProps, ...domElProps("HTMLDivElement") },
 	slotProps: { ...builderAndAttrsSlotProps },
 	dataAttributes: [
 		{
@@ -156,7 +156,7 @@ const header: APISchema<Accordion.HeaderProps> = {
 			description:
 				"The heading level to use for the header. This will be set as the `aria-level` attribute."
 		},
-		asChild
+		...domElProps("HTMLDivElement")
 	},
 	slotProps: {
 		...builderAndAttrsSlotProps

--- a/src/content/api-reference/alert-dialog.ts
+++ b/src/content/api-reference/alert-dialog.ts
@@ -1,15 +1,15 @@
 import type { APISchema } from "@/types/api.js";
 import {
-	asChild,
+	domElProps,
 	enums,
 	idsSlotProp,
 	portalProp,
-	transitionProps
+	transitionProps,
+	builderAndAttrsSlotProps
 } from "@/content/api-reference/helpers.js";
 import * as C from "@/content/constants.js";
 import { focusProp } from "@/content/api-reference/extended-types/index.js";
 import type * as AlertDialog from "$lib/bits/alert-dialog/_types.js";
-import { builderAndAttrsSlotProps } from "./helpers";
 
 const root: APISchema<AlertDialog.Props> = {
 	title: "Root",
@@ -60,7 +60,7 @@ const root: APISchema<AlertDialog.Props> = {
 const action: APISchema<AlertDialog.ActionProps> = {
 	title: "Action",
 	description: "A button used to close the alert dialog by taking an action.",
-	props: { asChild },
+	props: domElProps("HTMLButtonElement"),
 	slotProps: { ...builderAndAttrsSlotProps },
 	dataAttributes: [
 		{
@@ -73,7 +73,7 @@ const action: APISchema<AlertDialog.ActionProps> = {
 const cancel: APISchema<AlertDialog.CancelProps> = {
 	title: "Cancel",
 	description: "A button used to close the alert dialog without taking an action.",
-	props: { asChild },
+	props: domElProps("HTMLButtonElement"),
 	slotProps: { ...builderAndAttrsSlotProps },
 	dataAttributes: [
 		{
@@ -86,7 +86,7 @@ const cancel: APISchema<AlertDialog.CancelProps> = {
 const content: APISchema<AlertDialog.ContentProps> = {
 	title: "Content",
 	description: "The content displayed within the alert dialog modal.",
-	props: { ...transitionProps, asChild },
+	props: { ...transitionProps, ...domElProps("HTMLDivElement") },
 	slotProps: { ...builderAndAttrsSlotProps },
 	dataAttributes: [
 		{
@@ -106,7 +106,7 @@ const title: APISchema<AlertDialog.TitleProps> = {
 	title: "Title",
 	description: "An accessibile title for the alert dialog.",
 	props: {
-		asChild,
+		...domElProps("HTMLHeadingElement"),
 		level: {
 			type: {
 				type: "enum",
@@ -127,7 +127,7 @@ const title: APISchema<AlertDialog.TitleProps> = {
 const description: APISchema<AlertDialog.DescriptionProps> = {
 	title: "Description",
 	description: "An accessibile description for the alert dialog.",
-	props: { asChild },
+	props: domElProps("HTMLDivElement"),
 	slotProps: { ...builderAndAttrsSlotProps },
 	dataAttributes: [
 		{
@@ -140,7 +140,7 @@ const description: APISchema<AlertDialog.DescriptionProps> = {
 const trigger: APISchema<AlertDialog.TriggerProps> = {
 	title: "Trigger",
 	description: "The element which opens the alert dialog on press.",
-	props: { asChild },
+	props: domElProps("HTMLButtonElement"),
 	slotProps: { ...builderAndAttrsSlotProps },
 	dataAttributes: [
 		{
@@ -153,7 +153,7 @@ const trigger: APISchema<AlertDialog.TriggerProps> = {
 const overlay: APISchema<AlertDialog.OverlayProps> = {
 	title: "Overlay",
 	description: "An overlay which covers the body when the alert dialog is open.",
-	props: { ...transitionProps, asChild },
+	props: { ...transitionProps, ...domElProps("HTMLDivElement") },
 	slotProps: { ...builderAndAttrsSlotProps },
 	dataAttributes: [
 		{

--- a/src/content/api-reference/aspect-ratio.ts
+++ b/src/content/api-reference/aspect-ratio.ts
@@ -1,6 +1,7 @@
 import type { APISchema } from "@/types";
 import type * as AspectRatio from "$lib/bits/aspect-ratio/_types.js";
 import * as C from "@/content/constants";
+import { domElProps } from "./helpers";
 
 const root: APISchema<AspectRatio.Props> = {
 	title: "Root",
@@ -10,7 +11,8 @@ const root: APISchema<AspectRatio.Props> = {
 			type: C.NUMBER,
 			default: "1",
 			description: "The desired aspect ratio."
-		}
+		},
+		...domElProps("HTMLDivElement")
 	},
 	dataAttributes: [
 		{

--- a/src/content/api-reference/avatar.ts
+++ b/src/content/api-reference/avatar.ts
@@ -1,8 +1,8 @@
 import type { APISchema } from "@/types";
-import { asChild, attrsSlotProp, enums } from "@/content/api-reference/helpers.js";
+import { attrsSlotProp, enums } from "@/content/api-reference/helpers.js";
 import type * as Avatar from "$lib/bits/avatar/_types";
 import * as C from "@/content/constants.js";
-import { builderAndAttrsSlotProps } from "./helpers";
+import { builderAndAttrsSlotProps, domElProps } from "./helpers";
 
 export const root: APISchema<Avatar.Props> = {
 	title: "Root",
@@ -29,7 +29,7 @@ export const root: APISchema<Avatar.Props> = {
 			},
 			description: "A callback function called when the loading status of the image changes."
 		},
-		asChild
+		...domElProps("HTMLDivElement")
 	},
 	slotProps: {
 		attrs: attrsSlotProp
@@ -45,7 +45,7 @@ export const root: APISchema<Avatar.Props> = {
 export const image: APISchema<Avatar.ImageProps> = {
 	title: "Image",
 	description: "The avatar image displayed once it has loaded.",
-	props: { asChild },
+	props: domElProps("HTMLImageElement"),
 	slotProps: { ...builderAndAttrsSlotProps },
 	dataAttributes: [
 		{
@@ -58,7 +58,7 @@ export const image: APISchema<Avatar.ImageProps> = {
 export const fallback: APISchema<Avatar.FallbackProps> = {
 	title: "Fallback",
 	description: "The fallback displayed while the avatar image is loading or if it fails to load",
-	props: { asChild },
+	props: domElProps("HTMLSpanElement"),
 	slotProps: { ...builderAndAttrsSlotProps },
 	dataAttributes: [
 		{

--- a/src/content/api-reference/calendar.ts
+++ b/src/content/api-reference/calendar.ts
@@ -1,13 +1,8 @@
 import type { APISchema } from "@/types";
 import * as C from "@/content/constants.js";
-import {
-	asChild,
-	weekdaysSlotProp,
-	enums,
-	monthsSlotProp
-} from "@/content/api-reference/helpers.js";
+import { weekdaysSlotProp, enums, monthsSlotProp } from "@/content/api-reference/helpers.js";
 import type * as Calendar from "$lib/bits/calendar/_types.js";
-import { attrsSlotProp, builderAndAttrsSlotProps } from "./helpers";
+import { attrsSlotProp, builderAndAttrsSlotProps, domElProps } from "./helpers";
 
 export const root: APISchema<Calendar.Props> = {
 	title: "Root",
@@ -123,7 +118,7 @@ export const root: APISchema<Calendar.Props> = {
 				"If `true`, the calendar will focus the selected day, today, or the first day of the month in that order depending on what is visible when the calendar is mounted.",
 			default: C.FALSE
 		},
-		asChild
+		...domElProps("HTMLDivElement")
 	},
 	slotProps: {
 		months: monthsSlotProp,
@@ -154,11 +149,11 @@ export const cell: APISchema<Calendar.CellProps> = {
 	title: "Cell",
 	description: "A cell in the calendar grid.",
 	props: {
-		asChild,
 		date: {
 			type: "DateValue",
 			description: "The date for the cell."
-		}
+		},
+		...domElProps("HTMLTableCellElement")
 	},
 	slotProps: {
 		attrs: attrsSlotProp
@@ -179,7 +174,6 @@ export const day: APISchema<Calendar.DayProps> = {
 	title: "Day",
 	description: "A day in the calendar grid.",
 	props: {
-		asChild,
 		date: {
 			type: "DateValue",
 			description: "The date for the cell."
@@ -187,7 +181,8 @@ export const day: APISchema<Calendar.DayProps> = {
 		month: {
 			type: "DateValue",
 			description: "The current month the date is being displayed in."
-		}
+		},
+		...domElProps("HTMLDivElement")
 	},
 	slotProps: {
 		disabled: {
@@ -247,9 +242,7 @@ export const day: APISchema<Calendar.DayProps> = {
 export const grid: APISchema<Calendar.GridProps> = {
 	title: "Grid",
 	description: "The grid of dates in the calendar, typically representing a month.",
-	props: {
-		asChild
-	},
+	props: domElProps("HTMLTableElement"),
 	slotProps: { ...builderAndAttrsSlotProps },
 	dataAttributes: [
 		{
@@ -262,9 +255,7 @@ export const grid: APISchema<Calendar.GridProps> = {
 export const gridBody: APISchema<Calendar.GridBodyProps> = {
 	title: "GridBody",
 	description: "The body of the grid of dates in the calendar.",
-	props: {
-		asChild
-	},
+	props: domElProps("HTMLTableSectionElement"),
 	slotProps: { attrs: attrsSlotProp },
 	dataAttributes: [
 		{
@@ -277,9 +268,7 @@ export const gridBody: APISchema<Calendar.GridBodyProps> = {
 export const gridHead: APISchema<Calendar.GridHeadProps> = {
 	title: "GridHead",
 	description: "The head of the grid of dates in the calendar.",
-	props: {
-		asChild
-	},
+	props: domElProps("HTMLTableSectionElement"),
 	slotProps: {
 		attrs: attrsSlotProp
 	},
@@ -294,9 +283,7 @@ export const gridHead: APISchema<Calendar.GridHeadProps> = {
 export const gridRow: APISchema<Calendar.GridRowProps> = {
 	title: "GridRow",
 	description: "A row in the grid of dates in the calendar.",
-	props: {
-		asChild
-	},
+	props: domElProps("HTMLTableRowElement"),
 	slotProps: {
 		attrs: attrsSlotProp
 	},
@@ -311,9 +298,7 @@ export const gridRow: APISchema<Calendar.GridRowProps> = {
 export const headCell: APISchema<Calendar.HeadCellProps> = {
 	title: "HeadCell",
 	description: "A cell in the head of the grid of dates in the calendar.",
-	props: {
-		asChild
-	},
+	props: domElProps("HTMLTableCellElement"),
 	slotProps: {
 		attrs: attrsSlotProp
 	},
@@ -328,9 +313,7 @@ export const headCell: APISchema<Calendar.HeadCellProps> = {
 export const header: APISchema<Calendar.HeaderProps> = {
 	title: "Header",
 	description: "The header of the calendar.",
-	props: {
-		asChild
-	},
+	props: domElProps("HTMLElement"),
 	slotProps: {
 		attrs: attrsSlotProp
 	},
@@ -345,9 +328,7 @@ export const header: APISchema<Calendar.HeaderProps> = {
 export const heading: APISchema<Calendar.HeadingProps> = {
 	title: "Heading",
 	description: "The heading of the calendar.",
-	props: {
-		asChild
-	},
+	props: domElProps("HTMLDivElement"),
 	slotProps: {
 		...builderAndAttrsSlotProps,
 		headingValue: {
@@ -366,9 +347,7 @@ export const heading: APISchema<Calendar.HeadingProps> = {
 export const nextButton: APISchema<Calendar.NextButtonProps> = {
 	title: "NextButton",
 	description: "The next button of the calendar.",
-	props: {
-		asChild
-	},
+	props: domElProps("HTMLButtonElement"),
 	slotProps: {
 		...builderAndAttrsSlotProps
 	},
@@ -383,9 +362,7 @@ export const nextButton: APISchema<Calendar.NextButtonProps> = {
 export const prevButton: APISchema<Calendar.PrevButtonProps> = {
 	title: "PrevButton",
 	description: "The previous button of the calendar.",
-	props: {
-		asChild
-	},
+	props: domElProps("HTMLButtonElement"),
 	slotProps: {
 		...builderAndAttrsSlotProps
 	},

--- a/src/content/api-reference/checkbox.ts
+++ b/src/content/api-reference/checkbox.ts
@@ -1,8 +1,8 @@
-import { asChild, attrsSlotProp, enums, union } from "./helpers.js";
+import { attrsSlotProp, enums, union } from "./helpers.js";
 import type { APISchema } from "@/types";
 import type * as Checkbox from "$lib/bits/checkbox/_types";
 import * as C from "@/content/constants";
-import { builderAndAttrsSlotProps } from "./helpers";
+import { builderAndAttrsSlotProps, domElProps } from "./helpers";
 
 export const root: APISchema<Checkbox.Props> = {
 	title: "Root",
@@ -43,7 +43,7 @@ export const root: APISchema<Checkbox.Props> = {
 			type: C.STRING,
 			description: "The value of the checkbox. This is used for form submission."
 		},
-		asChild
+		...domElProps("HTMLButtonElement")
 	},
 	slotProps: { ...builderAndAttrsSlotProps },
 	dataAttributes: [
@@ -88,7 +88,7 @@ export const indicator: APISchema<Checkbox.IndicatorProps> = {
 	title: "Indicator",
 	description:
 		"A component which passes `isChecked` and `isIndeterminate` slot props to its children. This is useful for rendering the checkbox's indicator icon depending on its state.",
-	props: { asChild },
+	props: domElProps("HTMLDivElement"),
 	slotProps: {
 		isChecked: {
 			type: C.BOOLEAN,

--- a/src/content/api-reference/collapsible.ts
+++ b/src/content/api-reference/collapsible.ts
@@ -1,8 +1,8 @@
 import type { APISchema, PropObj } from "@/types";
-import { asChild, enums, transitionProps } from "@/content/api-reference/helpers.js";
+import { enums, transitionProps } from "@/content/api-reference/helpers.js";
 import type * as Collapsible from "$lib/bits/collapsible/_types";
 import * as C from "@/content/constants";
-import { builderAndAttrsSlotProps } from "./helpers";
+import { builderAndAttrsSlotProps, domElProps } from "./helpers";
 
 export const root: APISchema<Collapsible.Props> = {
 	title: "Root",
@@ -27,7 +27,7 @@ export const root: APISchema<Collapsible.Props> = {
 			},
 			description: "A callback that is fired when the collapsible's open state changes."
 		},
-		asChild
+		...domElProps("HTMLDivElement")
 	},
 	slotProps: { ...builderAndAttrsSlotProps },
 	dataAttributes: [
@@ -51,7 +51,7 @@ export const root: APISchema<Collapsible.Props> = {
 export const trigger: APISchema<Collapsible.TriggerProps> = {
 	title: "Trigger",
 	description: "The button responsible for toggling the collapsible's open state.",
-	props: { asChild },
+	props: domElProps("HTMLButtonElement"),
 	slotProps: { ...builderAndAttrsSlotProps },
 	dataAttributes: [
 		{
@@ -73,7 +73,7 @@ export const trigger: APISchema<Collapsible.TriggerProps> = {
 
 const contentProps = {
 	...transitionProps,
-	asChild
+	...domElProps("HTMLDivElement")
 } satisfies PropObj<Collapsible.ContentProps>;
 
 export const content: APISchema<Collapsible.ContentProps> = {

--- a/src/content/api-reference/context-menu.ts
+++ b/src/content/api-reference/context-menu.ts
@@ -3,14 +3,8 @@ import { menu } from "./menu";
 import type * as Menu from "$lib/bits/menu/_types";
 import type * as ContextMenu from "$lib/bits/context-menu/_types";
 import * as C from "@/content/constants.js";
-import {
-	transitionProps,
-	asChild,
-	union,
-	builderAndAttrsSlotProps,
-	enums,
-	seeFloating
-} from "./helpers";
+import { domElProps } from "./helpers";
+import { transitionProps, union, builderAndAttrsSlotProps, enums, seeFloating } from "./helpers";
 
 export const root: APISchema<Menu.Props> = {
 	title: "Root",
@@ -21,7 +15,14 @@ export const root: APISchema<Menu.Props> = {
 export const trigger: APISchema<Menu.TriggerProps> = {
 	title: "Trigger",
 	description: "The element which when right-clicked, opens the context menu.",
-	...menu.trigger
+	...menu.trigger,
+	props: {
+		...menu.trigger.props,
+		el: {
+			type: "HTMLDivElement",
+			description: "You can bind to this prop to programatically interact with the element."
+		}
+	}
 };
 
 export const content: APISchema<ContextMenu.ContentProps> = {
@@ -29,7 +30,6 @@ export const content: APISchema<ContextMenu.ContentProps> = {
 	description: "The content displayed when the context menu is open.",
 	props: {
 		...transitionProps,
-		asChild,
 		alignOffset: {
 			type: C.NUMBER,
 			default: "0",
@@ -90,7 +90,8 @@ export const content: APISchema<ContextMenu.ContentProps> = {
 				"Whether the floating element can overlap the reference element.",
 				"https://floating-ui.com/docs/shift#options"
 			)
-		}
+		},
+		...domElProps("HTMLDivElement")
 	},
 	slotProps: { ...builderAndAttrsSlotProps },
 	dataAttributes: menu.content.dataAttributes

--- a/src/content/api-reference/date-field.ts
+++ b/src/content/api-reference/date-field.ts
@@ -1,7 +1,7 @@
 import * as C from "@/content/constants.js";
 import type * as DateField from "$lib/bits/date-field/_types.js";
 import type { APISchema } from "@/types";
-import { enums, idsSlotProp, union, asChild } from "@/content/api-reference/helpers.js";
+import { enums, idsSlotProp, union, domElProps } from "@/content/api-reference/helpers.js";
 import { builderAndAttrsSlotProps } from "./helpers";
 
 export const root: APISchema<DateField.Props> = {
@@ -103,9 +103,7 @@ export const root: APISchema<DateField.Props> = {
 const input: APISchema<DateField.InputProps> = {
 	title: "Input",
 	description: "The container for the segments of the date field.",
-	props: {
-		asChild
-	},
+	props: domElProps("HTMLDivElement"),
 	slotProps: {
 		...builderAndAttrsSlotProps,
 		segments: {
@@ -154,7 +152,7 @@ export const segment: APISchema<DateField.SegmentProps> = {
 			description: "The part of the date to render.",
 			required: true
 		},
-		asChild
+		...domElProps("HTMLDivElement")
 	},
 	slotProps: {
 		...builderAndAttrsSlotProps
@@ -194,7 +192,7 @@ export const segment: APISchema<DateField.SegmentProps> = {
 export const label: APISchema<DateField.LabelProps> = {
 	title: "Label",
 	description: "The label for the date field.",
-	props: { asChild },
+	props: domElProps("HTMLSpanElement"),
 	slotProps: {
 		...builderAndAttrsSlotProps
 	},

--- a/src/content/api-reference/date-picker.ts
+++ b/src/content/api-reference/date-picker.ts
@@ -1,11 +1,11 @@
 import type { APISchema } from "@/types";
 import * as C from "@/content/constants.js";
 import {
-	asChild,
 	weekdaysSlotProp,
 	enums,
 	monthsSlotProp,
-	union
+	union,
+	domElProps
 } from "@/content/api-reference/helpers.js";
 import type * as DatePicker from "$lib/bits/date-picker/_types.js";
 import { builderAndAttrsSlotProps, portalProp } from "./helpers";
@@ -205,9 +205,7 @@ const root: APISchema<DatePicker.Props> = {
 			type: focusProp,
 			description: "Override the focus when the popover is closed."
 		},
-		portal: { ...portalProp("popover") },
-
-		asChild
+		portal: { ...portalProp("popover") }
 	},
 	slotProps: {
 		months: monthsSlotProp,
@@ -265,7 +263,7 @@ const calendar: APISchema<DatePicker.CalendarProps> = {
 const input: APISchema<DatePicker.InputProps> = {
 	title: "Input",
 	description: "The field input component which contains the segments of the date field.",
-	props: { asChild },
+	props: domElProps("HTMLDivElement"),
 	slotProps: {
 		...builderAndAttrsSlotProps,
 		segments: {

--- a/src/content/api-reference/date-range-field.ts
+++ b/src/content/api-reference/date-range-field.ts
@@ -1,7 +1,7 @@
 import * as C from "@/content/constants.js";
 import type * as DateRangeField from "$lib/bits/date-range-field/_types.js";
 import type { APISchema } from "@/types";
-import { enums, idsSlotProp, union, asChild } from "@/content/api-reference/helpers.js";
+import { enums, idsSlotProp, union, domElProps } from "@/content/api-reference/helpers.js";
 import { builderAndAttrsSlotProps } from "./helpers";
 
 export const root: APISchema<DateRangeField.Props> = {
@@ -106,9 +106,7 @@ export const root: APISchema<DateRangeField.Props> = {
 export const input: APISchema<DateRangeField.InputProps> = {
 	title: "Input",
 	description: "The container for the segments of the date field.",
-	props: {
-		asChild
-	},
+	props: domElProps("HTMLDivElement"),
 	slotProps: {
 		...builderAndAttrsSlotProps,
 		segments: {
@@ -165,7 +163,7 @@ export const segment: APISchema<DateRangeField.SegmentProps> = {
 			description: "The type of field to render (start or end).",
 			required: true
 		},
-		asChild
+		...domElProps("HTMLDivElement")
 	},
 	slotProps: {
 		...builderAndAttrsSlotProps
@@ -205,7 +203,7 @@ export const segment: APISchema<DateRangeField.SegmentProps> = {
 export const label: APISchema<DateRangeField.LabelProps> = {
 	title: "Label",
 	description: "The label for the date field.",
-	props: { asChild },
+	props: domElProps("HTMLSpanElement"),
 	slotProps: {
 		...builderAndAttrsSlotProps
 	},

--- a/src/content/api-reference/date-range-picker.ts
+++ b/src/content/api-reference/date-range-picker.ts
@@ -1,11 +1,11 @@
 import type { APISchema } from "@/types";
 import * as C from "@/content/constants.js";
 import {
-	asChild,
 	weekdaysSlotProp,
 	enums,
 	monthsSlotProp,
-	union
+	union,
+	domElProps
 } from "@/content/api-reference/helpers.js";
 import type * as DateRangePicker from "$lib/bits/date-range-picker/_types.js";
 import { builderAndAttrsSlotProps, portalProp } from "./helpers";
@@ -211,8 +211,7 @@ const root: APISchema<DateRangePicker.Props> = {
 			},
 			description:
 				"The `start` value of the date range, which can exist prior to the true `value` being set, which is only set once a `start` and `end` value are selected. You can `bind:startValue` to a value to receive updates, but modifying this value outside the component will have no effect. To programmatically control the `start` value, use `bind:value` and update the `start` property of the `DateRange` object. This is provided as a convenience for use cases where you want to display the selected `start` value outside the component before the `value` is set."
-		},
-		asChild
+		}
 	},
 	slotProps: {
 		months: monthsSlotProp,
@@ -270,7 +269,7 @@ const calendar: APISchema<DateRangePicker.CalendarProps> = {
 const input: APISchema<DateRangePicker.InputProps> = {
 	title: "Input",
 	description: "The field input component which contains the segments of the date field.",
-	props: { asChild },
+	props: domElProps("HTMLDivElement"),
 	slotProps: {
 		...builderAndAttrsSlotProps,
 		segments: {

--- a/src/content/api-reference/dialog.ts
+++ b/src/content/api-reference/dialog.ts
@@ -1,6 +1,5 @@
 import type { APISchema } from "@/types";
 import {
-	asChild,
 	enums,
 	idsSlotProp,
 	portalProp,
@@ -9,7 +8,7 @@ import {
 import type * as Dialog from "$lib/bits/dialog/_types";
 import { focusProp } from "./extended-types";
 import * as C from "@/content/constants";
-import { builderAndAttrsSlotProps } from "./helpers";
+import { builderAndAttrsSlotProps, domElProps } from "./helpers";
 
 export const root: APISchema<Dialog.Props> = {
 	title: "Root",
@@ -60,7 +59,7 @@ export const root: APISchema<Dialog.Props> = {
 export const close: APISchema<Dialog.CloseProps> = {
 	title: "Close",
 	description: "A button used to close the dialog.",
-	props: { asChild },
+	props: domElProps("HTMLButtonElement"),
 	slotProps: { ...builderAndAttrsSlotProps },
 	dataAttributes: [
 		{
@@ -73,7 +72,7 @@ export const close: APISchema<Dialog.CloseProps> = {
 export const content: APISchema<Dialog.ContentProps> = {
 	title: "Content",
 	description: "The content displayed within the dialog modal.",
-	props: { ...transitionProps, asChild },
+	props: { ...transitionProps, ...domElProps("HTMLDivElement") },
 	slotProps: { ...builderAndAttrsSlotProps },
 	dataAttributes: [
 		{
@@ -100,7 +99,7 @@ export const title: APISchema<Dialog.TitleProps> = {
 			},
 			description: "The heading level of the title."
 		},
-		asChild
+		...domElProps("HTMLHeadingElement")
 	},
 	slotProps: { ...builderAndAttrsSlotProps },
 	dataAttributes: [
@@ -114,7 +113,7 @@ export const title: APISchema<Dialog.TitleProps> = {
 export const description: APISchema<Dialog.DescriptionProps> = {
 	title: "Description",
 	description: "An accessibile description for the dialog.",
-	props: { asChild },
+	props: domElProps("HTMLDivElement"),
 	slotProps: { ...builderAndAttrsSlotProps },
 	dataAttributes: [
 		{
@@ -127,7 +126,7 @@ export const description: APISchema<Dialog.DescriptionProps> = {
 export const trigger: APISchema<Dialog.TriggerProps> = {
 	title: "Trigger",
 	description: "The element which opens the dialog on press.",
-	props: { asChild },
+	props: domElProps("HTMLButtonElement"),
 	slotProps: { ...builderAndAttrsSlotProps },
 	dataAttributes: [
 		{
@@ -140,7 +139,7 @@ export const trigger: APISchema<Dialog.TriggerProps> = {
 export const overlay: APISchema<Dialog.OverlayProps> = {
 	title: "Overlay",
 	description: "An overlay which covers the body when the dialog is open.",
-	props: { ...transitionProps, asChild },
+	props: { ...transitionProps, ...domElProps("HTMLDivElement") },
 	slotProps: { ...builderAndAttrsSlotProps },
 	dataAttributes: [
 		{
@@ -159,7 +158,7 @@ export const overlay: APISchema<Dialog.OverlayProps> = {
 export const portal: APISchema<Dialog.PortalProps> = {
 	title: "Portal",
 	description: "A portal which renders the dialog into the body when it is open.",
-	props: { asChild },
+	props: domElProps("HTMLDivElement"),
 	slotProps: { ...builderAndAttrsSlotProps },
 	dataAttributes: [
 		{

--- a/src/content/api-reference/helpers.ts
+++ b/src/content/api-reference/helpers.ts
@@ -8,6 +8,36 @@ export const asChild = {
 	description: "Whether to use [render delegation](/docs/delegation) with this component or not."
 };
 
+type ElementKind =
+	| "HTMLDivElement"
+	| "HTMLButtonElement"
+	| "HTMLSpanElement"
+	| "HTMLAnchorElement"
+	| "HTMLTableCellElement"
+	| "HTMLTableSectionElement"
+	| "HTMLTableRowElement"
+	| "HTMLTableElement"
+	| "HTMLLabelElement"
+	| "HTMLHeadingElement"
+	| "HTMLImageElement"
+	| "HTMLInputElement"
+	| "HTMLElement";
+
+export function domElProps(elType: ElementKind) {
+	return {
+		asChild: {
+			type: C.BOOLEAN,
+			default: C.FALSE,
+			description: `Whether to use [render delegation](/docs/delegation) with this component or not.`
+		},
+		el: {
+			type: elType,
+			description:
+				"The underlying DOM element being rendered. You can bind to this to programatically interact with the element."
+		}
+	};
+}
+
 const builderSlotProp: PropSchema = {
 	type: {
 		type: C.OBJECT,
@@ -51,12 +81,12 @@ export const idsSlotProp: PropSchema = {
 };
 
 export const arrowProps = {
-	asChild,
 	size: {
 		type: C.NUMBER,
 		default: "8",
 		description: "The height and width of the arrow in pixels."
-	}
+	},
+	...domElProps("HTMLDivElement")
 };
 
 const transitionProp: PropSchema = {

--- a/src/content/api-reference/label.ts
+++ b/src/content/api-reference/label.ts
@@ -1,11 +1,11 @@
 import type { APISchema } from "@/types";
-import { asChild, builderAndAttrsSlotProps } from "@/content/api-reference/helpers.js";
+import { builderAndAttrsSlotProps, domElProps } from "@/content/api-reference/helpers.js";
 import type * as Label from "$lib/bits/label/_types";
 
 export const root: APISchema<Label.Props> = {
 	title: "Root",
 	description: "An enhanced label component that can be used with any input.",
-	props: { asChild },
+	props: domElProps("HTMLLabelElement"),
 	slotProps: { ...builderAndAttrsSlotProps },
 	dataAttributes: [
 		{

--- a/src/content/api-reference/link-preview.ts
+++ b/src/content/api-reference/link-preview.ts
@@ -1,16 +1,16 @@
 import type { APISchema } from "@/types";
 import {
 	arrowProps,
-	asChild,
+	domElProps,
 	enums,
 	idsSlotProp,
 	portalProp,
-	transitionProps
+	transitionProps,
+	builderAndAttrsSlotProps
 } from "@/content/api-reference/helpers.js";
 import { floatingPositioning } from "./floating.js";
 import type * as LinkPreview from "$lib/bits/link-preview/_types";
 import * as C from "@/content/constants";
-import { builderAndAttrsSlotProps } from "./helpers";
 
 export const root: APISchema<LinkPreview.Props> = {
 	title: "Root",
@@ -61,7 +61,7 @@ export const trigger: APISchema<LinkPreview.TriggerProps> = {
 	title: "Trigger",
 	description:
 		"A component which triggers the opening and closing of the link preview on hover or focus.",
-	props: { asChild },
+	props: domElProps("HTMLAnchorElement"),
 	slotProps: { ...builderAndAttrsSlotProps },
 	dataAttributes: [
 		{
@@ -80,7 +80,7 @@ export const trigger: APISchema<LinkPreview.TriggerProps> = {
 export const content: APISchema<LinkPreview.ContentProps> = {
 	title: "Content",
 	description: "The contents of the link preview which are displayed when the preview is open.",
-	props: { ...transitionProps, ...floatingPositioning, asChild },
+	props: { ...transitionProps, ...floatingPositioning, ...domElProps("HTMLDivElement") },
 	slotProps: { ...builderAndAttrsSlotProps },
 	dataAttributes: [
 		{

--- a/src/content/api-reference/menu.ts
+++ b/src/content/api-reference/menu.ts
@@ -2,7 +2,6 @@ import type { APISchema, DataAttrSchema, PropObj } from "@/types";
 import { focusProp } from "./extended-types/index.js";
 import { floatingPositioning } from "./floating.js";
 import {
-	asChild,
 	transitionProps,
 	portalProp,
 	enums,
@@ -12,7 +11,7 @@ import {
 } from "@/content/api-reference/helpers.js";
 import type * as Menu from "$lib/bits/menu/_types";
 import * as C from "@/content/constants";
-import { builderAndAttrsSlotProps } from "./helpers";
+import { builderAndAttrsSlotProps, domElProps } from "./helpers";
 
 const props = {
 	preventScroll: {
@@ -99,22 +98,22 @@ const subProps = {
 const contentProps = {
 	...transitionProps,
 	...floatingPositioning,
-	asChild
+	...domElProps("HTMLDivElement")
 } satisfies PropObj<Menu.ContentProps>;
 
 const subContentProps = {
 	...transitionProps,
 	...floatingPositioning,
-	asChild
+	...domElProps("HTMLDivElement")
 } satisfies PropObj<Menu.SubContentProps>;
 
 const arrowProps = {
-	asChild,
 	size: {
 		type: C.NUMBER,
 		default: "8",
 		description: "The height and width of the arrow in pixels."
-	}
+	},
+	...domElProps("HTMLDivElement")
 } satisfies PropObj<Menu.ArrowProps>;
 
 const checkboxItemProps = {
@@ -136,7 +135,7 @@ const checkboxItemProps = {
 		},
 		description: "A callback that is fired when the checkbox menu item's checked state changes."
 	},
-	asChild
+	...domElProps("HTMLDivElement")
 } satisfies PropObj<Menu.CheckboxItemProps>;
 
 const radioGroupProps = {
@@ -151,7 +150,7 @@ const radioGroupProps = {
 		},
 		description: "A callback that is fired when the radio group's value changes."
 	},
-	asChild
+	...domElProps("HTMLDivElement")
 } satisfies PropObj<Menu.RadioGroupProps>;
 
 const radioItemProps = {
@@ -166,15 +165,14 @@ const radioItemProps = {
 		description:
 			"Whether or not the radio menu item is disabled. Disabled items cannot be interacted with and are skipped when navigating with the keyboard."
 	},
-	asChild
+	...domElProps("HTMLDivElement")
 } satisfies PropObj<Menu.RadioItemProps>;
 
 const radioIndicatorProps = {
-	asChild
+	...domElProps("HTMLDivElement")
 } satisfies PropObj<Menu.RadioIndicatorProps>;
 
 const itemProps = {
-	asChild,
 	disabled: {
 		type: C.BOOLEAN,
 		default: C.FALSE,
@@ -183,7 +181,8 @@ const itemProps = {
 	href: {
 		type: C.STRING,
 		description: "An optional prop that when passed converts the dropdown item into an anchor tag."
-	}
+	},
+	...domElProps("HTMLDivElement")
 } satisfies PropObj<Menu.ItemProps & { href: string }>;
 
 const subTriggerProps = {
@@ -192,15 +191,15 @@ const subTriggerProps = {
 		default: C.FALSE,
 		description: "Whether or not the submenu trigger is disabled."
 	},
-	asChild
+	...domElProps("HTMLDivElement")
 } satisfies PropObj<Menu.SubTriggerProps>;
 
-const triggerProps = { asChild } satisfies PropObj<Menu.TriggerProps>;
-const groupProps = { asChild } satisfies PropObj<Menu.GroupProps>;
-const labelProps = { asChild } satisfies PropObj<Menu.LabelProps>;
-const separatorProps = { asChild } satisfies PropObj<Menu.SeparatorProps>;
+const triggerProps = domElProps("HTMLButtonElement") satisfies PropObj<Menu.TriggerProps>;
+const groupProps = domElProps("HTMLDivElement") satisfies PropObj<Menu.GroupProps>;
+const labelProps = domElProps("HTMLDivElement") satisfies PropObj<Menu.LabelProps>;
+const separatorProps = domElProps("HTMLDivElement") satisfies PropObj<Menu.SeparatorProps>;
 const checkboxIndicatorProps = {
-	asChild
+	...domElProps("HTMLDivElement")
 } satisfies PropObj<Menu.CheckboxIndicatorProps>;
 
 const STATE: DataAttrSchema = {

--- a/src/content/api-reference/menubar.ts
+++ b/src/content/api-reference/menubar.ts
@@ -1,10 +1,10 @@
 import type { APISchema } from "@/types";
-import { asChild, idsSlotProp } from "@/content/api-reference/helpers.js";
+import { idsSlotProp } from "@/content/api-reference/helpers.js";
 import { menu as m } from "./menu";
 import type * as Menubar from "$lib/bits/menubar/_types";
 import type * as Menu from "$lib/bits/menu/_types";
 import * as C from "@/content/constants";
-import { builderAndAttrsSlotProps } from "./helpers";
+import { builderAndAttrsSlotProps, domElProps } from "./helpers";
 
 export const root: APISchema<Menubar.Props> = {
 	title: "Root",
@@ -21,7 +21,7 @@ export const root: APISchema<Menubar.Props> = {
 			description:
 				"Whether or not to loop through the menubar menu triggers when navigating with the keyboard."
 		},
-		asChild
+		...domElProps("HTMLDivElement")
 	},
 	slotProps: { ...builderAndAttrsSlotProps, ids: idsSlotProp }
 };

--- a/src/content/api-reference/pagination.ts
+++ b/src/content/api-reference/pagination.ts
@@ -1,8 +1,7 @@
 import type { APISchema } from "@/types";
 import type * as Pagination from "$lib/bits/pagination/_types.js";
 import * as C from "@/content/constants.js";
-import { asChild } from "@/content/api-reference/helpers.js";
-import { builderAndAttrsSlotProps } from "./helpers";
+import { builderAndAttrsSlotProps, domElProps } from "./helpers";
 import { pageItemProp } from "./extended-types";
 
 export const root: APISchema<Pagination.Props> = {
@@ -36,7 +35,7 @@ export const root: APISchema<Pagination.Props> = {
 			},
 			description: "A function called when the selected page changes."
 		},
-		asChild
+		...domElProps("HTMLDivElement")
 	}
 };
 
@@ -48,7 +47,7 @@ export const page: APISchema<Pagination.PageProps> = {
 			type: pageItemProp,
 			description: "The page item this component represents."
 		},
-		asChild
+		...domElProps("HTMLButtonElement")
 	},
 	slotProps: {
 		...builderAndAttrsSlotProps
@@ -68,9 +67,7 @@ export const page: APISchema<Pagination.PageProps> = {
 export const prevButton: APISchema<Pagination.PrevButtonProps> = {
 	title: "PrevButton",
 	description: "The previous button of the pagination.",
-	props: {
-		asChild
-	},
+	props: domElProps("HTMLButtonElement"),
 	slotProps: {
 		...builderAndAttrsSlotProps
 	},
@@ -85,9 +82,7 @@ export const prevButton: APISchema<Pagination.PrevButtonProps> = {
 export const nextButton: APISchema<Pagination.NextButtonProps> = {
 	title: "NextButton",
 	description: "The next button of the pagination.",
-	props: {
-		asChild
-	},
+	props: domElProps("HTMLButtonElement"),
 	slotProps: {
 		...builderAndAttrsSlotProps
 	},

--- a/src/content/api-reference/pin-input.ts
+++ b/src/content/api-reference/pin-input.ts
@@ -1,8 +1,8 @@
 import type { APISchema } from "@/types";
-import { asChild, enums } from "@/content/api-reference/helpers.js";
+import { enums } from "@/content/api-reference/helpers.js";
 import type * as PinInput from "$lib/bits/pin-input/_types.js";
 import * as C from "@/content/constants.js";
-import { builderAndAttrsSlotProps, idsSlotProp } from "./helpers";
+import { builderAndAttrsSlotProps, idsSlotProp, domElProps } from "./helpers";
 
 const root: APISchema<PinInput.Props> = {
 	title: "Root",
@@ -38,7 +38,7 @@ const root: APISchema<PinInput.Props> = {
 			},
 			description: "A callback function called when the pin-input value changes."
 		},
-		asChild
+		...domElProps("HTMLDivElement")
 	},
 	slotProps: { ...builderAndAttrsSlotProps, ids: idsSlotProp },
 	dataAttributes: [
@@ -56,9 +56,7 @@ const root: APISchema<PinInput.Props> = {
 const input: APISchema<PinInput.InputProps> = {
 	title: "Input",
 	description: "The input component which contains the pin-input.",
-	props: {
-		asChild
-	},
+	props: domElProps("HTMLInputElement"),
 	dataAttributes: [
 		{
 			name: "pin-input-input",
@@ -74,9 +72,7 @@ const input: APISchema<PinInput.InputProps> = {
 const hiddenInput: APISchema<PinInput.HiddenInputProps> = {
 	title: "HiddenInput",
 	description: "The hidden input component which contains the pin-input.",
-	props: {
-		asChild
-	},
+	props: domElProps("HTMLInputElement"),
 	dataAttributes: [
 		{
 			name: "pin-input-hidden-input",

--- a/src/content/api-reference/popover.ts
+++ b/src/content/api-reference/popover.ts
@@ -6,12 +6,12 @@ import {
 	portalProp,
 	transitionProps,
 	arrowProps,
-	asChild,
 	enums,
-	idsSlotProp
+	idsSlotProp,
+	domElProps,
+	builderAndAttrsSlotProps
 } from "@/content/api-reference/helpers.js";
 import * as C from "@/content/constants.js";
-import { builderAndAttrsSlotProps } from "./helpers";
 
 export const root: APISchema<Popover.Props> = {
 	title: "Root",
@@ -66,7 +66,7 @@ export const root: APISchema<Popover.Props> = {
 export const trigger: APISchema<Popover.TriggerProps> = {
 	title: "Trigger",
 	description: "A component which toggles the opening and closing of the popover on press.",
-	props: { asChild },
+	props: domElProps("HTMLButtonElement"),
 	slotProps: { ...builderAndAttrsSlotProps },
 	dataAttributes: [
 		{
@@ -85,7 +85,7 @@ export const trigger: APISchema<Popover.TriggerProps> = {
 export const content: APISchema<Popover.ContentProps> = {
 	title: "Content",
 	description: "The contents of the popover which are displayed when the popover is open.",
-	props: { ...transitionProps, ...floatingPositioning, asChild },
+	props: { ...transitionProps, ...floatingPositioning, ...domElProps("HTMLDivElement") },
 	slotProps: { ...builderAndAttrsSlotProps },
 	dataAttributes: [
 		{
@@ -105,7 +105,7 @@ export const close: APISchema<Popover.CloseProps> = {
 	title: "Close",
 	description:
 		"A button which closes the popover when pressed and is typically placed in the content.",
-	props: { asChild },
+	props: domElProps("HTMLButtonElement"),
 	slotProps: { ...builderAndAttrsSlotProps },
 	dataAttributes: [
 		{

--- a/src/content/api-reference/progress.ts
+++ b/src/content/api-reference/progress.ts
@@ -1,8 +1,8 @@
 import type { APISchema } from "@/types/index.js";
-import { asChild, enums } from "@/content/api-reference/helpers.js";
+import { enums } from "@/content/api-reference/helpers.js";
 import * as C from "@/content/constants.js";
 import type * as Progress from "$lib/bits/progress/_types.js";
-import { builderAndAttrsSlotProps } from "./helpers";
+import { builderAndAttrsSlotProps, domElProps } from "./helpers";
 
 export const root: APISchema<Progress.Props> = {
 	title: "Root",
@@ -26,7 +26,7 @@ export const root: APISchema<Progress.Props> = {
 			},
 			description: "A callback that fires when the value changes."
 		},
-		asChild
+		...domElProps("HTMLDivElement")
 	},
 	slotProps: { ...builderAndAttrsSlotProps },
 	dataAttributes: [

--- a/src/content/api-reference/radio-group.ts
+++ b/src/content/api-reference/radio-group.ts
@@ -1,8 +1,8 @@
 import type { APISchema } from "@/types";
-import { asChild, attrsSlotProp, enums } from "@/content/api-reference/helpers.js";
+import { attrsSlotProp, enums } from "@/content/api-reference/helpers.js";
 import type * as RadioGroup from "$lib/bits/radio-group/_types";
 import * as C from "@/content/constants";
-import { builderAndAttrsSlotProps } from "./helpers";
+import { builderAndAttrsSlotProps, domElProps } from "./helpers";
 
 export const root: APISchema<RadioGroup.Props> = {
 	title: "Root",
@@ -46,7 +46,7 @@ export const root: APISchema<RadioGroup.Props> = {
 			},
 			description: "A callback that is fired when the radio group's value changes."
 		},
-		asChild
+		...domElProps("HTMLDivElement")
 	},
 	slotProps: { ...builderAndAttrsSlotProps },
 	dataAttributes: [
@@ -79,7 +79,7 @@ export const item: APISchema<RadioGroup.ItemProps> = {
 				"The value of the radio item. This should be unique for each radio item in the group.",
 			required: true
 		},
-		asChild
+		...domElProps("HTMLButtonElement")
 	},
 	slotProps: { ...builderAndAttrsSlotProps },
 	dataAttributes: [
@@ -114,14 +114,14 @@ export const input: APISchema<RadioGroup.InputProps> = {
 	title: "Input",
 	description:
 		"A hidden input that is used to submit the radio group's value with a form. It can receive all the same props/attributes as a normal HTML input.",
-	props: { asChild }
+	props: domElProps("HTMLInputElement")
 };
 
 export const indicator: APISchema = {
 	title: "ItemIndicator",
 	description:
 		"A component which is used to indicate the radio item's checked state. Any children of this component will only be visible when the radio item is checked.",
-	props: { asChild },
+	props: domElProps("HTMLDivElement"),
 	slotProps: {
 		attrs: attrsSlotProp,
 		checked: {

--- a/src/content/api-reference/range-calendar.ts
+++ b/src/content/api-reference/range-calendar.ts
@@ -1,7 +1,6 @@
 import type { APISchema } from "@/types";
 import * as C from "@/content/constants.js";
 import {
-	asChild,
 	attrsSlotProp,
 	weekdaysSlotProp,
 	enums,
@@ -9,7 +8,7 @@ import {
 	union
 } from "@/content/api-reference/helpers.js";
 import type * as RangeCalendar from "$lib/bits/range-calendar/_types.js";
-import { builderAndAttrsSlotProps } from "./helpers";
+import { builderAndAttrsSlotProps, domElProps } from "./helpers";
 
 export const root: APISchema<RangeCalendar.Props> = {
 	title: "Root",
@@ -147,7 +146,7 @@ export const root: APISchema<RangeCalendar.Props> = {
 			description:
 				"The `start` value of the date range, which can exist prior to the true `value` being set, which is only set once a `start` and `end` value are selected. You can `bind:startValue` to a value to receive updates, but modifying this value outside the component will have no effect. To programmatically control the `start` value, use `bind:value` and update the `start` property of the `DateRange` object. This is provided as a convenience for use cases where you want to display the selected `start` value outside the component before the `value` is set."
 		},
-		asChild
+		...domElProps("HTMLDivElement")
 	},
 	slotProps: {
 		months: monthsSlotProp,
@@ -178,11 +177,11 @@ export const cell: APISchema<RangeCalendar.CellProps> = {
 	title: "Cell",
 	description: "A cell in the calendar grid.",
 	props: {
-		asChild,
 		date: {
 			type: "DateValue",
 			description: "The date for the cell."
-		}
+		},
+		...domElProps("HTMLTableCellElement")
 	},
 	slotProps: {
 		attrs: attrsSlotProp
@@ -203,7 +202,6 @@ export const day: APISchema<RangeCalendar.DayProps> = {
 	title: "Day",
 	description: "A day in the calendar grid.",
 	props: {
-		asChild,
 		date: {
 			type: "DateValue",
 			description: "The date for the cell."
@@ -211,7 +209,8 @@ export const day: APISchema<RangeCalendar.DayProps> = {
 		month: {
 			type: "DateValue",
 			description: "The current month the date is being displayed in."
-		}
+		},
+		...domElProps("HTMLDivElement")
 	},
 	slotProps: {
 		disabled: {
@@ -284,7 +283,7 @@ export const day: APISchema<RangeCalendar.DayProps> = {
 export const grid: APISchema<RangeCalendar.GridProps> = {
 	title: "Grid",
 	description: "The grid of dates in the calendar, typically representing a month.",
-	props: { asChild },
+	props: domElProps("HTMLTableElement"),
 	slotProps: { ...builderAndAttrsSlotProps },
 	dataAttributes: [
 		{
@@ -297,7 +296,7 @@ export const grid: APISchema<RangeCalendar.GridProps> = {
 export const gridBody: APISchema<RangeCalendar.GridBodyProps> = {
 	title: "GridBody",
 	description: "The body of the grid of dates in the calendar.",
-	props: { asChild },
+	props: domElProps("HTMLTableSectionElement"),
 	slotProps: { attrs: attrsSlotProp },
 	dataAttributes: [
 		{
@@ -310,7 +309,7 @@ export const gridBody: APISchema<RangeCalendar.GridBodyProps> = {
 export const gridHead: APISchema<RangeCalendar.GridHeadProps> = {
 	title: "GridHead",
 	description: "The head of the grid of dates in the calendar.",
-	props: { asChild },
+	props: domElProps("HTMLTableSectionElement"),
 	slotProps: { attrs: attrsSlotProp },
 	dataAttributes: [
 		{
@@ -323,7 +322,7 @@ export const gridHead: APISchema<RangeCalendar.GridHeadProps> = {
 export const gridRow: APISchema<RangeCalendar.GridRowProps> = {
 	title: "GridRow",
 	description: "A row in the grid of dates in the calendar.",
-	props: { asChild },
+	props: domElProps("HTMLTableRowElement"),
 	slotProps: { attrs: attrsSlotProp },
 	dataAttributes: [
 		{
@@ -336,7 +335,7 @@ export const gridRow: APISchema<RangeCalendar.GridRowProps> = {
 export const headCell: APISchema<RangeCalendar.HeadCellProps> = {
 	title: "HeadCell",
 	description: "A cell in the head of the grid of dates in the calendar.",
-	props: { asChild },
+	props: domElProps("HTMLTableCellElement"),
 	slotProps: { attrs: attrsSlotProp },
 	dataAttributes: [
 		{
@@ -349,7 +348,7 @@ export const headCell: APISchema<RangeCalendar.HeadCellProps> = {
 export const header: APISchema<RangeCalendar.HeaderProps> = {
 	title: "Header",
 	description: "The header of the calendar.",
-	props: { asChild },
+	props: domElProps("HTMLElement"),
 	slotProps: { attrs: attrsSlotProp },
 	dataAttributes: [
 		{
@@ -362,7 +361,7 @@ export const header: APISchema<RangeCalendar.HeaderProps> = {
 export const heading: APISchema<RangeCalendar.HeadingProps> = {
 	title: "Heading",
 	description: "The heading of the calendar.",
-	props: { asChild },
+	props: domElProps("HTMLDivElement"),
 	slotProps: {
 		...builderAndAttrsSlotProps,
 		headingValue: {
@@ -381,7 +380,7 @@ export const heading: APISchema<RangeCalendar.HeadingProps> = {
 export const nextButton: APISchema<RangeCalendar.NextButtonProps> = {
 	title: "NextButton",
 	description: "The next button of the calendar.",
-	props: { asChild },
+	props: domElProps("HTMLButtonElement"),
 	slotProps: { ...builderAndAttrsSlotProps },
 	dataAttributes: [
 		{
@@ -394,7 +393,7 @@ export const nextButton: APISchema<RangeCalendar.NextButtonProps> = {
 export const prevButton: APISchema<RangeCalendar.PrevButtonProps> = {
 	title: "PrevButton",
 	description: "The previous button of the calendar.",
-	props: { asChild },
+	props: domElProps("HTMLButtonElement"),
 	slotProps: { ...builderAndAttrsSlotProps },
 	dataAttributes: [
 		{

--- a/src/content/api-reference/select.ts
+++ b/src/content/api-reference/select.ts
@@ -3,15 +3,16 @@ import {
 	arrowProps,
 	asChild,
 	attrsSlotProp,
+	domElProps,
 	enums,
 	idsSlotProp,
 	portalProp,
-	transitionProps
+	transitionProps,
+	builderAndAttrsSlotProps
 } from "@/content/api-reference/helpers.js";
 import { floatingPositioning } from "./floating.js";
 import * as C from "@/content/constants.js";
 import type * as Select from "$lib/bits/select/_types.js";
-import { builderAndAttrsSlotProps } from "./helpers";
 
 export const root: APISchema<Select.Props> = {
 	title: "Root",
@@ -117,7 +118,7 @@ export const root: APISchema<Select.Props> = {
 export const trigger: APISchema<Select.TriggerProps> = {
 	title: "Trigger",
 	description: "The button element which toggles the select menu's open state.",
-	props: { asChild },
+	props: domElProps("HTMLButtonElement"),
 	slotProps: { ...builderAndAttrsSlotProps },
 	dataAttributes: [
 		{
@@ -140,7 +141,7 @@ export const trigger: APISchema<Select.TriggerProps> = {
 export const content: APISchema<Select.ContentProps> = {
 	title: "Content",
 	description: "The content/menu element which contains the select menu's items.",
-	props: { ...transitionProps, ...floatingPositioning, asChild },
+	props: { ...transitionProps, ...floatingPositioning, ...domElProps("HTMLDivElement") },
 	slotProps: { ...builderAndAttrsSlotProps },
 	dataAttributes: [
 		{
@@ -168,7 +169,7 @@ export const item: APISchema<Select.ItemProps> = {
 			description:
 				"Whether or not the select item is disabled. This will prevent interaction/selection."
 		},
-		asChild
+		...domElProps("HTMLDivElement")
 	},
 	slotProps: { ...builderAndAttrsSlotProps },
 	dataAttributes: [
@@ -219,14 +220,14 @@ export const input: APISchema<Select.InputProps> = {
 	title: "Input",
 	description:
 		"A hidden input element which is used to store the select menu's value, used for form submission. It receives the same value as the `Select.Value` component and can receive any props that a normal input element can receive.",
-	props: { asChild },
+	props: domElProps("HTMLInputElement"),
 	slotProps: { ...builderAndAttrsSlotProps }
 };
 
 export const group: APISchema<Select.GroupProps> = {
 	title: "Group",
 	description: "An accessible group of select menu items.",
-	props: { asChild },
+	props: domElProps("HTMLDivElement"),
 	slotProps: { ...builderAndAttrsSlotProps },
 	dataAttributes: [
 		{
@@ -240,7 +241,7 @@ export const label: APISchema<Select.LabelProps> = {
 	title: "Label",
 	description:
 		"A label for the select menu which will be skipped when navigating with the keyboard. This must be a child of the `Select.Group` component to be accessible.",
-	props: { asChild },
+	props: domElProps("HTMLLabelElement"),
 	slotProps: { ...builderAndAttrsSlotProps },
 	dataAttributes: [
 		{
@@ -253,7 +254,7 @@ export const label: APISchema<Select.LabelProps> = {
 export const separator: APISchema<Select.SeparatorProps> = {
 	title: "Separator",
 	description: "A visual separator for use between select items or groups.",
-	props: { asChild },
+	props: domElProps("HTMLDivElement"),
 	slotProps: { ...builderAndAttrsSlotProps },
 	dataAttributes: [
 		{
@@ -266,7 +267,7 @@ export const separator: APISchema<Select.SeparatorProps> = {
 export const indicator: APISchema<Select.IndicatorProps> = {
 	title: "Separator",
 	description: "A visual separator for use between select items or groups.",
-	props: { asChild },
+	props: domElProps("HTMLDivElement"),
 	slotProps: {
 		attrs: attrsSlotProp,
 		isSelected: {

--- a/src/content/api-reference/separator.ts
+++ b/src/content/api-reference/separator.ts
@@ -1,8 +1,7 @@
 import type { APISchema } from "@/types";
-import { asChild, enums } from "@/content/api-reference/helpers.js";
+import { enums, builderAndAttrsSlotProps, domElProps } from "@/content/api-reference/helpers.js";
 import * as C from "@/content/constants";
 import type * as Separator from "$lib/bits/separator/_types";
-import { builderAndAttrsSlotProps } from "./helpers";
 
 export const root: APISchema<Separator.Props> = {
 	title: "Root",
@@ -22,7 +21,7 @@ export const root: APISchema<Separator.Props> = {
 			description:
 				"Whether the separator is decorative or not, which will determine if it is announce by screen readers."
 		},
-		asChild
+		...domElProps("HTMLDivElement")
 	},
 	slotProps: { ...builderAndAttrsSlotProps },
 	dataAttributes: [

--- a/src/content/api-reference/slider.ts
+++ b/src/content/api-reference/slider.ts
@@ -1,8 +1,7 @@
 import type { APISchema } from "@/types";
-import { asChild, enums } from "@/content/api-reference/helpers.js";
+import { enums, builderAndAttrsSlotProps, domElProps } from "@/content/api-reference/helpers.js";
 import type * as Slider from "$lib/bits/slider/_types.js";
 import * as C from "@/content/constants.js";
-import { builderAndAttrsSlotProps } from "./helpers";
 
 const root: APISchema<Slider.Props> = {
 	title: "Root",
@@ -48,7 +47,7 @@ const root: APISchema<Slider.Props> = {
 			type: C.NUMBER,
 			description: "The step value of the slider."
 		},
-		asChild
+		...domElProps("HTMLSpanElement")
 	},
 	slotProps: {
 		...builderAndAttrsSlotProps,
@@ -74,7 +73,7 @@ const root: APISchema<Slider.Props> = {
 const thumb: APISchema<Slider.ThumbProps> = {
 	title: "Thumb",
 	description: "A thumb on the slider.",
-	props: { asChild },
+	props: domElProps("HTMLSpanElement"),
 	slotProps: { ...builderAndAttrsSlotProps },
 	dataAttributes: [
 		{
@@ -87,7 +86,7 @@ const thumb: APISchema<Slider.ThumbProps> = {
 const range: APISchema<Slider.RangeProps> = {
 	title: "Range",
 	description: "The range of the slider.",
-	props: { asChild },
+	props: domElProps("HTMLSpanElement"),
 	slotProps: { ...builderAndAttrsSlotProps },
 	dataAttributes: [
 		{
@@ -100,7 +99,7 @@ const range: APISchema<Slider.RangeProps> = {
 const tick: APISchema<Slider.TickProps> = {
 	title: "Tick",
 	description: "A tick mark on the slider.",
-	props: { asChild },
+	props: domElProps("HTMLSpanElement"),
 	slotProps: { ...builderAndAttrsSlotProps },
 	dataAttributes: [
 		{

--- a/src/content/api-reference/switch.ts
+++ b/src/content/api-reference/switch.ts
@@ -1,8 +1,8 @@
 import type { APISchema } from "@/types";
-import { asChild, attrsSlotProp, enums } from "@/content/api-reference/helpers.js";
+import { attrsSlotProp, enums } from "@/content/api-reference/helpers.js";
 import type * as Switch from "$lib/bits/switch/_types.js";
 import * as C from "@/content/constants.js";
-import { builderAndAttrsSlotProps } from "./helpers";
+import { builderAndAttrsSlotProps, domElProps } from "./helpers";
 
 const root: APISchema<Switch.Props> = {
 	title: "Root",
@@ -50,7 +50,7 @@ const root: APISchema<Switch.Props> = {
 			description:
 				"The value of the hidden input element to be used in form submissions when the switch is checked."
 		},
-		asChild
+		...domElProps("HTMLButtonElement")
 	},
 	slotProps: {
 		...builderAndAttrsSlotProps
@@ -80,7 +80,7 @@ const root: APISchema<Switch.Props> = {
 const thumb: APISchema<Switch.ThumbProps> = {
 	title: "Thumb",
 	description: "The thumb on the switch used to indicate the switch's state.",
-	props: { asChild },
+	props: domElProps("HTMLSpanElement"),
 	slotProps: {
 		attrs: attrsSlotProp,
 		checked: {

--- a/src/content/api-reference/tabs.ts
+++ b/src/content/api-reference/tabs.ts
@@ -1,8 +1,12 @@
 import type { APISchema } from "@/types";
 import * as C from "@/content/constants.js";
-import { union, enums, asChild } from "@/content/api-reference/helpers.js";
+import {
+	union,
+	enums,
+	builderAndAttrsSlotProps,
+	domElProps
+} from "@/content/api-reference/helpers.js";
 import type * as Tabs from "$lib/bits/tabs/_types.js";
-import { builderAndAttrsSlotProps } from "./helpers";
 
 const root: APISchema<Tabs.Props> = {
 	title: "Root",
@@ -45,7 +49,7 @@ const root: APISchema<Tabs.Props> = {
 			},
 			description: "The orientation of the tabs."
 		},
-		asChild
+		...domElProps("HTMLDivElement")
 	},
 	slotProps: {
 		...builderAndAttrsSlotProps,
@@ -70,7 +74,7 @@ const root: APISchema<Tabs.Props> = {
 const list: APISchema<Tabs.ListProps> = {
 	title: "List",
 	description: "The component containing the tab triggers.",
-	props: { asChild },
+	props: domElProps("HTMLDivElement"),
 	slotProps: { ...builderAndAttrsSlotProps },
 	dataAttributes: [
 		{
@@ -99,7 +103,7 @@ const trigger: APISchema<Tabs.TriggerProps> = {
 			type: C.BOOLEAN,
 			description: "Whether or not the tab is disabled."
 		},
-		asChild
+		...domElProps("HTMLButtonElement")
 	},
 	slotProps: { ...builderAndAttrsSlotProps },
 	dataAttributes: [
@@ -139,7 +143,7 @@ const content: APISchema<Tabs.ContentProps> = {
 			type: "string",
 			description: "The value of the tab this content represents."
 		},
-		asChild
+		...domElProps("HTMLDivElement")
 	},
 	slotProps: { ...builderAndAttrsSlotProps },
 	dataAttributes: [

--- a/src/content/api-reference/toggle-group.ts
+++ b/src/content/api-reference/toggle-group.ts
@@ -1,8 +1,12 @@
 import type { APISchema } from "@/types";
-import { asChild, enums } from "@/content/api-reference/helpers.js";
+import {
+	enums,
+	union,
+	builderAndAttrsSlotProps,
+	domElProps
+} from "@/content/api-reference/helpers.js";
 import type * as ToggleGroup from "$lib/bits/toggle-group/_types.js";
 import * as C from "@/content/constants.js";
-import { union, builderAndAttrsSlotProps } from "./helpers";
 
 const root: APISchema<ToggleGroup.Props<"multiple">> = {
 	title: "Root",
@@ -46,7 +50,7 @@ const root: APISchema<ToggleGroup.Props<"multiple">> = {
 			description: "The type of toggle group.",
 			type: enums("single", "multiple")
 		},
-		asChild
+		...domElProps("HTMLDivElement")
 	},
 	slotProps: { ...builderAndAttrsSlotProps },
 	dataAttributes: [
@@ -74,7 +78,7 @@ const item: APISchema<ToggleGroup.ItemProps> = {
 			type: C.BOOLEAN,
 			description: "Whether or not the switch is disabled."
 		},
-		asChild
+		...domElProps("HTMLButtonElement")
 	},
 	slotProps: { ...builderAndAttrsSlotProps },
 	dataAttributes: [

--- a/src/content/api-reference/toggle.ts
+++ b/src/content/api-reference/toggle.ts
@@ -1,8 +1,7 @@
 import type { APISchema } from "@/types";
-import { asChild, enums } from "@/content/api-reference/helpers.js";
+import { enums, builderAndAttrsSlotProps, domElProps } from "@/content/api-reference/helpers.js";
 import type * as Toggle from "$lib/bits/toggle/_types.js";
 import * as C from "@/content/constants.js";
-import { builderAndAttrsSlotProps } from "./helpers";
 
 const root: APISchema<Toggle.Props> = {
 	title: "Root",
@@ -25,7 +24,7 @@ const root: APISchema<Toggle.Props> = {
 			type: C.BOOLEAN,
 			description: "Whether or not the switch is disabled."
 		},
-		asChild
+		...domElProps("HTMLButtonElement")
 	},
 	slotProps: { ...builderAndAttrsSlotProps },
 	dataAttributes: [

--- a/src/content/api-reference/toolbar.ts
+++ b/src/content/api-reference/toolbar.ts
@@ -1,8 +1,13 @@
 import type { APISchema } from "@/types";
-import { asChild, enums } from "@/content/api-reference/helpers.js";
+import {
+	enums,
+	union,
+	builderAndAttrsSlotProps,
+	domElProps
+} from "@/content/api-reference/helpers.js";
 import type * as Toolbar from "$lib/bits/toolbar/_types.js";
 import * as C from "@/content/constants.js";
-import { union, builderAndAttrsSlotProps } from "./helpers";
+import {} from "./helpers";
 
 const root: APISchema<Toolbar.Props> = {
 	title: "Root",
@@ -21,7 +26,7 @@ const root: APISchema<Toolbar.Props> = {
 			},
 			description: "The orientation of the toolbar."
 		},
-		asChild
+		...domElProps("HTMLDivElement")
 	},
 	slotProps: { ...builderAndAttrsSlotProps },
 	dataAttributes: [
@@ -39,7 +44,7 @@ const root: APISchema<Toolbar.Props> = {
 const button: APISchema<Toolbar.ButtonProps> = {
 	title: "Button",
 	description: "A button in the toolbar.",
-	props: { asChild },
+	props: domElProps("HTMLButtonElement"),
 	slotProps: { ...builderAndAttrsSlotProps },
 	dataAttributes: [
 		{
@@ -52,7 +57,7 @@ const button: APISchema<Toolbar.ButtonProps> = {
 const link: APISchema<Toolbar.LinkProps> = {
 	title: "Link",
 	description: "A link in the toolbar.",
-	props: { asChild },
+	props: domElProps("HTMLAnchorElement"),
 	slotProps: { ...builderAndAttrsSlotProps },
 	dataAttributes: [
 		{
@@ -91,7 +96,7 @@ const group: APISchema<Toolbar.GroupProps<"multiple">> = {
 				definition: enums("single", "multiple")
 			}
 		},
-		asChild
+		...domElProps("HTMLDivElement")
 	},
 	slotProps: { ...builderAndAttrsSlotProps },
 	dataAttributes: [
@@ -116,7 +121,7 @@ const groupItem: APISchema<Toolbar.GroupItemProps> = {
 			type: C.BOOLEAN,
 			description: "Whether or not the item is disabled."
 		},
-		asChild
+		...domElProps("HTMLButtonElement")
 	},
 	slotProps: { ...builderAndAttrsSlotProps },
 	dataAttributes: [

--- a/src/content/api-reference/tooltip.ts
+++ b/src/content/api-reference/tooltip.ts
@@ -1,16 +1,16 @@
 import type { APISchema } from "@/types";
 import {
 	arrowProps,
-	asChild,
 	enums,
 	idsSlotProp,
 	portalProp,
-	transitionProps
+	transitionProps,
+	builderAndAttrsSlotProps,
+	domElProps
 } from "@/content/api-reference/helpers.js";
 import { floatingPositioning } from "./floating.js";
 import type * as Tooltip from "$lib/bits/tooltip/_types";
 import * as C from "@/content/constants";
-import { builderAndAttrsSlotProps } from "./helpers";
 
 export const root: APISchema<Tooltip.Props> = {
 	title: "Root",
@@ -71,7 +71,7 @@ export const trigger: APISchema<Tooltip.TriggerProps> = {
 	title: "Trigger",
 	description:
 		"A component which triggers the opening and closing of the tooltip on hover or focus.",
-	props: { asChild },
+	props: domElProps("HTMLButtonElement"),
 	slotProps: { ...builderAndAttrsSlotProps },
 	dataAttributes: [
 		{
@@ -90,7 +90,7 @@ export const trigger: APISchema<Tooltip.TriggerProps> = {
 export const content: APISchema<Tooltip.ContentProps> = {
 	title: "Content",
 	description: "The contents of the tooltip which are displayed when the tooltip is open.",
-	props: { ...transitionProps, ...floatingPositioning, asChild },
+	props: { ...transitionProps, ...floatingPositioning, ...domElProps("HTMLDivElement") },
 	slotProps: { ...builderAndAttrsSlotProps },
 	dataAttributes: [
 		{

--- a/src/lib/bits/accordion/_types.ts
+++ b/src/lib/bits/accordion/_types.ts
@@ -5,8 +5,8 @@ import type {
 	OmitForceVisible,
 	Expand,
 	OnChangeFn,
-	AsChild,
-	TransitionProps
+	TransitionProps,
+	DOMElement
 } from "$lib/internal/index.js";
 import type {
 	CreateAccordionProps,
@@ -26,10 +26,10 @@ type Props<Multiple extends boolean> = Expand<
 		 * A callback function called when the value changes.
 		 */
 		onValueChange?: OnChangeFn<CreateAccordionProps<Multiple>["defaultValue"]>;
-	} & AsChild
+	} & DOMElement
 >;
 
-type ItemProps = Expand<ObjectVariation<AccordionItemProps> & AsChild>;
+type ItemProps = Expand<ObjectVariation<AccordionItemProps> & DOMElement>;
 
 type HeaderProps = Expand<
 	{
@@ -37,15 +37,15 @@ type HeaderProps = Expand<
 		 * The heading level of the accordion header.
 		 */
 		level?: ObjectVariation<AccordionHeadingProps>["level"];
-	} & AsChild
+	} & DOMElement
 >;
 
-type TriggerProps = AsChild;
+type TriggerProps = DOMElement<HTMLButtonElement>;
 
 type ContentProps<
 	T extends Transition = Transition,
 	In extends Transition = Transition,
 	Out extends Transition = Transition
-> = Expand<TransitionProps<T, In, Out> & AsChild>;
+> = Expand<TransitionProps<T, In, Out> & DOMElement>;
 
 export type { Props, ItemProps, HeaderProps, TriggerProps, ContentProps };

--- a/src/lib/bits/accordion/components/accordion-content.svelte
+++ b/src/lib/bits/accordion/components/accordion-content.svelte
@@ -18,6 +18,7 @@
 	export let outTransition: $$Props["outTransition"] = undefined;
 	export let outTransitionConfig: $$Props["outTransitionConfig"] = undefined;
 	export let asChild: $$Props["asChild"] = false;
+	export let el: $$Props["el"] = undefined;
 
 	const { content, isSelected, props } = getContent();
 
@@ -31,6 +32,7 @@
 	<slot {builder} />
 {:else if transition && $isSelected(props)}
 	<div
+		bind:this={el}
 		transition:transition={transitionConfig}
 		use:melt={builder}
 		{...$$restProps}
@@ -39,6 +41,7 @@
 	</div>
 {:else if inTransition && outTransition && $isSelected(props)}
 	<div
+		bind:this={el}
 		in:inTransition={inTransitionConfig}
 		out:outTransition={outTransitionConfig}
 		use:melt={builder}
@@ -47,11 +50,17 @@
 		<slot {builder} />
 	</div>
 {:else if inTransition && $isSelected(props)}
-	<div in:inTransition={inTransitionConfig} use:melt={builder} {...$$restProps}>
+	<div
+		bind:this={el}
+		in:inTransition={inTransitionConfig}
+		use:melt={builder}
+		{...$$restProps}
+	>
 		<slot {builder} />
 	</div>
 {:else if outTransition && $isSelected(props)}
 	<div
+		bind:this={el}
 		out:outTransition={outTransitionConfig}
 		use:melt={builder}
 		{...$$restProps}
@@ -59,7 +68,7 @@
 		<slot {builder} />
 	</div>
 {:else if $isSelected(props)}
-	<div use:melt={builder} {...$$restProps}>
+	<div bind:this={el} use:melt={builder} {...$$restProps}>
 		<slot {builder} />
 	</div>
 {/if}

--- a/src/lib/bits/accordion/components/accordion-header.svelte
+++ b/src/lib/bits/accordion/components/accordion-header.svelte
@@ -7,6 +7,7 @@
 
 	export let level = 3;
 	export let asChild: $$Props["asChild"] = false;
+	export let el: $$Props["el"] = undefined;
 
 	const {
 		elements: { heading: header }
@@ -21,7 +22,7 @@
 {#if asChild}
 	<slot {builder} />
 {:else}
-	<div use:melt={builder} {...$$restProps}>
+	<div bind:this={el} use:melt={builder} {...$$restProps}>
 		<slot {builder} />
 	</div>
 {/if}

--- a/src/lib/bits/accordion/components/accordion-item.svelte
+++ b/src/lib/bits/accordion/components/accordion-item.svelte
@@ -7,6 +7,7 @@
 	export let value: $$Props["value"];
 	export let disabled: $$Props["disabled"] = undefined;
 	export let asChild: $$Props["asChild"] = false;
+	export let el: $$Props["el"] = undefined;
 
 	const { item, props } = setItem({ value, disabled });
 	const attrs = getAttrs("item");
@@ -18,7 +19,7 @@
 {#if asChild}
 	<slot {builder} />
 {:else}
-	<div use:melt={builder} {...$$restProps}>
+	<div bind:this={el} use:melt={builder} {...$$restProps}>
 		<slot {builder} />
 	</div>
 {/if}

--- a/src/lib/bits/accordion/components/accordion-trigger.svelte
+++ b/src/lib/bits/accordion/components/accordion-trigger.svelte
@@ -7,7 +7,8 @@
 	type $$Props = TriggerProps;
 	type $$Events = TriggerEvents;
 
-	export let asChild: TriggerProps["asChild"] = false;
+	export let asChild: $$Props["asChild"] = false;
+	export let el: $$Props["el"] = undefined;
 
 	const { trigger, props } = getTrigger();
 	const dispatch = createDispatcher();
@@ -21,6 +22,7 @@
 	<slot {builder} />
 {:else}
 	<button
+		bind:this={el}
 		use:melt={builder}
 		type="button"
 		{...$$restProps}

--- a/src/lib/bits/accordion/components/accordion.svelte
+++ b/src/lib/bits/accordion/components/accordion.svelte
@@ -11,6 +11,7 @@
 	export let onValueChange: $$Props["onValueChange"] = undefined;
 	export let disabled: $$Props["disabled"] = false;
 	export let asChild: $$Props["asChild"] = false;
+	export let el: $$Props["el"] = undefined;
 
 	const {
 		elements: { root },
@@ -55,7 +56,7 @@
 {#if asChild}
 	<slot {builder} />
 {:else}
-	<div use:melt={builder} {...$$restProps}>
+	<div bind:this={el} use:melt={builder} {...$$restProps}>
 		<slot {builder} />
 	</div>
 {/if}

--- a/src/lib/bits/accordion/types.ts
+++ b/src/lib/bits/accordion/types.ts
@@ -1,4 +1,4 @@
-import type { DOMEl, HTMLDivAttributes, Transition } from "$lib/internal/index.js";
+import type { HTMLDivAttributes, Transition } from "$lib/internal/index.js";
 import type { CustomEventHandler } from "$lib/index.js";
 import type {
 	AccordionItemProps as _ItemProps,
@@ -7,21 +7,19 @@ import type {
 import type { HTMLButtonAttributes } from "svelte/elements";
 import type * as I from "./_types.js";
 
-type Props<Multiple extends boolean> = I.Props<Multiple> &
-	HTMLDivAttributes &
-	DOMEl<HTMLDivElement>;
+type Props<Multiple extends boolean> = I.Props<Multiple> & HTMLDivAttributes;
 
-type ItemProps = I.ItemProps & HTMLDivAttributes & DOMEl;
+type ItemProps = I.ItemProps & HTMLDivAttributes;
 
-type HeaderProps = I.HeaderProps & HTMLDivAttributes & DOMEl;
+type HeaderProps = I.HeaderProps & HTMLDivAttributes;
 
-type TriggerProps = I.TriggerProps & HTMLButtonAttributes & DOMEl<HTMLButtonElement>;
+type TriggerProps = I.TriggerProps & HTMLButtonAttributes;
 
 type ContentProps<
 	T extends Transition = Transition,
 	In extends Transition = Transition,
 	Out extends Transition = Transition
-> = I.ContentProps<T, In, Out> & HTMLDivAttributes & DOMEl;
+> = I.ContentProps<T, In, Out> & HTMLDivAttributes;
 
 type TriggerEvents = {
 	click: CustomEventHandler<MouseEvent, HTMLButtonElement>;

--- a/src/lib/bits/accordion/types.ts
+++ b/src/lib/bits/accordion/types.ts
@@ -11,17 +11,17 @@ type Props<Multiple extends boolean> = I.Props<Multiple> &
 	HTMLDivAttributes &
 	DOMEl<HTMLDivElement>;
 
-type ItemProps = I.ItemProps & HTMLDivAttributes;
+type ItemProps = I.ItemProps & HTMLDivAttributes & DOMEl<HTMLDivElement>;
 
-type HeaderProps = I.HeaderProps & HTMLDivAttributes;
+type HeaderProps = I.HeaderProps & HTMLDivAttributes & DOMEl<HTMLDivElement>;
 
-type TriggerProps = I.TriggerProps & HTMLButtonAttributes;
+type TriggerProps = I.TriggerProps & HTMLButtonAttributes & DOMEl<HTMLButtonElement>;
 
 type ContentProps<
 	T extends Transition = Transition,
 	In extends Transition = Transition,
 	Out extends Transition = Transition
-> = I.ContentProps<T, In, Out> & HTMLDivAttributes;
+> = I.ContentProps<T, In, Out> & HTMLDivAttributes & DOMEl<HTMLDivElement>;
 
 type TriggerEvents = {
 	click: CustomEventHandler<MouseEvent, HTMLButtonElement>;

--- a/src/lib/bits/accordion/types.ts
+++ b/src/lib/bits/accordion/types.ts
@@ -1,4 +1,4 @@
-import type { HTMLDivAttributes, Transition } from "$lib/internal/index.js";
+import type { DOMEl, HTMLDivAttributes, Transition } from "$lib/internal/index.js";
 import type { CustomEventHandler } from "$lib/index.js";
 import type {
 	AccordionItemProps as _ItemProps,
@@ -7,7 +7,9 @@ import type {
 import type { HTMLButtonAttributes } from "svelte/elements";
 import type * as I from "./_types.js";
 
-type Props<Multiple extends boolean> = I.Props<Multiple> & HTMLDivAttributes;
+type Props<Multiple extends boolean> = I.Props<Multiple> &
+	HTMLDivAttributes &
+	DOMEl<HTMLDivElement>;
 
 type ItemProps = I.ItemProps & HTMLDivAttributes;
 

--- a/src/lib/bits/accordion/types.ts
+++ b/src/lib/bits/accordion/types.ts
@@ -11,9 +11,9 @@ type Props<Multiple extends boolean> = I.Props<Multiple> &
 	HTMLDivAttributes &
 	DOMEl<HTMLDivElement>;
 
-type ItemProps = I.ItemProps & HTMLDivAttributes & DOMEl<HTMLDivElement>;
+type ItemProps = I.ItemProps & HTMLDivAttributes & DOMEl;
 
-type HeaderProps = I.HeaderProps & HTMLDivAttributes & DOMEl<HTMLDivElement>;
+type HeaderProps = I.HeaderProps & HTMLDivAttributes & DOMEl;
 
 type TriggerProps = I.TriggerProps & HTMLButtonAttributes & DOMEl<HTMLButtonElement>;
 
@@ -21,7 +21,7 @@ type ContentProps<
 	T extends Transition = Transition,
 	In extends Transition = Transition,
 	Out extends Transition = Transition
-> = I.ContentProps<T, In, Out> & HTMLDivAttributes & DOMEl<HTMLDivElement>;
+> = I.ContentProps<T, In, Out> & HTMLDivAttributes & DOMEl;
 
 type TriggerEvents = {
 	click: CustomEventHandler<MouseEvent, HTMLButtonElement>;

--- a/src/lib/bits/alert-dialog/_types.ts
+++ b/src/lib/bits/alert-dialog/_types.ts
@@ -9,8 +9,8 @@ import type {
 	Expand,
 	OnChangeFn,
 	Transition,
-	AsChild,
-	TransitionProps
+	TransitionProps,
+	DOMElement
 } from "$lib/internal/index.js";
 import type { CreateDialogProps } from "@melt-ui/svelte";
 
@@ -31,7 +31,7 @@ type Props = Expand<
 	}
 >;
 
-type TriggerProps = AsChild;
+type TriggerProps = DOMElement<HTMLButtonElement>;
 
 type ActionProps = TriggerProps;
 type CancelProps = TriggerProps;
@@ -40,16 +40,16 @@ type ContentProps<
 	T extends Transition = Transition,
 	In extends Transition = Transition,
 	Out extends Transition = Transition
-> = Expand<TransitionProps<T, In, Out> & AsChild>;
+> = Expand<TransitionProps<T, In, Out> & DOMElement>;
 
-type DescriptionProps = AsChild;
+type DescriptionProps = DOMElement;
 
-type PortalProps = AsChild;
+type PortalProps = DOMElement;
 
 type TitleProps = Expand<
 	{
 		level?: "h1" | "h2" | "h3" | "h4" | "h5" | "h6";
-	} & AsChild
+	} & DOMElement<HTMLHeadingElement>
 >;
 
 export type {

--- a/src/lib/bits/alert-dialog/components/alert-dialog-action.svelte
+++ b/src/lib/bits/alert-dialog/components/alert-dialog-action.svelte
@@ -8,6 +8,7 @@
 	type $$Events = ActionEvents;
 
 	export let asChild: $$Props["asChild"] = false;
+	export let el: $$Props["el"] = undefined;
 
 	const {
 		elements: { close }
@@ -24,6 +25,7 @@
 	<slot {builder} />
 {:else}
 	<button
+		bind:this={el}
 		use:melt={builder}
 		type="button"
 		{...$$restProps}

--- a/src/lib/bits/alert-dialog/components/alert-dialog-cancel.svelte
+++ b/src/lib/bits/alert-dialog/components/alert-dialog-cancel.svelte
@@ -8,6 +8,7 @@
 	type $$Events = CancelEvents;
 
 	export let asChild: $$Props["asChild"] = false;
+	export let el: $$Props["el"] = undefined;
 
 	const {
 		elements: { close }
@@ -24,6 +25,7 @@
 	<slot {builder} />
 {:else}
 	<button
+		bind:this={el}
 		use:melt={builder}
 		type="button"
 		{...$$restProps}

--- a/src/lib/bits/alert-dialog/components/alert-dialog-content.svelte
+++ b/src/lib/bits/alert-dialog/components/alert-dialog-content.svelte
@@ -18,6 +18,7 @@
 	export let outTransitionConfig: $$Props["outTransitionConfig"] = undefined;
 	export let id: $$Props["id"] = undefined;
 	export let asChild: $$Props["asChild"] = false;
+	export let el: $$Props["el"] = undefined;
 
 	const {
 		elements: { content },
@@ -38,6 +39,7 @@
 	<slot {builder} />
 {:else if transition && $open}
 	<div
+		bind:this={el}
 		transition:transition={transitionConfig}
 		use:melt={builder}
 		{...$$restProps}
@@ -46,6 +48,7 @@
 	</div>
 {:else if inTransition && outTransition && $open}
 	<div
+		bind:this={el}
 		in:inTransition={inTransitionConfig}
 		out:outTransition={outTransitionConfig}
 		use:melt={builder}
@@ -54,11 +57,17 @@
 		<slot {builder} />
 	</div>
 {:else if inTransition && $open}
-	<div in:inTransition={inTransitionConfig} use:melt={builder} {...$$restProps}>
+	<div
+		bind:this={el}
+		in:inTransition={inTransitionConfig}
+		use:melt={builder}
+		{...$$restProps}
+	>
 		<slot {builder} />
 	</div>
 {:else if outTransition && $open}
 	<div
+		bind:this={el}
 		out:outTransition={outTransitionConfig}
 		use:melt={builder}
 		{...$$restProps}
@@ -66,7 +75,7 @@
 		<slot {builder} />
 	</div>
 {:else if $open}
-	<div use:melt={builder} {...$$restProps}>
+	<div bind:this={el} use:melt={builder} {...$$restProps}>
 		<slot {builder} />
 	</div>
 {/if}

--- a/src/lib/bits/alert-dialog/components/alert-dialog-description.svelte
+++ b/src/lib/bits/alert-dialog/components/alert-dialog-description.svelte
@@ -7,6 +7,7 @@
 
 	export let asChild: $$Props["asChild"] = false;
 	export let id: $$Props["id"] = undefined;
+	export let el: $$Props["el"] = undefined;
 
 	const {
 		elements: { description },
@@ -25,7 +26,7 @@
 {#if asChild}
 	<slot {builder} />
 {:else}
-	<div use:melt={builder} {...$$restProps}>
+	<div bind:this={el} use:melt={builder} {...$$restProps}>
 		<slot {builder} />
 	</div>
 {/if}

--- a/src/lib/bits/alert-dialog/components/alert-dialog-overlay.svelte
+++ b/src/lib/bits/alert-dialog/components/alert-dialog-overlay.svelte
@@ -17,6 +17,7 @@
 	export let outTransition: $$Props["outTransition"] = undefined;
 	export let outTransitionConfig: $$Props["outTransitionConfig"] = undefined;
 	export let asChild: $$Props["asChild"] = false;
+	export let el: $$Props["el"] = undefined;
 
 	const {
 		elements: { overlay },
@@ -33,12 +34,14 @@
 	<slot {builder} />
 {:else if transition && $open}
 	<div
+		bind:this={el}
 		transition:transition={transitionConfig}
 		use:melt={builder}
 		{...$$restProps}
 	/>
 {:else if inTransition && outTransition && $open}
 	<div
+		bind:this={el}
 		in:inTransition={inTransitionConfig}
 		out:outTransition={outTransitionConfig}
 		use:melt={builder}
@@ -46,16 +49,18 @@
 	/>
 {:else if inTransition && $open}
 	<div
+		bind:this={el}
 		in:inTransition={inTransitionConfig}
 		use:melt={builder}
 		{...$$restProps}
 	/>
 {:else if outTransition && $open}
 	<div
+		bind:this={el}
 		out:outTransition={outTransitionConfig}
 		use:melt={builder}
 		{...$$restProps}
 	/>
 {:else if $open}
-	<div use:melt={builder} {...$$restProps} />
+	<div bind:this={el} use:melt={builder} {...$$restProps} />
 {/if}

--- a/src/lib/bits/alert-dialog/components/alert-dialog-portal.svelte
+++ b/src/lib/bits/alert-dialog/components/alert-dialog-portal.svelte
@@ -6,6 +6,7 @@
 	type $$Props = PortalProps;
 
 	export let asChild: $$Props["asChild"] = false;
+	export let el: $$Props["el"] = undefined;
 
 	const {
 		elements: { portalled }
@@ -19,7 +20,7 @@
 {#if asChild}
 	<slot {builder} />
 {:else}
-	<div use:melt={builder} {...$$restProps}>
+	<div bind:this={el} use:melt={builder} {...$$restProps}>
 		<slot {builder} />
 	</div>
 {/if}

--- a/src/lib/bits/alert-dialog/components/alert-dialog-title.svelte
+++ b/src/lib/bits/alert-dialog/components/alert-dialog-title.svelte
@@ -8,6 +8,7 @@
 	export let level: $$Props["level"] = "h2";
 	export let asChild: $$Props["asChild"] = false;
 	export let id: $$Props["id"] = undefined;
+	export let el: $$Props["el"] = undefined;
 
 	const {
 		elements: { title },
@@ -27,7 +28,12 @@
 {#if asChild}
 	<slot {builder} />
 {:else}
-	<svelte:element this={level} use:melt={builder} {...$$restProps}>
+	<svelte:element
+		this={level}
+		bind:this={el}
+		use:melt={builder}
+		{...$$restProps}
+	>
 		<slot {builder} />
 	</svelte:element>
 {/if}

--- a/src/lib/bits/alert-dialog/components/alert-dialog-trigger.svelte
+++ b/src/lib/bits/alert-dialog/components/alert-dialog-trigger.svelte
@@ -8,6 +8,7 @@
 	type $$Events = TriggerEvents;
 
 	export let asChild: $$Props["asChild"] = false;
+	export let el: $$Props["el"] = undefined;
 
 	const {
 		elements: { trigger }
@@ -24,6 +25,7 @@
 	<slot {builder} />
 {:else}
 	<button
+		bind:this={el}
 		use:melt={builder}
 		type="button"
 		on:m-click={dispatch}

--- a/src/lib/bits/alert-dialog/types.ts
+++ b/src/lib/bits/alert-dialog/types.ts
@@ -1,32 +1,27 @@
-import type {
-	DOMEl,
-	HTMLDivAttributes,
-	HTMLHeadingAttributes,
-	Transition
-} from "$lib/internal/index.js";
+import type { HTMLDivAttributes, HTMLHeadingAttributes, Transition } from "$lib/internal/index.js";
 import type { HTMLButtonAttributes } from "svelte/elements";
 import type { CustomEventHandler } from "$lib/index.js";
 import type * as I from "./_types.js";
 
 type Props = I.Props;
 
-type TriggerProps = I.TriggerProps & HTMLButtonAttributes & DOMEl<HTMLButtonElement>;
+type TriggerProps = I.TriggerProps & HTMLButtonAttributes;
 
-type ActionProps = TriggerProps & DOMEl<HTMLButtonElement>;
+type ActionProps = TriggerProps;
 
-type CancelProps = TriggerProps & DOMEl<HTMLButtonElement>;
+type CancelProps = TriggerProps;
 
 type ContentProps<
 	T extends Transition = Transition,
 	In extends Transition = Transition,
 	Out extends Transition = Transition
-> = I.ContentProps<T, In, Out> & HTMLDivAttributes & DOMEl;
+> = I.ContentProps<T, In, Out> & HTMLDivAttributes;
 
-type DescriptionProps = I.DescriptionProps & HTMLDivAttributes & DOMEl;
+type DescriptionProps = I.DescriptionProps & HTMLDivAttributes;
 
-type PortalProps = I.PortalProps & HTMLDivAttributes & DOMEl;
+type PortalProps = I.PortalProps & HTMLDivAttributes;
 
-type TitleProps = I.TitleProps & HTMLHeadingAttributes & DOMEl<HTMLHeadingElement>;
+type TitleProps = I.TitleProps & HTMLHeadingAttributes;
 
 type TriggerEvents<T extends Element = HTMLButtonElement> = {
 	click: CustomEventHandler<MouseEvent, T>;

--- a/src/lib/bits/alert-dialog/types.ts
+++ b/src/lib/bits/alert-dialog/types.ts
@@ -20,11 +20,11 @@ type ContentProps<
 	T extends Transition = Transition,
 	In extends Transition = Transition,
 	Out extends Transition = Transition
-> = I.ContentProps<T, In, Out> & HTMLDivAttributes & DOMEl<HTMLDivElement>;
+> = I.ContentProps<T, In, Out> & HTMLDivAttributes & DOMEl;
 
-type DescriptionProps = I.DescriptionProps & HTMLDivAttributes & DOMEl<HTMLDivElement>;
+type DescriptionProps = I.DescriptionProps & HTMLDivAttributes & DOMEl;
 
-type PortalProps = I.PortalProps & HTMLDivAttributes & DOMEl<HTMLDivElement>;
+type PortalProps = I.PortalProps & HTMLDivAttributes & DOMEl;
 
 type TitleProps = I.TitleProps & HTMLHeadingAttributes & DOMEl<HTMLHeadingElement>;
 

--- a/src/lib/bits/alert-dialog/types.ts
+++ b/src/lib/bits/alert-dialog/types.ts
@@ -1,27 +1,32 @@
-import type { HTMLDivAttributes, HTMLHeadingAttributes, Transition } from "$lib/internal/index.js";
+import type {
+	DOMEl,
+	HTMLDivAttributes,
+	HTMLHeadingAttributes,
+	Transition
+} from "$lib/internal/index.js";
 import type { HTMLButtonAttributes } from "svelte/elements";
 import type { CustomEventHandler } from "$lib/index.js";
 import type * as I from "./_types.js";
 
 type Props = I.Props;
 
-type TriggerProps = I.TriggerProps & HTMLButtonAttributes;
+type TriggerProps = I.TriggerProps & HTMLButtonAttributes & DOMEl<HTMLButtonElement>;
 
-type ActionProps = TriggerProps;
+type ActionProps = TriggerProps & DOMEl<HTMLButtonElement>;
 
-type CancelProps = TriggerProps;
+type CancelProps = TriggerProps & DOMEl<HTMLButtonElement>;
 
 type ContentProps<
 	T extends Transition = Transition,
 	In extends Transition = Transition,
 	Out extends Transition = Transition
-> = I.ContentProps<T, In, Out> & HTMLDivAttributes;
+> = I.ContentProps<T, In, Out> & HTMLDivAttributes & DOMEl<HTMLDivElement>;
 
-type DescriptionProps = I.DescriptionProps & HTMLDivAttributes;
+type DescriptionProps = I.DescriptionProps & HTMLDivAttributes & DOMEl<HTMLDivElement>;
 
-type PortalProps = I.PortalProps & HTMLDivAttributes;
+type PortalProps = I.PortalProps & HTMLDivAttributes & DOMEl<HTMLDivElement>;
 
-type TitleProps = I.TitleProps & HTMLHeadingAttributes;
+type TitleProps = I.TitleProps & HTMLHeadingAttributes & DOMEl<HTMLHeadingElement>;
 
 type TriggerEvents<T extends Element = HTMLButtonElement> = {
 	click: CustomEventHandler<MouseEvent, T>;

--- a/src/lib/bits/aspect-ratio/_types.ts
+++ b/src/lib/bits/aspect-ratio/_types.ts
@@ -4,8 +4,12 @@
  * but we don't want to document the HTML attributes.
  */
 
-type Props = Expand<{
-	ratio: number;
-}>;
+import type { DOMEl } from "$lib/internal/index.js";
+
+type Props = Expand<
+	{
+		ratio: number;
+	} & DOMEl
+>;
 
 export type { Props };

--- a/src/lib/bits/aspect-ratio/components/aspect-ratio.svelte
+++ b/src/lib/bits/aspect-ratio/components/aspect-ratio.svelte
@@ -3,6 +3,7 @@
 
 	type $$Props = Props;
 	export let ratio: $$Props["ratio"] = 1 / 1;
+	export let el: $$Props["el"] = undefined;
 
 	const attrs = {
 		"data-aspect-ratio-root": ""
@@ -15,6 +16,7 @@
 	style:padding-bottom="{100 / ratio}%"
 >
 	<div
+		bind:this={el}
 		style:position="absolute"
 		style:top="0"
 		style:right="0"

--- a/src/lib/bits/aspect-ratio/types.ts
+++ b/src/lib/bits/aspect-ratio/types.ts
@@ -1,6 +1,6 @@
 import type { DOMEl, HTMLDivAttributes } from "$lib/internal/index.js";
 import type * as I from "./_types.js";
 
-type Props = I.Props & HTMLDivAttributes & DOMEl<HTMLDivElement>;
+type Props = I.Props & HTMLDivAttributes & DOMEl;
 
 export type { Props };

--- a/src/lib/bits/aspect-ratio/types.ts
+++ b/src/lib/bits/aspect-ratio/types.ts
@@ -1,6 +1,6 @@
-import type { DOMEl, HTMLDivAttributes } from "$lib/internal/index.js";
+import type { HTMLDivAttributes } from "$lib/internal/index.js";
 import type * as I from "./_types.js";
 
-type Props = I.Props & HTMLDivAttributes & DOMEl;
+type Props = I.Props & HTMLDivAttributes;
 
 export type { Props };

--- a/src/lib/bits/aspect-ratio/types.ts
+++ b/src/lib/bits/aspect-ratio/types.ts
@@ -1,6 +1,6 @@
-import type { HTMLDivAttributes } from "$lib/internal/index.js";
+import type { DOMEl, HTMLDivAttributes } from "$lib/internal/index.js";
 import type * as I from "./_types.js";
 
-type Props = I.Props & HTMLDivAttributes;
+type Props = I.Props & HTMLDivAttributes & DOMEl<HTMLDivElement>;
 
 export type { Props };

--- a/src/lib/bits/avatar/_types.ts
+++ b/src/lib/bits/avatar/_types.ts
@@ -4,7 +4,7 @@
  * but we don't want to document the HTML attributes.
  */
 
-import type { Expand, AsChild, OnChangeFn } from "$lib/internal/index.js";
+import type { Expand, OnChangeFn, DOMElement } from "$lib/internal/index.js";
 import type { CreateAvatarProps } from "@melt-ui/svelte";
 
 type Props = Expand<
@@ -19,11 +19,11 @@ type Props = Expand<
 		 * A callback function called when the loading state changes.
 		 */
 		onLoadingStatusChange?: OnChangeFn<"loading" | "loaded" | "error">;
-	} & AsChild
+	} & DOMElement
 >;
 
-type ImageProps = Expand<AsChild>;
+type ImageProps = DOMElement<HTMLImageElement>;
 
-type FallbackProps = AsChild;
+type FallbackProps = DOMElement<HTMLSpanElement>;
 
 export type { Props, ImageProps, FallbackProps };

--- a/src/lib/bits/avatar/components/avatar-fallback.svelte
+++ b/src/lib/bits/avatar/components/avatar-fallback.svelte
@@ -6,6 +6,7 @@
 	type $$Props = FallbackProps;
 
 	export let asChild: $$Props["asChild"] = false;
+	export let el: $$Props["el"] = undefined;
 
 	const {
 		elements: { fallback }
@@ -19,7 +20,7 @@
 {#if asChild}
 	<slot {builder} />
 {:else}
-	<span use:melt={builder} {...$$restProps}>
+	<span bind:this={el} use:melt={builder} {...$$restProps}>
 		<slot {builder} />
 	</span>
 {/if}

--- a/src/lib/bits/avatar/components/avatar-image.svelte
+++ b/src/lib/bits/avatar/components/avatar-image.svelte
@@ -8,6 +8,7 @@
 	export let src: $$Props["src"] = undefined;
 	export let alt: $$Props["alt"] = undefined;
 	export let asChild: $$Props["asChild"] = false;
+	export let el: $$Props["el"] = undefined;
 
 	const attrs = getAttrs("image");
 
@@ -20,5 +21,5 @@
 {#if asChild}
 	<slot {builder} />
 {:else}
-	<img use:melt={builder} {alt} {...$$restProps} />
+	<img bind:this={el} use:melt={builder} {alt} {...$$restProps} />
 {/if}

--- a/src/lib/bits/avatar/components/avatar.svelte
+++ b/src/lib/bits/avatar/components/avatar.svelte
@@ -8,6 +8,7 @@
 	export let onLoadingStatusChange: $$Props["onLoadingStatusChange"] =
 		undefined;
 	export let asChild: $$Props["asChild"] = false;
+	export let el: $$Props["el"] = undefined;
 
 	const {
 		states: { loadingStatus: localLoadingStatus },
@@ -30,7 +31,7 @@
 {#if asChild}
 	<slot {attrs} />
 {:else}
-	<div {...$$restProps} {...attrs}>
+	<div bind:this={el} {...$$restProps} {...attrs}>
 		<slot {attrs} />
 	</div>
 {/if}

--- a/src/lib/bits/avatar/types.ts
+++ b/src/lib/bits/avatar/types.ts
@@ -1,11 +1,11 @@
-import type { DOMEl, HTMLDivAttributes, HTMLSpanAttributes } from "$lib/internal/index.js";
+import type { HTMLDivAttributes, HTMLSpanAttributes } from "$lib/internal/index.js";
 import type { HTMLImgAttributes } from "svelte/elements";
 import type * as I from "./_types.js";
 
-type Props = I.Props & HTMLDivAttributes & DOMEl;
+type Props = I.Props & HTMLDivAttributes;
 
-type ImageProps = I.ImageProps & HTMLImgAttributes & DOMEl<HTMLImageElement>;
+type ImageProps = I.ImageProps & HTMLImgAttributes;
 
-type FallbackProps = I.FallbackProps & HTMLSpanAttributes & DOMEl<HTMLSpanElement>;
+type FallbackProps = I.FallbackProps & HTMLSpanAttributes;
 
 export type { Props, ImageProps, FallbackProps };

--- a/src/lib/bits/avatar/types.ts
+++ b/src/lib/bits/avatar/types.ts
@@ -1,11 +1,11 @@
-import type { HTMLDivAttributes, HTMLSpanAttributes } from "$lib/internal/index.js";
+import type { DOMEl, HTMLDivAttributes, HTMLSpanAttributes } from "$lib/internal/index.js";
 import type { HTMLImgAttributes } from "svelte/elements";
 import type * as I from "./_types.js";
 
-type Props = I.Props & HTMLDivAttributes;
+type Props = I.Props & HTMLDivAttributes & DOMEl<HTMLDivElement>;
 
-type ImageProps = I.ImageProps & HTMLImgAttributes;
+type ImageProps = I.ImageProps & HTMLImgAttributes & DOMEl<HTMLImageElement>;
 
-type FallbackProps = I.FallbackProps & HTMLSpanAttributes;
+type FallbackProps = I.FallbackProps & HTMLSpanAttributes & DOMEl<HTMLSpanElement>;
 
 export type { Props, ImageProps, FallbackProps };

--- a/src/lib/bits/avatar/types.ts
+++ b/src/lib/bits/avatar/types.ts
@@ -2,7 +2,7 @@ import type { DOMEl, HTMLDivAttributes, HTMLSpanAttributes } from "$lib/internal
 import type { HTMLImgAttributes } from "svelte/elements";
 import type * as I from "./_types.js";
 
-type Props = I.Props & HTMLDivAttributes & DOMEl<HTMLDivElement>;
+type Props = I.Props & HTMLDivAttributes & DOMEl;
 
 type ImageProps = I.ImageProps & HTMLImgAttributes & DOMEl<HTMLImageElement>;
 

--- a/src/lib/bits/button/components/button.svelte
+++ b/src/lib/bits/button/components/button.svelte
@@ -7,6 +7,7 @@
 	export let href: $$Props["href"] = undefined;
 	export let type: $$Props["type"] = undefined;
 	export let builders: $$Props["builders"] = [];
+	export let el: $$Props["el"] = undefined;
 	const attrs = {
 		"data-button-root": ""
 	};
@@ -15,6 +16,7 @@
 {#if builders && builders.length}
 	<!-- svelte-ignore a11y-no-static-element-interactions -->
 	<svelte:element
+		bind:this={el}
 		this={href ? "a" : "button"}
 		type={href ? undefined : type}
 		{href}

--- a/src/lib/bits/button/components/button.svelte
+++ b/src/lib/bits/button/components/button.svelte
@@ -16,8 +16,8 @@
 {#if builders && builders.length}
 	<!-- svelte-ignore a11y-no-static-element-interactions -->
 	<svelte:element
-		bind:this={el}
 		this={href ? "a" : "button"}
+		bind:this={el}
 		type={href ? undefined : type}
 		{href}
 		on:click

--- a/src/lib/bits/button/types.ts
+++ b/src/lib/bits/button/types.ts
@@ -1,17 +1,18 @@
 import type { HTMLAnchorAttributes, HTMLButtonAttributes } from "svelte/elements";
 import type * as I from "./_types.js";
+import type { DOMEl } from "$lib/internal/types.js";
 
 type AnchorElement = I.Props &
 	HTMLAnchorAttributes & {
 		href?: HTMLAnchorAttributes["href"];
 		type?: never;
-	};
+	} & DOMEl<HTMLAnchorElement>;
 
 type ButtonElement = I.Props &
 	HTMLButtonAttributes & {
 		type?: HTMLButtonAttributes["type"];
 		href?: never;
-	};
+	} & DOMEl<HTMLButtonElement>;
 
 type Props = AnchorElement | ButtonElement;
 

--- a/src/lib/bits/calendar/_types.ts
+++ b/src/lib/bits/calendar/_types.ts
@@ -4,7 +4,7 @@
  * but we don't want to document the HTML attributes.
  */
 
-import type { AsChild, OnChangeFn } from "$lib/internal";
+import type { DOMElement, OnChangeFn } from "$lib/internal/index.js";
 import type { DateValue } from "@internationalized/date";
 import type { CreateCalendarProps } from "@melt-ui/svelte";
 
@@ -58,44 +58,42 @@ type Props<Multiple extends boolean = false> = Expand<
 		 * @default false
 		 */
 		initialFocus?: boolean;
-	} & AsChild
+	} & DOMElement
 >;
 
-type PrevButtonProps = AsChild;
+type PrevButtonProps = DOMElement<HTMLButtonElement>;
 
-type NextButtonProps = AsChild;
+type NextButtonProps = DOMElement<HTMLButtonElement>;
 
-type HeadingProps = AsChild;
+type HeadingProps = DOMElement;
 
-type HeaderProps = AsChild;
+type HeaderProps = DOMElement<HTMLElement>;
 
-type GridHeadProps = AsChild;
+type GridHeadProps = DOMElement<HTMLTableSectionElement>;
 
-type HeadCellProps = AsChild;
+type HeadCellProps = DOMElement<HTMLTableCellElement>;
 
-type GridProps = AsChild;
+type GridProps = DOMElement<HTMLTableElement>;
 
-type GridBodyProps = AsChild;
+type GridBodyProps = DOMElement<HTMLTableSectionElement>;
 
-type GridRowProps = AsChild;
+type GridRowProps = DOMElement<HTMLTableRowElement>;
 
-type BaseDayProps = Expand<
-	{
-		/**
-		 * The date value of the cell.
-		 */
-		date: DateValue;
+type BaseDayProps = Expand<{
+	/**
+	 * The date value of the cell.
+	 */
+	date: DateValue;
 
-		/**
-		 * The month value that the cell belongs to.
-		 */
-		month: DateValue;
-	} & AsChild
->;
+	/**
+	 * The month value that the cell belongs to.
+	 */
+	month: DateValue;
+}>;
 
-type CellProps = Expand<Omit<BaseDayProps, "month">>;
+type CellProps = Expand<Omit<BaseDayProps, "month">> & DOMElement<HTMLTableCellElement>;
 
-type DayProps = Expand<BaseDayProps>;
+type DayProps = Expand<BaseDayProps & DOMElement>;
 
 export type {
 	Props,

--- a/src/lib/bits/calendar/components/calendar-cell.svelte
+++ b/src/lib/bits/calendar/components/calendar-cell.svelte
@@ -6,6 +6,7 @@
 
 	export let date: $$Props["date"];
 	export let asChild: $$Props["asChild"] = false;
+	export let el: $$Props["el"] = undefined;
 
 	const {
 		helpers: { isDateDisabled, isDateUnavailable }
@@ -22,7 +23,7 @@
 {#if asChild}
 	<slot {attrs} />
 {:else}
-	<td {...$$restProps} {...attrs}>
+	<td bind:this={el} {...$$restProps} {...attrs}>
 		<slot {attrs} />
 	</td>
 {/if}

--- a/src/lib/bits/calendar/components/calendar-day.svelte
+++ b/src/lib/bits/calendar/components/calendar-day.svelte
@@ -10,6 +10,7 @@
 	export let date: $$Props["date"];
 	export let month: $$Props["month"];
 	export let asChild: $$Props["asChild"] = false;
+	export let el: $$Props["el"] = undefined;
 
 	const {
 		elements: { cell },
@@ -29,7 +30,7 @@
 {#if asChild}
 	<slot {builder} {disabled} {unavailable} {selected} />
 {:else}
-	<div use:melt={builder} {...$$restProps} on:m-click={dispatch}>
+	<div bind:this={el} use:melt={builder} {...$$restProps} on:m-click={dispatch}>
 		<slot {builder} {disabled} {unavailable} {selected}>
 			{date.day}
 		</slot>

--- a/src/lib/bits/calendar/components/calendar-grid-body.svelte
+++ b/src/lib/bits/calendar/components/calendar-grid-body.svelte
@@ -4,6 +4,7 @@
 
 	type $$Props = GridBodyProps;
 	export let asChild: $$Props["asChild"] = false;
+	export let el: $$Props["el"] = undefined;
 
 	const attrs = getAttrs("grid-body");
 </script>
@@ -11,7 +12,7 @@
 {#if asChild}
 	<slot {attrs} />
 {:else}
-	<tbody {...$$restProps} {...attrs}>
+	<tbody bind:this={el} {...$$restProps} {...attrs}>
 		<slot {attrs} />
 	</tbody>
 {/if}

--- a/src/lib/bits/calendar/components/calendar-grid-head.svelte
+++ b/src/lib/bits/calendar/components/calendar-grid-head.svelte
@@ -4,6 +4,7 @@
 
 	type $$Props = GridHeadProps;
 	export let asChild: $$Props["asChild"] = false;
+	export let el: $$Props["el"] = undefined;
 
 	const attrs = { ...getAttrs("grid-head"), "aria-hidden": true };
 </script>
@@ -11,7 +12,7 @@
 {#if asChild}
 	<slot {attrs} />
 {:else}
-	<thead {...$$restProps} {...attrs}>
+	<thead bind:this={el} {...$$restProps} {...attrs}>
 		<slot {attrs} />
 	</thead>
 {/if}

--- a/src/lib/bits/calendar/components/calendar-grid-row.svelte
+++ b/src/lib/bits/calendar/components/calendar-grid-row.svelte
@@ -5,6 +5,7 @@
 	type $$Props = GridRowProps;
 
 	export let asChild: $$Props["asChild"] = false;
+	export let el: $$Props["el"] = undefined;
 
 	const attrs = getAttrs("grid-row");
 </script>
@@ -12,7 +13,7 @@
 {#if asChild}
 	<slot {attrs} />
 {:else}
-	<tr {...$$restProps} {...attrs}>
+	<tr bind:this={el} {...$$restProps} {...attrs}>
 		<slot {attrs} />
 	</tr>
 {/if}

--- a/src/lib/bits/calendar/components/calendar-grid.svelte
+++ b/src/lib/bits/calendar/components/calendar-grid.svelte
@@ -6,6 +6,7 @@
 	type $$Props = GridProps;
 
 	export let asChild: $$Props["asChild"] = false;
+	export let el: $$Props["el"] = undefined;
 
 	const {
 		elements: { grid }
@@ -20,7 +21,7 @@
 {#if asChild}
 	<slot {builder} />
 {:else}
-	<table use:melt={builder} {...$$restProps}>
+	<table bind:this={el} use:melt={builder} {...$$restProps}>
 		<slot {builder} />
 	</table>
 {/if}

--- a/src/lib/bits/calendar/components/calendar-head-cell.svelte
+++ b/src/lib/bits/calendar/components/calendar-head-cell.svelte
@@ -4,6 +4,7 @@
 
 	type $$Props = HeadCellProps;
 	export let asChild: $$Props["asChild"] = false;
+	export let el: $$Props["el"] = undefined;
 
 	const attrs = getAttrs("head-cell");
 </script>
@@ -11,7 +12,7 @@
 {#if asChild}
 	<slot {attrs} />
 {:else}
-	<th {...$$restProps} {...attrs}>
+	<th bind:this={el} {...$$restProps} {...attrs}>
 		<slot {attrs} />
 	</th>
 {/if}

--- a/src/lib/bits/calendar/components/calendar-header.svelte
+++ b/src/lib/bits/calendar/components/calendar-header.svelte
@@ -1,8 +1,10 @@
 <script lang="ts">
 	import { getAttrs } from "../ctx.js";
 	import type { HeaderProps } from "../types.js";
+
 	type $$Props = HeaderProps;
 	export let asChild: $$Props["asChild"] = false;
+	export let el: $$Props["el"] = undefined;
 
 	const attrs = getAttrs("header");
 </script>
@@ -10,7 +12,7 @@
 {#if asChild}
 	<slot {attrs} />
 {:else}
-	<header {...$$restProps} {...attrs}>
+	<header bind:this={el} {...$$restProps} {...attrs}>
 		<slot {attrs} />
 	</header>
 {/if}

--- a/src/lib/bits/calendar/components/calendar-heading.svelte
+++ b/src/lib/bits/calendar/components/calendar-heading.svelte
@@ -6,6 +6,7 @@
 	type $$Props = HeadingProps;
 
 	export let asChild: $$Props["asChild"] = false;
+	export let el: $$Props["el"] = undefined;
 
 	const {
 		elements: { heading },
@@ -21,7 +22,7 @@
 {#if asChild}
 	<slot {builder} headingValue={$headingValue} />
 {:else}
-	<div use:melt={builder} {...$$restProps}>
+	<div bind:this={el} use:melt={builder} {...$$restProps}>
 		<slot {builder} headingValue={$headingValue}>
 			{$headingValue}
 		</slot>

--- a/src/lib/bits/calendar/components/calendar-next-button.svelte
+++ b/src/lib/bits/calendar/components/calendar-next-button.svelte
@@ -8,6 +8,7 @@
 	type $$Events = NextButtonEvents;
 
 	export let asChild: $$Props["asChild"] = false;
+	export let el: $$Props["el"] = undefined;
 
 	const {
 		elements: { nextButton }
@@ -25,6 +26,7 @@
 	<slot {builder} />
 {:else}
 	<button
+		bind:this={el}
 		use:melt={builder}
 		type="button"
 		{...$$restProps}

--- a/src/lib/bits/calendar/components/calendar-prev-button.svelte
+++ b/src/lib/bits/calendar/components/calendar-prev-button.svelte
@@ -8,6 +8,7 @@
 	type $$Events = PrevButtonEvents;
 
 	export let asChild: $$Props["asChild"] = false;
+	export let el: $$Props["el"] = undefined;
 
 	const {
 		elements: { prevButton }
@@ -25,6 +26,7 @@
 	<slot {builder} />
 {:else}
 	<button
+		bind:this={el}
 		use:melt={builder}
 		type="button"
 		{...$$restProps}

--- a/src/lib/bits/calendar/components/calendar.svelte
+++ b/src/lib/bits/calendar/components/calendar.svelte
@@ -33,8 +33,7 @@
 	export let id: $$Props["id"] = undefined;
 	export let numberOfMonths: $$Props["numberOfMonths"] = undefined;
 	export let initialFocus: $$Props["initialFocus"] = false;
-
-	let el: HTMLElement | undefined = undefined;
+	export let el: $$Props["el"] = undefined;
 
 	onMount(() => {
 		if (!initialFocus || !el) return;

--- a/src/lib/bits/calendar/types.ts
+++ b/src/lib/bits/calendar/types.ts
@@ -1,4 +1,4 @@
-import type { DOMEl, HTMLDivAttributes } from "$lib/internal";
+import type { HTMLDivAttributes } from "$lib/internal/index.js";
 import type {
 	HTMLAttributes,
 	HTMLButtonAttributes,
@@ -7,39 +7,32 @@ import type {
 	HTMLThAttributes
 } from "svelte/elements";
 import type * as I from "./_types.js";
-import type { CustomEventHandler } from "$lib";
+import type { CustomEventHandler } from "$lib/index.js";
 
 type Props<Multiple extends boolean = false> = I.Props<Multiple> &
-	Omit<HTMLDivAttributes, "placeholder"> &
-	DOMEl;
+	Omit<HTMLDivAttributes, "placeholder">;
 
-type PrevButtonProps = I.PrevButtonProps & HTMLButtonAttributes & DOMEl<HTMLButtonElement>;
+type PrevButtonProps = I.PrevButtonProps & HTMLButtonAttributes;
 
-type NextButtonProps = I.NextButtonProps & HTMLButtonAttributes & DOMEl<HTMLButtonElement>;
+type NextButtonProps = I.NextButtonProps & HTMLButtonAttributes;
 
-type HeadingProps = I.HeadingProps & HTMLDivAttributes & DOMEl;
+type HeadingProps = I.HeadingProps & HTMLDivAttributes;
 
-type HeaderProps = I.HeaderProps & HTMLDivAttributes & DOMEl<Element>;
+type HeaderProps = I.HeaderProps & HTMLDivAttributes;
 
-type GridProps = I.GridProps & HTMLTableAttributes & DOMEl<HTMLTableElement>;
+type GridProps = I.GridProps & HTMLTableAttributes;
 
-type GridHeadProps = I.GridHeadProps &
-	HTMLAttributes<HTMLTableSectionElement> &
-	DOMEl<HTMLTableSectionElement>;
+type GridHeadProps = I.GridHeadProps & HTMLAttributes<HTMLTableSectionElement>;
 
-type HeadCellProps = I.HeadCellProps & HTMLThAttributes & DOMEl<HTMLTableCellElement>;
+type HeadCellProps = I.HeadCellProps & HTMLThAttributes;
 
-type GridBodyProps = I.GridBodyProps &
-	HTMLAttributes<HTMLTableSectionElement> &
-	DOMEl<HTMLTableSectionElement>;
+type GridBodyProps = I.GridBodyProps & HTMLAttributes<HTMLTableSectionElement>;
 
-type GridRowProps = I.GridRowProps &
-	HTMLAttributes<HTMLTableRowElement> &
-	DOMEl<HTMLTableRowElement>;
+type GridRowProps = I.GridRowProps & HTMLAttributes<HTMLTableRowElement>;
 
-type CellProps = I.CellProps & HTMLTdAttributes & DOMEl<HTMLTableCellElement>;
+type CellProps = I.CellProps & HTMLTdAttributes;
 
-type DayProps = I.DayProps & HTMLDivAttributes & DOMEl;
+type DayProps = I.DayProps & HTMLDivAttributes;
 
 /**
  * Events

--- a/src/lib/bits/calendar/types.ts
+++ b/src/lib/bits/calendar/types.ts
@@ -1,4 +1,4 @@
-import type { HTMLDivAttributes } from "$lib/internal";
+import type { DOMEl, HTMLDivAttributes } from "$lib/internal";
 import type {
 	HTMLAttributes,
 	HTMLButtonAttributes,
@@ -10,29 +10,36 @@ import type * as I from "./_types.js";
 import type { CustomEventHandler } from "$lib";
 
 type Props<Multiple extends boolean = false> = I.Props<Multiple> &
-	Omit<HTMLDivAttributes, "placeholder">;
+	Omit<HTMLDivAttributes, "placeholder"> &
+	DOMEl<HTMLDivElement>;
 
-type PrevButtonProps = I.PrevButtonProps & HTMLButtonAttributes;
+type PrevButtonProps = I.PrevButtonProps & HTMLButtonAttributes & DOMEl<HTMLButtonElement>;
 
-type NextButtonProps = I.NextButtonProps & HTMLButtonAttributes;
+type NextButtonProps = I.NextButtonProps & HTMLButtonAttributes & DOMEl<HTMLButtonElement>;
 
-type HeadingProps = I.HeadingProps & HTMLDivAttributes;
+type HeadingProps = I.HeadingProps & HTMLDivAttributes & DOMEl<HTMLDivElement>;
 
-type HeaderProps = I.HeaderProps & HTMLDivAttributes;
+type HeaderProps = I.HeaderProps & HTMLDivAttributes & DOMEl;
 
-type GridProps = I.GridProps & HTMLTableAttributes;
+type GridProps = I.GridProps & HTMLTableAttributes & DOMEl<HTMLTableElement>;
 
-type GridHeadProps = I.GridHeadProps & HTMLAttributes<HTMLTableSectionElement>;
+type GridHeadProps = I.GridHeadProps &
+	HTMLAttributes<HTMLTableSectionElement> &
+	DOMEl<HTMLTableSectionElement>;
 
-type HeadCellProps = I.HeadCellProps & HTMLThAttributes;
+type HeadCellProps = I.HeadCellProps & HTMLThAttributes & DOMEl<HTMLTableCellElement>;
 
-type GridBodyProps = I.GridBodyProps & HTMLAttributes<HTMLTableSectionElement>;
+type GridBodyProps = I.GridBodyProps &
+	HTMLAttributes<HTMLTableSectionElement> &
+	DOMEl<HTMLTableSectionElement>;
 
-type GridRowProps = I.GridRowProps & HTMLAttributes<HTMLTableRowElement>;
+type GridRowProps = I.GridRowProps &
+	HTMLAttributes<HTMLTableRowElement> &
+	DOMEl<HTMLTableRowElement>;
 
-type CellProps = I.CellProps & HTMLTdAttributes;
+type CellProps = I.CellProps & HTMLTdAttributes & DOMEl<HTMLTableCellElement>;
 
-type DayProps = I.DayProps & HTMLDivAttributes;
+type DayProps = I.DayProps & HTMLDivAttributes & DOMEl<HTMLDivElement>;
 
 /**
  * Events

--- a/src/lib/bits/calendar/types.ts
+++ b/src/lib/bits/calendar/types.ts
@@ -11,15 +11,15 @@ import type { CustomEventHandler } from "$lib";
 
 type Props<Multiple extends boolean = false> = I.Props<Multiple> &
 	Omit<HTMLDivAttributes, "placeholder"> &
-	DOMEl<HTMLDivElement>;
+	DOMEl;
 
 type PrevButtonProps = I.PrevButtonProps & HTMLButtonAttributes & DOMEl<HTMLButtonElement>;
 
 type NextButtonProps = I.NextButtonProps & HTMLButtonAttributes & DOMEl<HTMLButtonElement>;
 
-type HeadingProps = I.HeadingProps & HTMLDivAttributes & DOMEl<HTMLDivElement>;
+type HeadingProps = I.HeadingProps & HTMLDivAttributes & DOMEl;
 
-type HeaderProps = I.HeaderProps & HTMLDivAttributes & DOMEl;
+type HeaderProps = I.HeaderProps & HTMLDivAttributes & DOMEl<Element>;
 
 type GridProps = I.GridProps & HTMLTableAttributes & DOMEl<HTMLTableElement>;
 
@@ -39,7 +39,7 @@ type GridRowProps = I.GridRowProps &
 
 type CellProps = I.CellProps & HTMLTdAttributes & DOMEl<HTMLTableCellElement>;
 
-type DayProps = I.DayProps & HTMLDivAttributes & DOMEl<HTMLDivElement>;
+type DayProps = I.DayProps & HTMLDivAttributes & DOMEl;
 
 /**
  * Events

--- a/src/lib/bits/checkbox/_types.ts
+++ b/src/lib/bits/checkbox/_types.ts
@@ -4,7 +4,7 @@
  * but we don't want to document the HTML attributes.
  */
 
-import type { Expand, OmitChecked, OnChangeFn, AsChild } from "$lib/internal/index.js";
+import type { Expand, OmitChecked, OnChangeFn, DOMElement } from "$lib/internal/index.js";
 import type { CreateCheckboxProps } from "@melt-ui/svelte";
 
 type Props = Expand<
@@ -21,10 +21,10 @@ type Props = Expand<
 		 * A callback function called when the checked state changes.
 		 */
 		onCheckedChange?: OnChangeFn<boolean | "indeterminate">;
-	} & AsChild
+	} & DOMElement<HTMLButtonElement>
 >;
 
-type IndicatorProps = AsChild;
+type IndicatorProps = DOMElement;
 
 export type {
 	Props,

--- a/src/lib/bits/checkbox/components/checkbox-indicator.svelte
+++ b/src/lib/bits/checkbox/components/checkbox-indicator.svelte
@@ -5,6 +5,7 @@
 	type $$Props = IndicatorProps;
 
 	export let asChild: $$Props["asChild"] = false;
+	export let el: $$Props["el"] = undefined;
 
 	const {
 		helpers: { isChecked, isIndeterminate },
@@ -26,7 +27,7 @@
 {#if asChild}
 	<slot {attrs} isChecked={$isChecked} isIndeterminate={$isIndeterminate} />
 {:else}
-	<div {...$$restProps} {...attrs}>
+	<div bind:this={el} {...$$restProps} {...attrs}>
 		<slot {attrs} isChecked={$isChecked} isIndeterminate={$isIndeterminate} />
 	</div>
 {/if}

--- a/src/lib/bits/checkbox/components/checkbox-input.svelte
+++ b/src/lib/bits/checkbox/components/checkbox-input.svelte
@@ -1,6 +1,10 @@
 <script lang="ts">
 	import { melt } from "@melt-ui/svelte";
 	import { getCtx } from "../ctx.js";
+	import type { InputProps } from "../types.js";
+
+	type $$Props = InputProps;
+	export let el: $$Props["el"] = undefined;
 
 	const {
 		elements: { input },
@@ -8,4 +12,9 @@
 	} = getCtx();
 </script>
 
-<input use:melt={$input} value={$value ?? "on"} {...$$restProps} />
+<input
+	bind:this={el}
+	use:melt={$input}
+	value={$value ?? "on"}
+	{...$$restProps}
+/>

--- a/src/lib/bits/checkbox/components/checkbox.svelte
+++ b/src/lib/bits/checkbox/components/checkbox.svelte
@@ -13,6 +13,7 @@
 	export let value: $$Props["value"] = undefined;
 	export let onCheckedChange: $$Props["onCheckedChange"] = undefined;
 	export let asChild: $$Props["asChild"] = false;
+	export let el: $$Props["el"] = undefined;
 
 	const {
 		elements: { root },
@@ -51,6 +52,7 @@
 	<slot {builder} />
 {:else}
 	<button
+		bind:this={el}
 		use:melt={builder}
 		type="button"
 		{...$$restProps}

--- a/src/lib/bits/checkbox/types.ts
+++ b/src/lib/bits/checkbox/types.ts
@@ -3,9 +3,9 @@ import type { CustomEventHandler } from "$lib/index.js";
 import type { HTMLButtonAttributes, HTMLInputAttributes } from "svelte/elements";
 import type * as I from "./_types.js";
 
-type Props = I.Props & HTMLButtonAttributes & DOMEl<HTMLButtonElement>;
+type Props = I.Props & HTMLButtonAttributes;
 
-type IndicatorProps = I.IndicatorProps & HTMLDivAttributes & DOMEl;
+type IndicatorProps = I.IndicatorProps & HTMLDivAttributes;
 
 type InputProps = Omit<HTMLInputAttributes, "value"> & DOMEl<HTMLInputElement>;
 

--- a/src/lib/bits/checkbox/types.ts
+++ b/src/lib/bits/checkbox/types.ts
@@ -5,7 +5,7 @@ import type * as I from "./_types.js";
 
 type Props = I.Props & HTMLButtonAttributes & DOMEl<HTMLButtonElement>;
 
-type IndicatorProps = I.IndicatorProps & HTMLDivAttributes & DOMEl<HTMLDivElement>;
+type IndicatorProps = I.IndicatorProps & HTMLDivAttributes & DOMEl;
 
 type InputProps = Omit<HTMLInputAttributes, "value"> & DOMEl<HTMLInputElement>;
 

--- a/src/lib/bits/checkbox/types.ts
+++ b/src/lib/bits/checkbox/types.ts
@@ -1,13 +1,13 @@
-import type { HTMLDivAttributes } from "$lib/internal/index.js";
+import type { DOMEl, HTMLDivAttributes } from "$lib/internal/index.js";
 import type { CustomEventHandler } from "$lib/index.js";
 import type { HTMLButtonAttributes, HTMLInputAttributes } from "svelte/elements";
 import type * as I from "./_types.js";
 
-type Props = I.Props & HTMLButtonAttributes;
+type Props = I.Props & HTMLButtonAttributes & DOMEl<HTMLButtonElement>;
 
-type IndicatorProps = I.IndicatorProps & HTMLDivAttributes;
+type IndicatorProps = I.IndicatorProps & HTMLDivAttributes & DOMEl<HTMLDivElement>;
 
-type InputProps = Omit<HTMLInputAttributes, "value">;
+type InputProps = Omit<HTMLInputAttributes, "value"> & DOMEl<HTMLInputElement>;
 
 type Events = {
 	click: CustomEventHandler<MouseEvent, HTMLButtonElement>;

--- a/src/lib/bits/collapsible/_types.ts
+++ b/src/lib/bits/collapsible/_types.ts
@@ -10,8 +10,8 @@ import type {
 	OmitForceVisible,
 	Expand,
 	OnChangeFn,
-	AsChild,
-	TransitionProps
+	TransitionProps,
+	DOMElement
 } from "$lib/internal/index.js";
 import type { CreateCollapsibleProps } from "@melt-ui/svelte";
 
@@ -29,15 +29,15 @@ type Props = Expand<
 		 * A callback function called when the open state changes.
 		 */
 		onOpenChange?: OnChangeFn<boolean>;
-	} & AsChild
+	} & DOMElement
 >;
 
 type ContentProps<
 	T extends Transition = Transition,
 	In extends Transition = Transition,
 	Out extends Transition = Transition
-> = Expand<TransitionProps<T, In, Out> & AsChild>;
+> = Expand<TransitionProps<T, In, Out> & DOMElement>;
 
-type TriggerProps = AsChild;
+type TriggerProps = DOMElement<HTMLButtonElement>;
 
 export type { Props, ContentProps, TriggerProps };

--- a/src/lib/bits/collapsible/components/collapsible-content.svelte
+++ b/src/lib/bits/collapsible/components/collapsible-content.svelte
@@ -16,6 +16,7 @@
 	export let outTransition: $$Props["outTransition"] = undefined;
 	export let outTransitionConfig: $$Props["outTransitionConfig"] = undefined;
 	export let asChild: $$Props["asChild"] = false;
+	export let el: $$Props["el"] = undefined;
 
 	const {
 		elements: { content },
@@ -32,6 +33,7 @@
 	<slot {builder} />
 {:else if transition && $open}
 	<div
+		bind:this={el}
 		transition:transition={transitionConfig}
 		use:melt={builder}
 		{...$$restProps}
@@ -40,6 +42,7 @@
 	</div>
 {:else if inTransition && outTransition && $open}
 	<div
+		bind:this={el}
 		in:inTransition={inTransitionConfig}
 		out:outTransition={outTransitionConfig}
 		use:melt={builder}
@@ -48,11 +51,17 @@
 		<slot {builder} />
 	</div>
 {:else if inTransition && $open}
-	<div in:inTransition={inTransitionConfig} use:melt={builder} {...$$restProps}>
+	<div
+		bind:this={el}
+		in:inTransition={inTransitionConfig}
+		use:melt={builder}
+		{...$$restProps}
+	>
 		<slot {builder} />
 	</div>
 {:else if outTransition && $open}
 	<div
+		bind:this={el}
 		out:outTransition={outTransitionConfig}
 		use:melt={builder}
 		{...$$restProps}
@@ -60,7 +69,7 @@
 		<slot {builder} />
 	</div>
 {:else if $open}
-	<div use:melt={builder} {...$$restProps}>
+	<div bind:this={el} use:melt={builder} {...$$restProps}>
 		<slot {builder} />
 	</div>
 {/if}

--- a/src/lib/bits/collapsible/components/collapsible-trigger.svelte
+++ b/src/lib/bits/collapsible/components/collapsible-trigger.svelte
@@ -8,6 +8,7 @@
 	type $$Events = TriggerEvents;
 
 	export let asChild: $$Props["asChild"] = false;
+	export let el: $$Props["el"] = undefined;
 
 	const {
 		elements: { trigger }
@@ -24,6 +25,7 @@
 	<slot {builder} />
 {:else}
 	<button
+		bind:this={el}
 		use:melt={builder}
 		type="button"
 		{...$$restProps}

--- a/src/lib/bits/collapsible/components/collapsible.svelte
+++ b/src/lib/bits/collapsible/components/collapsible.svelte
@@ -8,6 +8,7 @@
 	export let open: $$Props["open"] = undefined;
 	export let onOpenChange: $$Props["onOpenChange"] = undefined;
 	export let asChild: $$Props["asChild"] = false;
+	export let el: $$Props["el"] = undefined;
 
 	const {
 		elements: { root },
@@ -38,7 +39,7 @@
 {#if asChild}
 	<slot {builder} />
 {:else}
-	<div use:melt={builder} {...$$restProps}>
+	<div bind:this={el} use:melt={builder} {...$$restProps}>
 		<slot {builder} />
 	</div>
 {/if}

--- a/src/lib/bits/collapsible/types.ts
+++ b/src/lib/bits/collapsible/types.ts
@@ -1,17 +1,17 @@
-import type { DOMEl, HTMLDivAttributes, Transition } from "$lib/internal/index.js";
+import type { HTMLDivAttributes, Transition } from "$lib/internal/index.js";
 import type { CustomEventHandler } from "$lib/index.js";
 import type { HTMLButtonAttributes } from "svelte/elements";
 import type * as I from "./_types.js";
 
-type Props = I.Props & HTMLDivAttributes & DOMEl;
+type Props = I.Props & HTMLDivAttributes;
 
 type ContentProps<
 	T extends Transition = Transition,
 	In extends Transition = Transition,
 	Out extends Transition = Transition
-> = I.ContentProps<T, In, Out> & HTMLDivAttributes & DOMEl;
+> = I.ContentProps<T, In, Out> & HTMLDivAttributes;
 
-type TriggerProps = I.TriggerProps & HTMLButtonAttributes & DOMEl<HTMLButtonElement>;
+type TriggerProps = I.TriggerProps & HTMLButtonAttributes;
 
 type TriggerEvents = {
 	click: CustomEventHandler<MouseEvent, HTMLButtonElement>;

--- a/src/lib/bits/collapsible/types.ts
+++ b/src/lib/bits/collapsible/types.ts
@@ -3,13 +3,13 @@ import type { CustomEventHandler } from "$lib/index.js";
 import type { HTMLButtonAttributes } from "svelte/elements";
 import type * as I from "./_types.js";
 
-type Props = I.Props & HTMLDivAttributes & DOMEl<HTMLDivElement>;
+type Props = I.Props & HTMLDivAttributes & DOMEl;
 
 type ContentProps<
 	T extends Transition = Transition,
 	In extends Transition = Transition,
 	Out extends Transition = Transition
-> = I.ContentProps<T, In, Out> & HTMLDivAttributes & DOMEl<HTMLDivElement>;
+> = I.ContentProps<T, In, Out> & HTMLDivAttributes & DOMEl;
 
 type TriggerProps = I.TriggerProps & HTMLButtonAttributes & DOMEl<HTMLButtonElement>;
 

--- a/src/lib/bits/collapsible/types.ts
+++ b/src/lib/bits/collapsible/types.ts
@@ -1,17 +1,17 @@
-import type { HTMLDivAttributes, Transition } from "$lib/internal/index.js";
+import type { DOMEl, HTMLDivAttributes, Transition } from "$lib/internal/index.js";
 import type { CustomEventHandler } from "$lib/index.js";
 import type { HTMLButtonAttributes } from "svelte/elements";
 import type * as I from "./_types.js";
 
-type Props = I.Props & HTMLDivAttributes;
+type Props = I.Props & HTMLDivAttributes & DOMEl<HTMLDivElement>;
 
 type ContentProps<
 	T extends Transition = Transition,
 	In extends Transition = Transition,
 	Out extends Transition = Transition
-> = I.ContentProps<T, In, Out> & HTMLDivAttributes;
+> = I.ContentProps<T, In, Out> & HTMLDivAttributes & DOMEl<HTMLDivElement>;
 
-type TriggerProps = I.TriggerProps & HTMLButtonAttributes;
+type TriggerProps = I.TriggerProps & HTMLButtonAttributes & DOMEl<HTMLButtonElement>;
 
 type TriggerEvents = {
 	click: CustomEventHandler<MouseEvent, HTMLButtonElement>;

--- a/src/lib/bits/context-menu/_types.ts
+++ b/src/lib/bits/context-menu/_types.ts
@@ -1,4 +1,4 @@
-import type { AsChild, Transition, TransitionProps } from "$lib/internal/index.js";
+import type { DOMElement, Transition, TransitionProps } from "$lib/internal/index.js";
 import type { FloatingProps } from "$lib/bits/floating/_types.js";
 
 type ContextFloatingProps = Omit<FloatingProps, "sameWidth" | "side" | "sideOffset" | "align">;
@@ -7,4 +7,4 @@ export type ContentProps<
 	T extends Transition = Transition,
 	In extends Transition = Transition,
 	Out extends Transition = Transition
-> = Expand<ContextFloatingProps & TransitionProps<T, In, Out> & AsChild>;
+> = Expand<ContextFloatingProps & TransitionProps<T, In, Out> & DOMElement>;

--- a/src/lib/bits/context-menu/components/context-menu-content.svelte
+++ b/src/lib/bits/context-menu/components/context-menu-content.svelte
@@ -24,6 +24,7 @@
 	export let avoidCollisions: $$Props["avoidCollisions"] = true;
 	export let collisionBoundary: $$Props["collisionBoundary"] = undefined;
 	export let fitViewport: $$Props["fitViewport"] = false;
+	export let el: $$Props["el"] = undefined;
 
 	const {
 		elements: { menu },
@@ -53,6 +54,7 @@
 	<slot {builder} />
 {:else if transition && $open}
 	<div
+		bind:this={el}
 		transition:transition={transitionConfig}
 		use:melt={builder}
 		{...$$restProps}
@@ -62,6 +64,7 @@
 	</div>
 {:else if inTransition && outTransition && $open}
 	<div
+		bind:this={el}
 		in:inTransition={inTransitionConfig}
 		out:outTransition={outTransitionConfig}
 		use:melt={builder}
@@ -72,6 +75,7 @@
 	</div>
 {:else if inTransition && $open}
 	<div
+		bind:this={el}
 		in:inTransition={inTransitionConfig}
 		use:melt={builder}
 		{...$$restProps}
@@ -81,6 +85,7 @@
 	</div>
 {:else if outTransition && $open}
 	<div
+		bind:this={el}
 		out:outTransition={outTransitionConfig}
 		use:melt={builder}
 		{...$$restProps}
@@ -89,7 +94,12 @@
 		<slot {builder} />
 	</div>
 {:else if $open}
-	<div use:melt={builder} {...$$restProps} on:m-keydown={dispatch}>
+	<div
+		bind:this={el}
+		use:melt={builder}
+		{...$$restProps}
+		on:m-keydown={dispatch}
+	>
 		<slot {builder} />
 	</div>
 {/if}

--- a/src/lib/bits/context-menu/components/context-menu-trigger.svelte
+++ b/src/lib/bits/context-menu/components/context-menu-trigger.svelte
@@ -9,6 +9,7 @@
 
 	export let asChild: $$Props["asChild"] = false;
 	export let id: $$Props["id"] = undefined;
+	export let el: $$Props["el"] = undefined;
 
 	const {
 		elements: { trigger },
@@ -30,6 +31,7 @@
 	<slot {builder} />
 {:else}
 	<div
+		bind:this={el}
 		use:melt={builder}
 		{...$$restProps}
 		on:m-contextmenu={dispatch}

--- a/src/lib/bits/context-menu/types.ts
+++ b/src/lib/bits/context-menu/types.ts
@@ -23,14 +23,14 @@ import type {
 	ContextTriggerEvents as TriggerEvents,
 	SubContentEvents
 } from "$lib/bits/menu/index.js";
-import type { DOMEl, HTMLDivAttributes, Transition } from "$lib/internal";
+import type { HTMLDivAttributes, Transition } from "$lib/internal";
 import type * as I from "./_types.js";
 
 type ContentProps<
 	T extends Transition = Transition,
 	In extends Transition = Transition,
 	Out extends Transition = Transition
-> = I.ContentProps<T, In, Out> & HTMLDivAttributes & DOMEl;
+> = I.ContentProps<T, In, Out> & HTMLDivAttributes;
 
 export type {
 	Props,

--- a/src/lib/bits/context-menu/types.ts
+++ b/src/lib/bits/context-menu/types.ts
@@ -30,7 +30,7 @@ type ContentProps<
 	T extends Transition = Transition,
 	In extends Transition = Transition,
 	Out extends Transition = Transition
-> = I.ContentProps<T, In, Out> & HTMLDivAttributes & DOMEl<HTMLDivElement>;
+> = I.ContentProps<T, In, Out> & HTMLDivAttributes & DOMEl;
 
 export type {
 	Props,

--- a/src/lib/bits/context-menu/types.ts
+++ b/src/lib/bits/context-menu/types.ts
@@ -23,14 +23,14 @@ import type {
 	ContextTriggerEvents as TriggerEvents,
 	SubContentEvents
 } from "$lib/bits/menu/index.js";
-import type { HTMLDivAttributes, Transition } from "$lib/internal";
+import type { DOMEl, HTMLDivAttributes, Transition } from "$lib/internal";
 import type * as I from "./_types.js";
 
 type ContentProps<
 	T extends Transition = Transition,
 	In extends Transition = Transition,
 	Out extends Transition = Transition
-> = I.ContentProps<T, In, Out> & HTMLDivAttributes;
+> = I.ContentProps<T, In, Out> & HTMLDivAttributes & DOMEl<HTMLDivElement>;
 
 export type {
 	Props,

--- a/src/lib/bits/date-field/_types.ts
+++ b/src/lib/bits/date-field/_types.ts
@@ -4,7 +4,7 @@
  * but we don't want to document the HTML attributes.
  */
 
-import type { Expand, OnChangeFn, AsChild, OmitDates } from "$lib/internal/index.js";
+import type { Expand, OnChangeFn, OmitDates, DOMElement } from "$lib/internal/index.js";
 import type { SegmentPart } from "$lib/shared";
 import type { DateValue } from "@internationalized/date";
 import type { CreateDateFieldProps } from "@melt-ui/svelte";
@@ -46,16 +46,16 @@ type Props = Expand<
 	}
 >;
 
-type InputProps = AsChild;
+type InputProps = DOMElement;
 
-type DescriptionProps = AsChild;
+type DescriptionProps = DOMElement;
 
-type LabelProps = AsChild;
+type LabelProps = DOMElement<HTMLSpanElement>;
 
 type SegmentProps = Expand<
 	{
 		part: SegmentPart;
-	} & AsChild
+	} & DOMElement
 >;
 
 export type { Props, LabelProps, DescriptionProps, InputProps, SegmentProps };

--- a/src/lib/bits/date-field/components/date-field-input.svelte
+++ b/src/lib/bits/date-field/components/date-field-input.svelte
@@ -7,6 +7,7 @@
 
 	export let asChild: $$Props["asChild"] = false;
 	export let id: $$Props["id"] = undefined;
+	export let el: $$Props["el"] = undefined;
 
 	const {
 		elements: { field },
@@ -27,7 +28,7 @@
 {#if asChild}
 	<slot {builder} segments={$segmentContents} />
 {:else}
-	<div use:melt={builder} {...$$restProps}>
+	<div bind:this={el} use:melt={builder} {...$$restProps}>
 		<slot {builder} segments={$segmentContents} />
 	</div>
 {/if}

--- a/src/lib/bits/date-field/components/date-field-label.svelte
+++ b/src/lib/bits/date-field/components/date-field-label.svelte
@@ -7,6 +7,7 @@
 
 	export let asChild: $$Props["asChild"] = false;
 	export let id: $$Props["id"] = undefined;
+	export let el: $$Props["el"] = undefined;
 
 	const {
 		elements: { label },
@@ -26,7 +27,7 @@
 {#if asChild}
 	<slot {builder} />
 {:else}
-	<span use:melt={builder} {...$$restProps}>
+	<span bind:this={el} use:melt={builder} {...$$restProps}>
 		<slot {builder} />
 	</span>
 {/if}

--- a/src/lib/bits/date-field/components/date-field-segment.svelte
+++ b/src/lib/bits/date-field/components/date-field-segment.svelte
@@ -10,6 +10,7 @@
 	export let asChild: $$Props["asChild"] = false;
 	export let id: $$Props["id"] = undefined;
 	export let part: $$Props["part"];
+	export let el: $$Props["el"] = undefined;
 
 	const {
 		elements: { segment },
@@ -31,6 +32,7 @@
 	<slot {builder} />
 {:else}
 	<div
+		bind:this={el}
 		use:melt={builder}
 		{...$$restProps}
 		on:m-click={dispatch}

--- a/src/lib/bits/date-field/types.ts
+++ b/src/lib/bits/date-field/types.ts
@@ -1,16 +1,16 @@
 import type { CustomEventHandler } from "$lib";
-import type { HTMLDivAttributes, HTMLSpanAttributes } from "$lib/internal/index.js";
+import type { DOMEl, HTMLDivAttributes, HTMLSpanAttributes } from "$lib/internal/index.js";
 import type * as I from "./_types.js";
 
 type Props = I.Props;
 
-type LabelProps = I.LabelProps & HTMLSpanAttributes;
+type LabelProps = I.LabelProps & HTMLSpanAttributes & DOMEl<HTMLSpanElement>;
 
-type SegmentProps = I.SegmentProps & HTMLDivAttributes;
+type SegmentProps = I.SegmentProps & HTMLDivAttributes & DOMEl<HTMLDivElement>;
 
-type InputProps = I.InputProps & HTMLDivAttributes;
+type InputProps = I.InputProps & HTMLDivAttributes & DOMEl<HTMLDivElement>;
 
-type DescriptionProps = I.DescriptionProps & HTMLDivAttributes;
+type DescriptionProps = I.DescriptionProps & HTMLDivAttributes & DOMEl<HTMLDivElement>;
 
 type SegmentEvents = {
 	click: CustomEventHandler<MouseEvent, HTMLDivElement>;

--- a/src/lib/bits/date-field/types.ts
+++ b/src/lib/bits/date-field/types.ts
@@ -6,11 +6,11 @@ type Props = I.Props;
 
 type LabelProps = I.LabelProps & HTMLSpanAttributes & DOMEl<HTMLSpanElement>;
 
-type SegmentProps = I.SegmentProps & HTMLDivAttributes & DOMEl<HTMLDivElement>;
+type SegmentProps = I.SegmentProps & HTMLDivAttributes & DOMEl;
 
-type InputProps = I.InputProps & HTMLDivAttributes & DOMEl<HTMLDivElement>;
+type InputProps = I.InputProps & HTMLDivAttributes & DOMEl;
 
-type DescriptionProps = I.DescriptionProps & HTMLDivAttributes & DOMEl<HTMLDivElement>;
+type DescriptionProps = I.DescriptionProps & HTMLDivAttributes & DOMEl;
 
 type SegmentEvents = {
 	click: CustomEventHandler<MouseEvent, HTMLDivElement>;

--- a/src/lib/bits/date-field/types.ts
+++ b/src/lib/bits/date-field/types.ts
@@ -1,16 +1,16 @@
 import type { CustomEventHandler } from "$lib";
-import type { DOMEl, HTMLDivAttributes, HTMLSpanAttributes } from "$lib/internal/index.js";
+import type { HTMLDivAttributes, HTMLSpanAttributes } from "$lib/internal/index.js";
 import type * as I from "./_types.js";
 
 type Props = I.Props;
 
-type LabelProps = I.LabelProps & HTMLSpanAttributes & DOMEl<HTMLSpanElement>;
+type LabelProps = I.LabelProps & HTMLSpanAttributes;
 
-type SegmentProps = I.SegmentProps & HTMLDivAttributes & DOMEl;
+type SegmentProps = I.SegmentProps & HTMLDivAttributes;
 
-type InputProps = I.InputProps & HTMLDivAttributes & DOMEl;
+type InputProps = I.InputProps & HTMLDivAttributes;
 
-type DescriptionProps = I.DescriptionProps & HTMLDivAttributes & DOMEl;
+type DescriptionProps = I.DescriptionProps & HTMLDivAttributes;
 
 type SegmentEvents = {
 	click: CustomEventHandler<MouseEvent, HTMLDivElement>;

--- a/src/lib/bits/date-picker/_types.ts
+++ b/src/lib/bits/date-picker/_types.ts
@@ -4,7 +4,13 @@
  * but we don't want to document the HTML attributes.
  */
 
-import type { Expand, OnChangeFn, AsChild, OmitDates, OmitFloating } from "$lib/internal/index.js";
+import type {
+	Expand,
+	OnChangeFn,
+	OmitDates,
+	OmitFloating,
+	DOMElement
+} from "$lib/internal/index.js";
 import type { SegmentPart } from "$lib/shared";
 import type { DateValue } from "@internationalized/date";
 import type { CreateDatePickerProps } from "@melt-ui/svelte";
@@ -59,21 +65,21 @@ type Props = Expand<
 		 * This is used to apply the appropriate `aria-describedby` attribute to the input.
 		 */
 		descriptionId?: string;
-	} & AsChild
+	}
 >;
 
-type InputProps = AsChild;
+type InputProps = DOMElement;
 
-type DescriptionProps = AsChild;
+type DescriptionProps = DOMElement;
 
-type LabelProps = AsChild;
+type LabelProps = DOMElement<HTMLSpanElement>;
 
-type CalendarProps = AsChild;
+type CalendarProps = DOMElement;
 
 type SegmentProps = Expand<
 	{
 		part: SegmentPart;
-	} & AsChild
+	} & DOMElement
 >;
 
 export type { Props, CalendarProps, LabelProps, DescriptionProps, InputProps, SegmentProps };

--- a/src/lib/bits/date-picker/components/date-picker-arrow.svelte
+++ b/src/lib/bits/date-picker/components/date-picker-arrow.svelte
@@ -6,6 +6,7 @@
 	type $$Props = ArrowProps;
 
 	export let asChild: $$Props["asChild"] = false;
+	export let el: $$Props["el"] = undefined;
 	export let size = 8;
 
 	const {
@@ -24,5 +25,5 @@
 {#if asChild}
 	<slot {builder} />
 {:else}
-	<div use:melt={builder} {...$$restProps} />
+	<div bind:this={el} use:melt={builder} {...$$restProps} />
 {/if}

--- a/src/lib/bits/date-picker/components/date-picker-calendar.svelte
+++ b/src/lib/bits/date-picker/components/date-picker-calendar.svelte
@@ -10,6 +10,7 @@
 
 	export let asChild: $$Props["asChild"] = false;
 	export let id: $$Props["id"] = undefined;
+	export let el: $$Props["el"] = undefined;
 
 	const {
 		elements: { calendar },
@@ -33,7 +34,12 @@
 {#if asChild}
 	<slot {builder} {months} weekdays={$weekdays} />
 {:else}
-	<div use:melt={builder} {...$$restProps} on:m-keydown={dispatch}>
+	<div
+		bind:this={el}
+		use:melt={builder}
+		{...$$restProps}
+		on:m-keydown={dispatch}
+	>
 		<slot {builder} {months} weekdays={$weekdays} />
 	</div>
 {/if}

--- a/src/lib/bits/date-picker/components/date-picker-cell.svelte
+++ b/src/lib/bits/date-picker/components/date-picker-cell.svelte
@@ -6,6 +6,7 @@
 
 	export let date: $$Props["date"];
 	export let asChild: $$Props["asChild"] = false;
+	export let el: $$Props["el"] = undefined;
 
 	const {
 		helpers: { isDateDisabled, isDateUnavailable }
@@ -22,7 +23,7 @@
 {#if asChild}
 	<slot {attrs} />
 {:else}
-	<td {...$$restProps} {...attrs}>
+	<td bind:this={el} {...$$restProps} {...attrs}>
 		<slot {attrs} />
 	</td>
 {/if}

--- a/src/lib/bits/date-picker/components/date-picker-close.svelte
+++ b/src/lib/bits/date-picker/components/date-picker-close.svelte
@@ -8,6 +8,7 @@
 	type $$Events = CloseEvents;
 
 	export let asChild: $$Props["asChild"] = false;
+	export let el: $$Props["el"] = undefined;
 
 	const {
 		elements: { close }
@@ -24,6 +25,7 @@
 	<slot {builder} />
 {:else}
 	<button
+		bind:this={el}
 		use:melt={builder}
 		type="button"
 		{...$$restProps}

--- a/src/lib/bits/date-picker/components/date-picker-content.svelte
+++ b/src/lib/bits/date-picker/components/date-picker-content.svelte
@@ -29,6 +29,7 @@
 	export let fitViewport: $$Props["fitViewport"] = false;
 	export let strategy: $$Props["strategy"] = "absolute";
 	export let overlap: $$Props["overlap"] = false;
+	export let el: $$Props["el"] = undefined;
 
 	const {
 		elements: { content },
@@ -64,6 +65,7 @@
 	<slot {builder} />
 {:else if transition && $open}
 	<div
+		bind:this={el}
 		transition:transition={transitionConfig}
 		use:melt={builder}
 		{...$$restProps}
@@ -72,6 +74,7 @@
 	</div>
 {:else if inTransition && outTransition && $open}
 	<div
+		bind:this={el}
 		in:inTransition={inTransitionConfig}
 		out:outTransition={outTransitionConfig}
 		use:melt={builder}
@@ -80,11 +83,17 @@
 		<slot {builder} />
 	</div>
 {:else if inTransition && $open}
-	<div in:inTransition={inTransitionConfig} use:melt={builder} {...$$restProps}>
+	<div
+		bind:this={el}
+		in:inTransition={inTransitionConfig}
+		use:melt={builder}
+		{...$$restProps}
+	>
 		<slot {builder} />
 	</div>
 {:else if outTransition && $open}
 	<div
+		bind:this={el}
 		out:outTransition={outTransitionConfig}
 		use:melt={builder}
 		{...$$restProps}
@@ -92,7 +101,7 @@
 		<slot {builder} />
 	</div>
 {:else if $open}
-	<div use:melt={builder} {...$$restProps}>
+	<div bind:this={el} use:melt={builder} {...$$restProps}>
 		<slot {builder} />
 	</div>
 {/if}

--- a/src/lib/bits/date-picker/components/date-picker-day.svelte
+++ b/src/lib/bits/date-picker/components/date-picker-day.svelte
@@ -10,6 +10,7 @@
 	export let date: $$Props["date"];
 	export let month: $$Props["month"];
 	export let asChild: $$Props["asChild"] = false;
+	export let el: $$Props["el"] = undefined;
 
 	const {
 		elements: { cell },
@@ -30,7 +31,7 @@
 {#if asChild}
 	<slot {builder} {disabled} {unavailable} {selected} />
 {:else}
-	<div use:melt={builder} {...$$restProps} on:m-click={dispatch}>
+	<div bind:this={el} use:melt={builder} {...$$restProps} on:m-click={dispatch}>
 		<slot {builder} {disabled} {unavailable} {selected}>
 			{date.day}
 		</slot>

--- a/src/lib/bits/date-picker/components/date-picker-grid.svelte
+++ b/src/lib/bits/date-picker/components/date-picker-grid.svelte
@@ -6,6 +6,7 @@
 	type $$Props = GridProps;
 
 	export let asChild: $$Props["asChild"] = false;
+	export let el: $$Props["el"] = undefined;
 
 	const {
 		elements: { grid }
@@ -20,7 +21,7 @@
 {#if asChild}
 	<slot {builder} />
 {:else}
-	<table use:melt={builder} {...$$restProps}>
+	<table bind:this={el} use:melt={builder} {...$$restProps}>
 		<slot {builder} />
 	</table>
 {/if}

--- a/src/lib/bits/date-picker/components/date-picker-heading.svelte
+++ b/src/lib/bits/date-picker/components/date-picker-heading.svelte
@@ -6,6 +6,7 @@
 	type $$Props = HeadingProps;
 
 	export let asChild: $$Props["asChild"] = false;
+	export let el: $$Props["el"] = undefined;
 
 	const {
 		elements: { heading },
@@ -20,7 +21,7 @@
 {#if asChild}
 	<slot {builder} headingValue={$headingValue} />
 {:else}
-	<div use:melt={builder} {...$$restProps}>
+	<div bind:this={el} use:melt={builder} {...$$restProps}>
 		<slot {builder} headingValue={$headingValue}>
 			{$headingValue}
 		</slot>

--- a/src/lib/bits/date-picker/components/date-picker-input.svelte
+++ b/src/lib/bits/date-picker/components/date-picker-input.svelte
@@ -7,6 +7,7 @@
 
 	export let asChild: $$Props["asChild"] = false;
 	export let id: $$Props["id"] = undefined;
+	export let el: $$Props["el"] = undefined;
 
 	const {
 		elements: { field },
@@ -27,7 +28,7 @@
 {#if asChild}
 	<slot builder segments={$segmentContents} />
 {:else}
-	<div use:melt={builder} {...$$restProps}>
+	<div bind:this={el} use:melt={builder} {...$$restProps}>
 		<slot builder segments={$segmentContents} />
 	</div>
 {/if}

--- a/src/lib/bits/date-picker/components/date-picker-label.svelte
+++ b/src/lib/bits/date-picker/components/date-picker-label.svelte
@@ -7,6 +7,7 @@
 
 	export let asChild: $$Props["asChild"] = false;
 	export let id: $$Props["id"] = undefined;
+	export let el: $$Props["el"] = undefined;
 
 	const {
 		elements: { label },
@@ -26,7 +27,7 @@
 {#if asChild}
 	<slot {builder} />
 {:else}
-	<span use:melt={builder} {...$$restProps}>
+	<span bind:this={el} use:melt={builder} {...$$restProps}>
 		<slot {builder} />
 	</span>
 {/if}

--- a/src/lib/bits/date-picker/components/date-picker-next-button.svelte
+++ b/src/lib/bits/date-picker/components/date-picker-next-button.svelte
@@ -8,6 +8,7 @@
 	type $$Events = NextButtonEvents;
 
 	export let asChild: $$Props["asChild"] = false;
+	export let el: $$Props["el"] = undefined;
 
 	const {
 		elements: { nextButton }
@@ -24,6 +25,7 @@
 	<slot {builder} />
 {:else}
 	<button
+		bind:this={el}
 		use:melt={builder}
 		type="button"
 		{...$$restProps}

--- a/src/lib/bits/date-picker/components/date-picker-prev-button.svelte
+++ b/src/lib/bits/date-picker/components/date-picker-prev-button.svelte
@@ -8,6 +8,7 @@
 	type $$Events = PrevButtonEvents;
 
 	export let asChild: $$Props["asChild"] = false;
+	export let el: $$Props["el"] = undefined;
 
 	const {
 		elements: { prevButton }
@@ -24,6 +25,7 @@
 	<slot {builder} />
 {:else}
 	<button
+		bind:this={el}
 		use:melt={builder}
 		type="button"
 		{...$$restProps}

--- a/src/lib/bits/date-picker/components/date-picker-segment.svelte
+++ b/src/lib/bits/date-picker/components/date-picker-segment.svelte
@@ -10,6 +10,7 @@
 	export let asChild: $$Props["asChild"] = false;
 	export let id: $$Props["id"] = undefined;
 	export let part: $$Props["part"];
+	export let el: $$Props["el"] = undefined;
 
 	const {
 		elements: { segment },
@@ -31,6 +32,7 @@
 	<slot {builder} />
 {:else}
 	<div
+		bind:this={el}
 		use:melt={builder}
 		{...$$restProps}
 		on:m-click={dispatch}

--- a/src/lib/bits/date-picker/components/date-picker-trigger.svelte
+++ b/src/lib/bits/date-picker/components/date-picker-trigger.svelte
@@ -9,6 +9,7 @@
 
 	export let asChild: $$Props["asChild"] = false;
 	export let id: $$Props["id"] = undefined;
+	export let el: $$Props["el"] = undefined;
 
 	const {
 		elements: { trigger },
@@ -30,6 +31,7 @@
 	<slot {builder} />
 {:else}
 	<button
+		bind:this={el}
 		use:melt={builder}
 		type="button"
 		{...$$restProps}

--- a/src/lib/bits/date-picker/types.ts
+++ b/src/lib/bits/date-picker/types.ts
@@ -1,4 +1,4 @@
-import type { HTMLDivAttributes, HTMLSpanAttributes } from "$lib/internal/index.js";
+import type { DOMEl, HTMLDivAttributes, HTMLSpanAttributes } from "$lib/internal/index.js";
 import type * as I from "./_types.js";
 import type {
 	CellProps,
@@ -28,11 +28,11 @@ import type {
 import type { SegmentEvents } from "../date-field/types.js";
 
 type Props = I.Props;
-type LabelProps = I.Props & HTMLSpanAttributes;
-type SegmentProps = I.SegmentProps & HTMLDivAttributes;
-type InputProps = I.InputProps & HTMLDivAttributes;
-type DescriptionProps = I.DescriptionProps & HTMLDivAttributes;
-type CalendarProps = I.CalendarProps & HTMLDivAttributes;
+type LabelProps = I.Props & HTMLSpanAttributes & DOMEl<HTMLSpanElement>;
+type SegmentProps = I.SegmentProps & HTMLDivAttributes & DOMEl<HTMLDivElement>;
+type InputProps = I.InputProps & HTMLDivAttributes & DOMEl<HTMLDivElement>;
+type DescriptionProps = I.DescriptionProps & HTMLDivAttributes & DOMEl<HTMLDivElement>;
+type CalendarProps = I.CalendarProps & HTMLDivAttributes & DOMEl<HTMLDivElement>;
 
 export type {
 	Props,

--- a/src/lib/bits/date-picker/types.ts
+++ b/src/lib/bits/date-picker/types.ts
@@ -29,10 +29,10 @@ import type { SegmentEvents } from "../date-field/types.js";
 
 type Props = I.Props;
 type LabelProps = I.Props & HTMLSpanAttributes & DOMEl<HTMLSpanElement>;
-type SegmentProps = I.SegmentProps & HTMLDivAttributes & DOMEl<HTMLDivElement>;
-type InputProps = I.InputProps & HTMLDivAttributes & DOMEl<HTMLDivElement>;
-type DescriptionProps = I.DescriptionProps & HTMLDivAttributes & DOMEl<HTMLDivElement>;
-type CalendarProps = I.CalendarProps & HTMLDivAttributes & DOMEl<HTMLDivElement>;
+type SegmentProps = I.SegmentProps & HTMLDivAttributes & DOMEl;
+type InputProps = I.InputProps & HTMLDivAttributes & DOMEl;
+type DescriptionProps = I.DescriptionProps & HTMLDivAttributes & DOMEl;
+type CalendarProps = I.CalendarProps & HTMLDivAttributes & DOMEl;
 
 export type {
 	Props,

--- a/src/lib/bits/date-picker/types.ts
+++ b/src/lib/bits/date-picker/types.ts
@@ -1,4 +1,4 @@
-import type { DOMEl, HTMLDivAttributes, HTMLSpanAttributes } from "$lib/internal/index.js";
+import type { HTMLDivAttributes, HTMLSpanAttributes } from "$lib/internal/index.js";
 import type * as I from "./_types.js";
 import type {
 	CellProps,
@@ -28,11 +28,11 @@ import type {
 import type { SegmentEvents } from "../date-field/types.js";
 
 type Props = I.Props;
-type LabelProps = I.Props & HTMLSpanAttributes & DOMEl<HTMLSpanElement>;
-type SegmentProps = I.SegmentProps & HTMLDivAttributes & DOMEl;
-type InputProps = I.InputProps & HTMLDivAttributes & DOMEl;
-type DescriptionProps = I.DescriptionProps & HTMLDivAttributes & DOMEl;
-type CalendarProps = I.CalendarProps & HTMLDivAttributes & DOMEl;
+type LabelProps = I.LabelProps & HTMLSpanAttributes;
+type SegmentProps = I.SegmentProps & HTMLDivAttributes;
+type InputProps = I.InputProps & HTMLDivAttributes;
+type DescriptionProps = I.DescriptionProps & HTMLDivAttributes;
+type CalendarProps = I.CalendarProps & HTMLDivAttributes;
 
 export type {
 	Props,

--- a/src/lib/bits/date-range-field/_types.ts
+++ b/src/lib/bits/date-range-field/_types.ts
@@ -4,7 +4,7 @@
  * but we don't want to document the HTML attributes.
  */
 
-import type { Expand, OnChangeFn, AsChild, OmitDates } from "$lib/internal/index.js";
+import type { Expand, OnChangeFn, OmitDates, DOMElement } from "$lib/internal/index.js";
 import type { DateRange, SegmentPart } from "$lib/shared/index.js";
 import type { DateValue } from "@internationalized/date";
 import type { CreateDateFieldProps } from "@melt-ui/svelte";
@@ -46,9 +46,9 @@ type Props = Expand<
 	}
 >;
 
-type InputProps = AsChild;
+type InputProps = DOMElement;
 
-type LabelProps = AsChild;
+type LabelProps = DOMElement<HTMLSpanElement>;
 
 type SegmentProps = Expand<
 	{
@@ -61,7 +61,7 @@ type SegmentProps = Expand<
 		 * The part of the date to render.
 		 */
 		part: SegmentPart;
-	} & AsChild
+	} & DOMElement
 >;
 
 export type { Props, LabelProps, InputProps, SegmentProps };

--- a/src/lib/bits/date-range-field/components/date-range-field-input.svelte
+++ b/src/lib/bits/date-range-field/components/date-range-field-input.svelte
@@ -7,6 +7,7 @@
 
 	export let asChild: $$Props["asChild"] = false;
 	export let id: $$Props["id"] = undefined;
+	export let el: $$Props["el"] = undefined;
 
 	const {
 		elements: { field },
@@ -31,7 +32,7 @@
 {#if asChild}
 	<slot {builder} {segments} />
 {:else}
-	<div use:melt={builder} {...$$restProps}>
+	<div bind:this={el} use:melt={builder} {...$$restProps}>
 		<slot {builder} {segments} />
 	</div>
 {/if}

--- a/src/lib/bits/date-range-field/components/date-range-field-label.svelte
+++ b/src/lib/bits/date-range-field/components/date-range-field-label.svelte
@@ -7,6 +7,7 @@
 
 	export let asChild: $$Props["asChild"] = false;
 	export let id: $$Props["id"] = undefined;
+	export let el: $$Props["el"] = undefined;
 
 	const {
 		elements: { label },
@@ -26,7 +27,7 @@
 {#if asChild}
 	<slot {builder} />
 {:else}
-	<span use:melt={builder} {...$$restProps}>
+	<span bind:this={el} use:melt={builder} {...$$restProps}>
 		<slot {builder} />
 	</span>
 {/if}

--- a/src/lib/bits/date-range-field/components/date-range-field-segment.svelte
+++ b/src/lib/bits/date-range-field/components/date-range-field-segment.svelte
@@ -10,6 +10,7 @@
 	export let id: $$Props["id"] = undefined;
 	export let part: $$Props["part"];
 	export let type: $$Props["type"];
+	export let el: $$Props["el"] = undefined;
 
 	const {
 		elements: { startSegment, endSegment },
@@ -35,6 +36,7 @@
 	<slot {builder} />
 {:else}
 	<div
+		bind:this={el}
 		use:melt={builder}
 		{...$$restProps}
 		on:m-click={dispatch}

--- a/src/lib/bits/date-range-field/types.ts
+++ b/src/lib/bits/date-range-field/types.ts
@@ -1,10 +1,10 @@
-import type { DOMEl, HTMLDivAttributes, HTMLSpanAttributes } from "$lib/internal/index.js";
+import type { HTMLDivAttributes, HTMLSpanAttributes } from "$lib/internal/index.js";
 import type * as I from "./_types.js";
 import type { SegmentEvents } from "../date-field/types.js";
 
 type Props = I.Props;
-type LabelProps = I.LabelProps & HTMLSpanAttributes & DOMEl<HTMLSpanElement>;
-type SegmentProps = I.SegmentProps & HTMLDivAttributes & DOMEl;
-type InputProps = I.InputProps & HTMLDivAttributes & DOMEl;
+type LabelProps = I.LabelProps & HTMLSpanAttributes;
+type SegmentProps = I.SegmentProps & HTMLDivAttributes;
+type InputProps = I.InputProps & HTMLDivAttributes;
 
 export type { Props, LabelProps, InputProps, SegmentProps, SegmentEvents };

--- a/src/lib/bits/date-range-field/types.ts
+++ b/src/lib/bits/date-range-field/types.ts
@@ -4,7 +4,7 @@ import type { SegmentEvents } from "../date-field/types.js";
 
 type Props = I.Props;
 type LabelProps = I.LabelProps & HTMLSpanAttributes & DOMEl<HTMLSpanElement>;
-type SegmentProps = I.SegmentProps & HTMLDivAttributes & DOMEl<HTMLDivElement>;
-type InputProps = I.InputProps & HTMLDivAttributes & DOMEl<HTMLDivElement>;
+type SegmentProps = I.SegmentProps & HTMLDivAttributes & DOMEl;
+type InputProps = I.InputProps & HTMLDivAttributes & DOMEl;
 
 export type { Props, LabelProps, InputProps, SegmentProps, SegmentEvents };

--- a/src/lib/bits/date-range-field/types.ts
+++ b/src/lib/bits/date-range-field/types.ts
@@ -1,10 +1,10 @@
-import type { HTMLDivAttributes, HTMLSpanAttributes } from "$lib/internal/index.js";
+import type { DOMEl, HTMLDivAttributes, HTMLSpanAttributes } from "$lib/internal/index.js";
 import type * as I from "./_types.js";
 import type { SegmentEvents } from "../date-field/types.js";
 
 type Props = I.Props;
-type LabelProps = I.LabelProps & HTMLSpanAttributes;
-type SegmentProps = I.SegmentProps & HTMLDivAttributes;
-type InputProps = I.InputProps & HTMLDivAttributes;
+type LabelProps = I.LabelProps & HTMLSpanAttributes & DOMEl<HTMLSpanElement>;
+type SegmentProps = I.SegmentProps & HTMLDivAttributes & DOMEl<HTMLDivElement>;
+type InputProps = I.InputProps & HTMLDivAttributes & DOMEl<HTMLDivElement>;
 
 export type { Props, LabelProps, InputProps, SegmentProps, SegmentEvents };

--- a/src/lib/bits/date-range-picker/_types.ts
+++ b/src/lib/bits/date-range-picker/_types.ts
@@ -4,7 +4,13 @@
  * but we don't want to document the HTML attributes.
  */
 
-import type { Expand, OnChangeFn, AsChild, OmitDates, OmitFloating } from "$lib/internal/index.js";
+import type {
+	Expand,
+	OnChangeFn,
+	OmitDates,
+	OmitFloating,
+	DOMElement
+} from "$lib/internal/index.js";
 import type { DateRange, SegmentPart } from "$lib/shared";
 import type { DateValue } from "@internationalized/date";
 import type { CreateDateRangePickerProps } from "@melt-ui/svelte";
@@ -83,16 +89,16 @@ type Props = Expand<
 		 * the `value` is set.
 		 */
 		startValue?: DateValue | undefined;
-	} & AsChild
+	}
 >;
 
-type InputProps = AsChild;
+type InputProps = DOMElement;
 
-type DescriptionProps = AsChild;
+type DescriptionProps = DOMElement;
 
-type LabelProps = AsChild;
+type LabelProps = DOMElement<HTMLSpanElement>;
 
-type CalendarProps = AsChild;
+type CalendarProps = DOMElement;
 
 type SegmentProps = Expand<
 	{
@@ -105,7 +111,7 @@ type SegmentProps = Expand<
 		 * The part of the date to render.
 		 */
 		part: SegmentPart;
-	} & AsChild
+	} & DOMElement
 >;
 
 export type { Props, CalendarProps, LabelProps, DescriptionProps, InputProps, SegmentProps };

--- a/src/lib/bits/date-range-picker/components/date-range-picker-arrow.svelte
+++ b/src/lib/bits/date-range-picker/components/date-range-picker-arrow.svelte
@@ -6,6 +6,7 @@
 	type $$Props = ArrowProps;
 
 	export let asChild: $$Props["asChild"] = false;
+	export let el: $$Props["el"] = undefined;
 	export let size = 8;
 
 	const {
@@ -24,5 +25,5 @@
 {#if asChild}
 	<slot {builder} />
 {:else}
-	<div use:melt={builder} {...$$restProps} />
+	<div bind:this={el} use:melt={builder} {...$$restProps} />
 {/if}

--- a/src/lib/bits/date-range-picker/components/date-range-picker-calendar.svelte
+++ b/src/lib/bits/date-range-picker/components/date-range-picker-calendar.svelte
@@ -8,6 +8,7 @@
 
 	export let asChild: $$Props["asChild"] = false;
 	export let id: $$Props["id"] = undefined;
+	export let el: $$Props["el"] = undefined;
 
 	const {
 		elements: { calendar },
@@ -30,7 +31,7 @@
 {#if asChild}
 	<slot {builder} {months} weekdays={$weekdays} />
 {:else}
-	<div use:melt={builder} {...$$restProps}>
+	<div bind:this={el} use:melt={builder} {...$$restProps}>
 		<slot {builder} {months} weekdays={$weekdays} />
 	</div>
 {/if}

--- a/src/lib/bits/date-range-picker/components/date-range-picker-cell.svelte
+++ b/src/lib/bits/date-range-picker/components/date-range-picker-cell.svelte
@@ -6,6 +6,7 @@
 
 	export let date: $$Props["date"];
 	export let asChild: $$Props["asChild"] = false;
+	export let el: $$Props["el"] = undefined;
 
 	const {
 		helpers: { isDateDisabled, isDateUnavailable }
@@ -22,7 +23,7 @@
 {#if asChild}
 	<slot {attrs} />
 {:else}
-	<td {...$$restProps} {...attrs}>
+	<td bind:this={el} {...$$restProps} {...attrs}>
 		<slot {attrs} />
 	</td>
 {/if}

--- a/src/lib/bits/date-range-picker/components/date-range-picker-close.svelte
+++ b/src/lib/bits/date-range-picker/components/date-range-picker-close.svelte
@@ -8,6 +8,7 @@
 	type $$Events = CloseEvents;
 
 	export let asChild: $$Props["asChild"] = false;
+	export let el: $$Props["el"] = undefined;
 
 	const {
 		elements: { close }
@@ -24,6 +25,7 @@
 	<slot {builder} />
 {:else}
 	<button
+		bind:this={el}
 		use:melt={builder}
 		type="button"
 		{...$$restProps}

--- a/src/lib/bits/date-range-picker/components/date-range-picker-content.svelte
+++ b/src/lib/bits/date-range-picker/components/date-range-picker-content.svelte
@@ -29,6 +29,7 @@
 	export let fitViewport: $$Props["fitViewport"] = false;
 	export let strategy: $$Props["strategy"] = "absolute";
 	export let overlap: $$Props["overlap"] = false;
+	export let el: $$Props["el"] = undefined;
 
 	const {
 		elements: { content },
@@ -63,6 +64,7 @@
 	<slot {builder} />
 {:else if transition && $open}
 	<div
+		bind:this={el}
 		transition:transition={transitionConfig}
 		use:melt={builder}
 		{...$$restProps}
@@ -71,6 +73,7 @@
 	</div>
 {:else if inTransition && outTransition && $open}
 	<div
+		bind:this={el}
 		in:inTransition={inTransitionConfig}
 		out:outTransition={outTransitionConfig}
 		use:melt={builder}
@@ -79,11 +82,17 @@
 		<slot {builder} />
 	</div>
 {:else if inTransition && $open}
-	<div in:inTransition={inTransitionConfig} use:melt={builder} {...$$restProps}>
+	<div
+		bind:this={el}
+		in:inTransition={inTransitionConfig}
+		use:melt={builder}
+		{...$$restProps}
+	>
 		<slot {builder} />
 	</div>
 {:else if outTransition && $open}
 	<div
+		bind:this={el}
 		out:outTransition={outTransitionConfig}
 		use:melt={builder}
 		{...$$restProps}
@@ -91,7 +100,7 @@
 		<slot {builder} />
 	</div>
 {:else if $open}
-	<div use:melt={builder} {...$$restProps}>
+	<div bind:this={el} use:melt={builder} {...$$restProps}>
 		<slot {builder} />
 	</div>
 {/if}

--- a/src/lib/bits/date-range-picker/components/date-range-picker-day.svelte
+++ b/src/lib/bits/date-range-picker/components/date-range-picker-day.svelte
@@ -8,6 +8,7 @@
 	export let date: $$Props["date"];
 	export let month: $$Props["month"];
 	export let asChild: $$Props["asChild"] = false;
+	export let el: $$Props["el"] = undefined;
 
 	const {
 		elements: { cell },
@@ -25,7 +26,7 @@
 {#if asChild}
 	<slot {builder} {disabled} {unavailable} />
 {:else}
-	<div use:melt={builder} {...$$restProps}>
+	<div bind:this={el} use:melt={builder} {...$$restProps}>
 		<slot {builder} {disabled} {unavailable}>
 			{date.day}
 		</slot>

--- a/src/lib/bits/date-range-picker/components/date-range-picker-grid.svelte
+++ b/src/lib/bits/date-range-picker/components/date-range-picker-grid.svelte
@@ -6,6 +6,7 @@
 	type $$Props = GridProps;
 
 	export let asChild: $$Props["asChild"] = false;
+	export let el: $$Props["el"] = undefined;
 
 	const {
 		elements: { grid }
@@ -20,7 +21,7 @@
 {#if asChild}
 	<slot {builder} />
 {:else}
-	<table use:melt={builder} {...$$restProps}>
+	<table bind:this={el} use:melt={builder} {...$$restProps}>
 		<slot {builder} />
 	</table>
 {/if}

--- a/src/lib/bits/date-range-picker/components/date-range-picker-heading.svelte
+++ b/src/lib/bits/date-range-picker/components/date-range-picker-heading.svelte
@@ -6,6 +6,7 @@
 	type $$Props = HeadingProps;
 
 	export let asChild: $$Props["asChild"] = false;
+	export let el: $$Props["el"] = undefined;
 
 	const {
 		elements: { heading },
@@ -21,7 +22,7 @@
 {#if asChild}
 	<slot {builder} headingValue={$headingValue} />
 {:else}
-	<div use:melt={builder} {...$$restProps}>
+	<div bind:this={el} use:melt={builder} {...$$restProps}>
 		<slot {builder} headingValue={$headingValue}>
 			{$headingValue}
 		</slot>

--- a/src/lib/bits/date-range-picker/components/date-range-picker-input.svelte
+++ b/src/lib/bits/date-range-picker/components/date-range-picker-input.svelte
@@ -7,6 +7,7 @@
 
 	export let asChild: $$Props["asChild"] = false;
 	export let id: $$Props["id"] = undefined;
+	export let el: $$Props["el"] = undefined;
 
 	const {
 		elements: { field },
@@ -27,7 +28,7 @@
 {#if asChild}
 	<slot {builder} segments={$segmentContents} />
 {:else}
-	<div use:melt={builder} {...$$restProps}>
+	<div bind:this={el} use:melt={builder} {...$$restProps}>
 		<slot {builder} segments={$segmentContents} />
 	</div>
 {/if}

--- a/src/lib/bits/date-range-picker/components/date-range-picker-label.svelte
+++ b/src/lib/bits/date-range-picker/components/date-range-picker-label.svelte
@@ -7,6 +7,7 @@
 
 	export let asChild: $$Props["asChild"] = false;
 	export let id: $$Props["id"] = undefined;
+	export let el: $$Props["el"] = undefined;
 
 	const {
 		elements: { label },
@@ -26,7 +27,7 @@
 {#if asChild}
 	<slot {builder} />
 {:else}
-	<span use:melt={builder} {...$$restProps}>
+	<span bind:this={el} use:melt={builder} {...$$restProps}>
 		<slot {builder} />
 	</span>
 {/if}

--- a/src/lib/bits/date-range-picker/components/date-range-picker-next-button.svelte
+++ b/src/lib/bits/date-range-picker/components/date-range-picker-next-button.svelte
@@ -6,6 +6,7 @@
 	type $$Props = NextButtonProps;
 
 	export let asChild: $$Props["asChild"] = false;
+	export let el: $$Props["el"] = undefined;
 
 	const {
 		elements: { nextButton }
@@ -20,7 +21,7 @@
 {#if asChild}
 	<slot {builder} />
 {:else}
-	<button use:melt={builder} type="button" {...$$restProps}>
+	<button bind:this={el} use:melt={builder} type="button" {...$$restProps}>
 		<slot {builder} />
 	</button>
 {/if}

--- a/src/lib/bits/date-range-picker/components/date-range-picker-prev-button.svelte
+++ b/src/lib/bits/date-range-picker/components/date-range-picker-prev-button.svelte
@@ -6,6 +6,7 @@
 	type $$Props = PrevButtonProps;
 
 	export let asChild: $$Props["asChild"] = false;
+	export let el: $$Props["el"] = undefined;
 
 	const {
 		elements: { prevButton }
@@ -20,7 +21,7 @@
 {#if asChild}
 	<slot {builder} />
 {:else}
-	<button use:melt={builder} type="button" {...$$restProps}>
+	<button bind:this={el} use:melt={builder} type="button" {...$$restProps}>
 		<slot {builder} />
 	</button>
 {/if}

--- a/src/lib/bits/date-range-picker/components/date-range-picker-segment.svelte
+++ b/src/lib/bits/date-range-picker/components/date-range-picker-segment.svelte
@@ -9,6 +9,7 @@
 	export let id: $$Props["id"] = undefined;
 	export let part: $$Props["part"];
 	export let type: $$Props["type"];
+	export let el: $$Props["el"] = undefined;
 
 	const {
 		elements: { startSegment, endSegment },
@@ -32,7 +33,7 @@
 {#if asChild}
 	<slot {builder} />
 {:else}
-	<div use:melt={builder} {...$$restProps}>
+	<div bind:this={el} use:melt={builder} {...$$restProps}>
 		<slot {builder} />
 	</div>
 {/if}

--- a/src/lib/bits/date-range-picker/components/date-range-picker-trigger.svelte
+++ b/src/lib/bits/date-range-picker/components/date-range-picker-trigger.svelte
@@ -9,6 +9,7 @@
 
 	export let asChild: $$Props["asChild"] = false;
 	export let id: $$Props["id"] = undefined;
+	export let el: $$Props["el"] = undefined;
 
 	const {
 		elements: { trigger },
@@ -30,6 +31,7 @@
 	<slot {builder} />
 {:else}
 	<button
+		bind:this={el}
 		use:melt={builder}
 		type="button"
 		{...$$restProps}

--- a/src/lib/bits/date-range-picker/types.ts
+++ b/src/lib/bits/date-range-picker/types.ts
@@ -1,4 +1,4 @@
-import type { HTMLDivAttributes, HTMLSpanAttributes } from "$lib/internal/index.js";
+import type { DOMEl, HTMLDivAttributes, HTMLSpanAttributes } from "$lib/internal/index.js";
 import type * as I from "./_types.js";
 import type {
 	CellProps,
@@ -28,11 +28,11 @@ import type {
 import type { SegmentEvents } from "$lib/bits/date-range-field/types.js";
 
 type Props = I.Props;
-type LabelProps = I.Props & HTMLSpanAttributes;
-type SegmentProps = I.SegmentProps & HTMLDivAttributes;
-type InputProps = I.InputProps & HTMLDivAttributes;
-type DescriptionProps = I.DescriptionProps & HTMLDivAttributes;
-type CalendarProps = I.CalendarProps & HTMLDivAttributes;
+type LabelProps = I.Props & HTMLSpanAttributes & DOMEl<HTMLSpanElement>;
+type SegmentProps = I.SegmentProps & HTMLDivAttributes & DOMEl<HTMLDivElement>;
+type InputProps = I.InputProps & HTMLDivAttributes & DOMEl<HTMLDivElement>;
+type DescriptionProps = I.DescriptionProps & HTMLDivAttributes & DOMEl<HTMLDivElement>;
+type CalendarProps = I.CalendarProps & HTMLDivAttributes & DOMEl<HTMLDivElement>;
 
 export type {
 	Props,

--- a/src/lib/bits/date-range-picker/types.ts
+++ b/src/lib/bits/date-range-picker/types.ts
@@ -1,4 +1,4 @@
-import type { DOMEl, HTMLDivAttributes, HTMLSpanAttributes } from "$lib/internal/index.js";
+import type { HTMLDivAttributes, HTMLSpanAttributes } from "$lib/internal/index.js";
 import type * as I from "./_types.js";
 import type {
 	CellProps,
@@ -28,11 +28,11 @@ import type {
 import type { SegmentEvents } from "$lib/bits/date-range-field/types.js";
 
 type Props = I.Props;
-type LabelProps = I.Props & HTMLSpanAttributes & DOMEl<HTMLSpanElement>;
-type SegmentProps = I.SegmentProps & HTMLDivAttributes & DOMEl;
-type InputProps = I.InputProps & HTMLDivAttributes & DOMEl;
-type DescriptionProps = I.DescriptionProps & HTMLDivAttributes & DOMEl;
-type CalendarProps = I.CalendarProps & HTMLDivAttributes & DOMEl;
+type LabelProps = I.LabelProps & HTMLSpanAttributes;
+type SegmentProps = I.SegmentProps & HTMLDivAttributes;
+type InputProps = I.InputProps & HTMLDivAttributes;
+type DescriptionProps = I.DescriptionProps & HTMLDivAttributes;
+type CalendarProps = I.CalendarProps & HTMLDivAttributes;
 
 export type {
 	Props,

--- a/src/lib/bits/date-range-picker/types.ts
+++ b/src/lib/bits/date-range-picker/types.ts
@@ -29,10 +29,10 @@ import type { SegmentEvents } from "$lib/bits/date-range-field/types.js";
 
 type Props = I.Props;
 type LabelProps = I.Props & HTMLSpanAttributes & DOMEl<HTMLSpanElement>;
-type SegmentProps = I.SegmentProps & HTMLDivAttributes & DOMEl<HTMLDivElement>;
-type InputProps = I.InputProps & HTMLDivAttributes & DOMEl<HTMLDivElement>;
-type DescriptionProps = I.DescriptionProps & HTMLDivAttributes & DOMEl<HTMLDivElement>;
-type CalendarProps = I.CalendarProps & HTMLDivAttributes & DOMEl<HTMLDivElement>;
+type SegmentProps = I.SegmentProps & HTMLDivAttributes & DOMEl;
+type InputProps = I.InputProps & HTMLDivAttributes & DOMEl;
+type DescriptionProps = I.DescriptionProps & HTMLDivAttributes & DOMEl;
+type CalendarProps = I.CalendarProps & HTMLDivAttributes & DOMEl;
 
 export type {
 	Props,

--- a/src/lib/bits/dialog/_types.ts
+++ b/src/lib/bits/dialog/_types.ts
@@ -5,7 +5,7 @@
  */
 
 import type {
-	AsChild,
+	DOMElement,
 	Expand,
 	OmitOpen,
 	OnChangeFn,
@@ -31,7 +31,7 @@ type Props = Expand<
 	}
 >;
 
-type TriggerProps = AsChild;
+type TriggerProps = DOMElement<HTMLButtonElement>;
 
 type CloseProps = TriggerProps;
 
@@ -39,22 +39,22 @@ type ContentProps<
 	T extends Transition = Transition,
 	In extends Transition = Transition,
 	Out extends Transition = Transition
-> = Expand<TransitionProps<T, In, Out> & AsChild>;
+> = Expand<TransitionProps<T, In, Out> & DOMElement>;
 
-type DescriptionProps = AsChild;
+type DescriptionProps = DOMElement;
 
 type OverlayProps<
 	T extends Transition = Transition,
 	In extends Transition = Transition,
 	Out extends Transition = Transition
-> = Expand<TransitionProps<T, In, Out> & AsChild>;
+> = Expand<TransitionProps<T, In, Out> & DOMElement>;
 
-type PortalProps = AsChild;
+type PortalProps = DOMElement;
 
 type TitleProps = Expand<
 	{
 		level?: "h1" | "h2" | "h3" | "h4" | "h5" | "h6";
-	} & AsChild
+	} & DOMElement<HTMLHeadingElement>
 >;
 
 export type {

--- a/src/lib/bits/dialog/components/dialog-close.svelte
+++ b/src/lib/bits/dialog/components/dialog-close.svelte
@@ -8,6 +8,7 @@
 	type $$Events = CloseEvents;
 
 	export let asChild: $$Props["asChild"] = false;
+	export let el: $$Props["el"] = undefined;
 
 	const {
 		elements: { close }
@@ -24,6 +25,7 @@
 	<slot {builder} />
 {:else}
 	<button
+		bind:this={el}
 		use:melt={builder}
 		type="button"
 		{...$$restProps}

--- a/src/lib/bits/dialog/components/dialog-content.svelte
+++ b/src/lib/bits/dialog/components/dialog-content.svelte
@@ -18,6 +18,7 @@
 	export let outTransitionConfig: $$Props["outTransitionConfig"] = undefined;
 	export let asChild: $$Props["asChild"] = false;
 	export let id: $$Props["id"] = undefined;
+	export let el: $$Props["el"] = undefined;
 
 	const {
 		elements: { content },
@@ -38,6 +39,7 @@
 	<slot {builder} />
 {:else if transition && $open}
 	<div
+		bind:this={el}
 		transition:transition={transitionConfig}
 		use:melt={builder}
 		{...$$restProps}
@@ -46,6 +48,7 @@
 	</div>
 {:else if inTransition && outTransition && $open}
 	<div
+		bind:this={el}
 		in:inTransition={inTransitionConfig}
 		out:outTransition={outTransitionConfig}
 		use:melt={builder}
@@ -54,11 +57,17 @@
 		<slot {builder} />
 	</div>
 {:else if inTransition && $open}
-	<div in:inTransition={inTransitionConfig} use:melt={builder} {...$$restProps}>
+	<div
+		bind:this={el}
+		in:inTransition={inTransitionConfig}
+		use:melt={builder}
+		{...$$restProps}
+	>
 		<slot {builder} />
 	</div>
 {:else if outTransition && $open}
 	<div
+		bind:this={el}
 		out:outTransition={outTransitionConfig}
 		use:melt={builder}
 		{...$$restProps}
@@ -66,7 +75,7 @@
 		<slot {builder} />
 	</div>
 {:else if $open}
-	<div use:melt={builder} {...$$restProps}>
+	<div bind:this={el} use:melt={builder} {...$$restProps}>
 		<slot {builder} />
 	</div>
 {/if}

--- a/src/lib/bits/dialog/components/dialog-description.svelte
+++ b/src/lib/bits/dialog/components/dialog-description.svelte
@@ -7,6 +7,7 @@
 
 	export let asChild: $$Props["asChild"] = false;
 	export let id: $$Props["id"] = undefined;
+	export let el: $$Props["el"] = undefined;
 
 	const {
 		elements: { description },
@@ -24,7 +25,7 @@
 {#if asChild}
 	<slot {builder} />
 {:else}
-	<div use:melt={builder} {...$$restProps}>
+	<div bind:this={el} use:melt={builder} {...$$restProps}>
 		<slot {builder} />
 	</div>
 {/if}

--- a/src/lib/bits/dialog/components/dialog-overlay.svelte
+++ b/src/lib/bits/dialog/components/dialog-overlay.svelte
@@ -17,6 +17,7 @@
 	export let outTransition: $$Props["outTransition"] = undefined;
 	export let outTransitionConfig: $$Props["outTransitionConfig"] = undefined;
 	export let asChild: $$Props["asChild"] = false;
+	export let el: $$Props["el"] = undefined;
 
 	const {
 		elements: { overlay },
@@ -32,12 +33,14 @@
 	<slot {builder} />
 {:else if transition && $open}
 	<div
+		bind:this={el}
 		transition:transition={transitionConfig}
 		use:melt={builder}
 		{...$$restProps}
 	/>
 {:else if inTransition && outTransition && $open}
 	<div
+		bind:this={el}
 		in:inTransition={inTransitionConfig}
 		out:outTransition={outTransitionConfig}
 		use:melt={builder}
@@ -45,16 +48,18 @@
 	/>
 {:else if inTransition && $open}
 	<div
+		bind:this={el}
 		in:inTransition={inTransitionConfig}
 		use:melt={builder}
 		{...$$restProps}
 	/>
 {:else if outTransition && $open}
 	<div
+		bind:this={el}
 		out:outTransition={outTransitionConfig}
 		use:melt={builder}
 		{...$$restProps}
 	/>
 {:else if $open}
-	<div use:melt={builder} {...$$restProps} />
+	<div bind:this={el} use:melt={builder} {...$$restProps} />
 {/if}

--- a/src/lib/bits/dialog/components/dialog-portal.svelte
+++ b/src/lib/bits/dialog/components/dialog-portal.svelte
@@ -6,6 +6,7 @@
 	type $$Props = PortalProps;
 
 	export let asChild: $$Props["asChild"] = false;
+	export let el: $$Props["el"] = undefined;
 
 	const {
 		elements: { portalled }
@@ -20,7 +21,7 @@
 {#if asChild}
 	<slot {builder} />
 {:else}
-	<div use:melt={builder} {...$$restProps}>
+	<div bind:this={el} use:melt={builder} {...$$restProps}>
 		<slot {builder} />
 	</div>
 {/if}

--- a/src/lib/bits/dialog/components/dialog-title.svelte
+++ b/src/lib/bits/dialog/components/dialog-title.svelte
@@ -8,6 +8,7 @@
 	export let level: $$Props["level"] = "h2";
 	export let asChild: $$Props["asChild"] = false;
 	export let id: $$Props["id"] = undefined;
+	export let el: $$Props["el"] = undefined;
 
 	const {
 		elements: { title },
@@ -27,7 +28,12 @@
 {#if asChild}
 	<slot {builder} />
 {:else}
-	<svelte:element this={level} use:melt={builder} {...$$restProps}>
+	<svelte:element
+		this={level}
+		bind:this={el}
+		use:melt={builder}
+		{...$$restProps}
+	>
 		<slot {builder} />
 	</svelte:element>
 {/if}

--- a/src/lib/bits/dialog/components/dialog-trigger.svelte
+++ b/src/lib/bits/dialog/components/dialog-trigger.svelte
@@ -8,6 +8,7 @@
 	type $$Events = TriggerEvents;
 
 	export let asChild: $$Props["asChild"] = false;
+	export let el: $$Props["el"] = undefined;
 
 	const {
 		elements: { trigger }
@@ -24,6 +25,7 @@
 	<slot {builder} />
 {:else}
 	<button
+		bind:this={el}
 		use:melt={builder}
 		type="button"
 		{...$$restProps}

--- a/src/lib/bits/dialog/types.ts
+++ b/src/lib/bits/dialog/types.ts
@@ -1,29 +1,34 @@
-import type { HTMLDivAttributes, HTMLHeadingAttributes, Transition } from "$lib/internal/index.js";
+import type {
+	DOMEl,
+	HTMLDivAttributes,
+	HTMLHeadingAttributes,
+	Transition
+} from "$lib/internal/index.js";
 import type { HTMLButtonAttributes } from "svelte/elements";
 import type { CustomEventHandler } from "$lib/index.js";
 import type * as I from "./_types.js";
 
 type Props = I.Props;
 
-type TriggerProps = I.TriggerProps & HTMLButtonAttributes;
+type TriggerProps = I.TriggerProps & HTMLButtonAttributes & DOMEl<HTMLButtonElement>;
 type CloseProps = TriggerProps;
 
 type ContentProps<
 	T extends Transition = Transition,
 	In extends Transition = Transition,
 	Out extends Transition = Transition
-> = I.ContentProps<T, In, Out> & HTMLDivAttributes;
+> = I.ContentProps<T, In, Out> & HTMLDivAttributes & DOMEl<HTMLDivElement>;
 
-type DescriptionProps = I.DescriptionProps & HTMLDivAttributes;
+type DescriptionProps = I.DescriptionProps & HTMLDivAttributes & DOMEl<HTMLDivElement>;
 
 type OverlayProps<
 	T extends Transition = Transition,
 	In extends Transition = Transition,
 	Out extends Transition = Transition
-> = I.OverlayProps<T, In, Out> & HTMLDivAttributes;
+> = I.OverlayProps<T, In, Out> & HTMLDivAttributes & DOMEl<HTMLDivElement>;
 
-type PortalProps = I.PortalProps & HTMLDivAttributes;
-type TitleProps = I.TitleProps & HTMLHeadingAttributes;
+type PortalProps = I.PortalProps & HTMLDivAttributes & DOMEl<HTMLDivElement>;
+type TitleProps = I.TitleProps & HTMLHeadingAttributes & DOMEl<HTMLHeadingElement>;
 
 type TriggerEvents<T extends Element = HTMLButtonElement> = {
 	click: CustomEventHandler<MouseEvent, T>;

--- a/src/lib/bits/dialog/types.ts
+++ b/src/lib/bits/dialog/types.ts
@@ -1,34 +1,29 @@
-import type {
-	DOMEl,
-	HTMLDivAttributes,
-	HTMLHeadingAttributes,
-	Transition
-} from "$lib/internal/index.js";
+import type { HTMLDivAttributes, HTMLHeadingAttributes, Transition } from "$lib/internal/index.js";
 import type { HTMLButtonAttributes } from "svelte/elements";
 import type { CustomEventHandler } from "$lib/index.js";
 import type * as I from "./_types.js";
 
 type Props = I.Props;
 
-type TriggerProps = I.TriggerProps & HTMLButtonAttributes & DOMEl<HTMLButtonElement>;
+type TriggerProps = I.TriggerProps & HTMLButtonAttributes;
 type CloseProps = TriggerProps;
 
 type ContentProps<
 	T extends Transition = Transition,
 	In extends Transition = Transition,
 	Out extends Transition = Transition
-> = I.ContentProps<T, In, Out> & HTMLDivAttributes & DOMEl;
+> = I.ContentProps<T, In, Out> & HTMLDivAttributes;
 
-type DescriptionProps = I.DescriptionProps & HTMLDivAttributes & DOMEl;
+type DescriptionProps = I.DescriptionProps & HTMLDivAttributes;
 
 type OverlayProps<
 	T extends Transition = Transition,
 	In extends Transition = Transition,
 	Out extends Transition = Transition
-> = I.OverlayProps<T, In, Out> & HTMLDivAttributes & DOMEl;
+> = I.OverlayProps<T, In, Out> & HTMLDivAttributes;
 
-type PortalProps = I.PortalProps & HTMLDivAttributes & DOMEl;
-type TitleProps = I.TitleProps & HTMLHeadingAttributes & DOMEl<HTMLHeadingElement>;
+type PortalProps = I.PortalProps & HTMLDivAttributes;
+type TitleProps = I.TitleProps & HTMLHeadingAttributes;
 
 type TriggerEvents<T extends Element = HTMLButtonElement> = {
 	click: CustomEventHandler<MouseEvent, T>;

--- a/src/lib/bits/dialog/types.ts
+++ b/src/lib/bits/dialog/types.ts
@@ -17,17 +17,17 @@ type ContentProps<
 	T extends Transition = Transition,
 	In extends Transition = Transition,
 	Out extends Transition = Transition
-> = I.ContentProps<T, In, Out> & HTMLDivAttributes & DOMEl<HTMLDivElement>;
+> = I.ContentProps<T, In, Out> & HTMLDivAttributes & DOMEl;
 
-type DescriptionProps = I.DescriptionProps & HTMLDivAttributes & DOMEl<HTMLDivElement>;
+type DescriptionProps = I.DescriptionProps & HTMLDivAttributes & DOMEl;
 
 type OverlayProps<
 	T extends Transition = Transition,
 	In extends Transition = Transition,
 	Out extends Transition = Transition
-> = I.OverlayProps<T, In, Out> & HTMLDivAttributes & DOMEl<HTMLDivElement>;
+> = I.OverlayProps<T, In, Out> & HTMLDivAttributes & DOMEl;
 
-type PortalProps = I.PortalProps & HTMLDivAttributes & DOMEl<HTMLDivElement>;
+type PortalProps = I.PortalProps & HTMLDivAttributes & DOMEl;
 type TitleProps = I.TitleProps & HTMLHeadingAttributes & DOMEl<HTMLHeadingElement>;
 
 type TriggerEvents<T extends Element = HTMLButtonElement> = {

--- a/src/lib/bits/floating/_types.ts
+++ b/src/lib/bits/floating/_types.ts
@@ -1,9 +1,9 @@
-import type { AsChild, Transition, TransitionProps } from "$lib/internal/index.js";
+import type { DOMElement, Transition, TransitionProps } from "$lib/internal/index.js";
 
 export type ArrowProps = Expand<
 	{
 		size?: number;
-	} & AsChild
+	} & DOMElement
 >;
 
 export type Boundary = "clippingAncestors" | Element | Array<Element> | Rect;
@@ -103,4 +103,4 @@ export type ContentProps<
 	T extends Transition = Transition,
 	In extends Transition = Transition,
 	Out extends Transition = Transition
-> = Expand<FloatingProps & TransitionProps<T, In, Out> & AsChild>;
+> = Expand<FloatingProps & TransitionProps<T, In, Out> & DOMElement>;

--- a/src/lib/bits/floating/types.ts
+++ b/src/lib/bits/floating/types.ts
@@ -5,4 +5,4 @@ export type ContentProps<
 	T extends Transition = Transition,
 	In extends Transition = Transition,
 	Out extends Transition = Transition
-> = I.ContentProps<T, In, Out> & HTMLDivAttributes & DOMEl<HTMLDivElement>;
+> = I.ContentProps<T, In, Out> & HTMLDivAttributes & DOMEl;

--- a/src/lib/bits/floating/types.ts
+++ b/src/lib/bits/floating/types.ts
@@ -1,8 +1,8 @@
-import type { HTMLDivAttributes, Transition } from "$lib/internal";
+import type { DOMEl, HTMLDivAttributes, Transition } from "$lib/internal";
 import type * as I from "./_types.js";
 
 export type ContentProps<
 	T extends Transition = Transition,
 	In extends Transition = Transition,
 	Out extends Transition = Transition
-> = I.ContentProps<T, In, Out> & HTMLDivAttributes;
+> = I.ContentProps<T, In, Out> & HTMLDivAttributes & DOMEl<HTMLDivElement>;

--- a/src/lib/bits/floating/types.ts
+++ b/src/lib/bits/floating/types.ts
@@ -1,8 +1,8 @@
-import type { DOMEl, HTMLDivAttributes, Transition } from "$lib/internal";
+import type { HTMLDivAttributes, Transition } from "$lib/internal";
 import type * as I from "./_types.js";
 
 export type ContentProps<
 	T extends Transition = Transition,
 	In extends Transition = Transition,
 	Out extends Transition = Transition
-> = I.ContentProps<T, In, Out> & HTMLDivAttributes & DOMEl;
+> = I.ContentProps<T, In, Out> & HTMLDivAttributes;

--- a/src/lib/bits/label/_types.ts
+++ b/src/lib/bits/label/_types.ts
@@ -1,5 +1,5 @@
-import type { AsChild } from "$lib/internal/types.js";
+import type { DOMElement } from "$lib/internal/types.js";
 
-type Props = AsChild;
+type Props = DOMElement<HTMLLabelElement>;
 
 export type { Props };

--- a/src/lib/bits/label/components/label.svelte
+++ b/src/lib/bits/label/components/label.svelte
@@ -8,6 +8,7 @@
 	type $$Events = Events;
 
 	export let asChild: $$Props["asChild"] = false;
+	export let el: $$Props["el"] = undefined;
 
 	const {
 		elements: { root }
@@ -23,7 +24,12 @@
 {#if asChild}
 	<slot {builder} />
 {:else}
-	<label use:melt={builder} {...$$restProps} on:m-mousedown={dispatch}>
+	<label
+		bind:this={el}
+		use:melt={builder}
+		{...$$restProps}
+		on:m-mousedown={dispatch}
+	>
 		<slot {builder} />
 	</label>
 {/if}

--- a/src/lib/bits/label/types.ts
+++ b/src/lib/bits/label/types.ts
@@ -1,8 +1,9 @@
 import type { CustomEventHandler } from "$lib";
 import type { HTMLLabelAttributes } from "svelte/elements";
 import type * as I from "./_types.js";
+import type { DOMEl } from "$lib/internal/types.js";
 
-type Props = I.Props & HTMLLabelAttributes;
+type Props = I.Props & HTMLLabelAttributes & DOMEl<HTMLLabelElement>;
 
 type Events<T extends Element = HTMLLabelElement> = {
 	mousedown: CustomEventHandler<MouseEvent, T>;

--- a/src/lib/bits/label/types.ts
+++ b/src/lib/bits/label/types.ts
@@ -1,9 +1,8 @@
-import type { CustomEventHandler } from "$lib";
+import type { CustomEventHandler } from "$lib/index.js";
 import type { HTMLLabelAttributes } from "svelte/elements";
 import type * as I from "./_types.js";
-import type { DOMEl } from "$lib/internal/types.js";
 
-type Props = I.Props & HTMLLabelAttributes & DOMEl<HTMLLabelElement>;
+type Props = I.Props & HTMLLabelAttributes;
 
 type Events<T extends Element = HTMLLabelElement> = {
 	mousedown: CustomEventHandler<MouseEvent, T>;

--- a/src/lib/bits/link-preview/_types.ts
+++ b/src/lib/bits/link-preview/_types.ts
@@ -4,7 +4,7 @@
  * but we don't want to document the HTML attributes.
  */
 
-import type { Expand, OnChangeFn, AsChild, OmitFloating } from "$lib/internal/index.js";
+import type { Expand, OnChangeFn, OmitFloating, DOMElement } from "$lib/internal/index.js";
 import type { ArrowProps, ContentProps } from "$lib/bits/floating/_types.js";
 import type { CreateLinkPreviewProps } from "@melt-ui/svelte";
 
@@ -25,6 +25,6 @@ type Props = Expand<
 	}
 >;
 
-type TriggerProps = AsChild;
+type TriggerProps = DOMElement<HTMLAnchorElement>;
 
 export type { Props, ArrowProps, ContentProps, TriggerProps };

--- a/src/lib/bits/link-preview/components/link-preview-arrow.svelte
+++ b/src/lib/bits/link-preview/components/link-preview-arrow.svelte
@@ -6,6 +6,7 @@
 	type $$Props = ArrowProps;
 
 	export let asChild: $$Props["asChild"] = false;
+	export let el: $$Props["el"] = undefined;
 	export let size = 8;
 
 	const {
@@ -20,5 +21,5 @@
 {#if asChild}
 	<slot {builder} />
 {:else}
-	<div use:melt={builder} {...$$restProps} />
+	<div bind:this={el} use:melt={builder} {...$$restProps} />
 {/if}

--- a/src/lib/bits/link-preview/components/link-preview-content.svelte
+++ b/src/lib/bits/link-preview/components/link-preview-content.svelte
@@ -30,6 +30,7 @@
 	export let fitViewport: $$Props["fitViewport"] = false;
 	export let strategy: $$Props["strategy"] = "absolute";
 	export let overlap: $$Props["overlap"] = false;
+	export let el: $$Props["el"] = undefined;
 
 	const {
 		elements: { content },
@@ -66,6 +67,7 @@
 	<slot {builder} />
 {:else if transition && $open}
 	<div
+		bind:this={el}
 		transition:transition={transitionConfig}
 		use:melt={builder}
 		{...$$restProps}
@@ -78,6 +80,7 @@
 	</div>
 {:else if inTransition && outTransition && $open}
 	<div
+		bind:this={el}
 		in:inTransition={inTransitionConfig}
 		out:outTransition={outTransitionConfig}
 		use:melt={builder}
@@ -91,6 +94,7 @@
 	</div>
 {:else if inTransition && $open}
 	<div
+		bind:this={el}
 		in:inTransition={inTransitionConfig}
 		use:melt={builder}
 		{...$$restProps}
@@ -103,6 +107,7 @@
 	</div>
 {:else if outTransition && $open}
 	<div
+		bind:this={el}
 		out:outTransition={outTransitionConfig}
 		use:melt={builder}
 		{...$$restProps}
@@ -115,6 +120,7 @@
 	</div>
 {:else if $open}
 	<div
+		bind:this={el}
 		use:melt={builder}
 		{...$$restProps}
 		on:m-focusout={dispatch}

--- a/src/lib/bits/link-preview/components/link-preview-trigger.svelte
+++ b/src/lib/bits/link-preview/components/link-preview-trigger.svelte
@@ -9,6 +9,7 @@
 
 	export let asChild: $$Props["asChild"] = false;
 	export let id: $$Props["id"] = undefined;
+	export let el: $$Props["el"] = undefined;
 
 	const {
 		elements: { trigger },
@@ -30,6 +31,7 @@
 {:else}
 	<svelte:element
 		this={"a"}
+		bind:this={el}
 		use:melt={builder}
 		{...$$restProps}
 		{...attrs}

--- a/src/lib/bits/link-preview/types.ts
+++ b/src/lib/bits/link-preview/types.ts
@@ -11,9 +11,9 @@ type ContentProps<
 	T extends Transition = Transition,
 	In extends Transition = Transition,
 	Out extends Transition = Transition
-> = I.ContentProps<T, In, Out> & HTMLDivAttributes & DOMEl<HTMLDivElement>;
+> = I.ContentProps<T, In, Out> & HTMLDivAttributes & DOMEl;
 
-type ArrowProps = I.ArrowProps & HTMLDivAttributes & DOMEl<HTMLDivElement>;
+type ArrowProps = I.ArrowProps & HTMLDivAttributes & DOMEl;
 
 type TriggerEvents<T extends Element = HTMLAnchorElement> = {
 	click: CustomEventHandler<MouseEvent, T>;

--- a/src/lib/bits/link-preview/types.ts
+++ b/src/lib/bits/link-preview/types.ts
@@ -1,19 +1,19 @@
 import type { CustomEventHandler } from "$lib/index.js";
-import type { HTMLDivAttributes, Transition } from "$lib/internal/index.js";
+import type { DOMEl, HTMLDivAttributes, Transition } from "$lib/internal/index.js";
 import type { HTMLAnchorAttributes } from "svelte/elements";
 import type * as I from "./_types.js";
 
 type Props = I.Props;
 
-type TriggerProps = I.TriggerProps & HTMLAnchorAttributes;
+type TriggerProps = I.TriggerProps & HTMLAnchorAttributes & DOMEl<HTMLAnchorElement>;
 
 type ContentProps<
 	T extends Transition = Transition,
 	In extends Transition = Transition,
 	Out extends Transition = Transition
-> = I.ContentProps<T, In, Out> & HTMLDivAttributes;
+> = I.ContentProps<T, In, Out> & HTMLDivAttributes & DOMEl<HTMLDivElement>;
 
-type ArrowProps = I.ArrowProps & HTMLDivAttributes;
+type ArrowProps = I.ArrowProps & HTMLDivAttributes & DOMEl<HTMLDivElement>;
 
 type TriggerEvents<T extends Element = HTMLAnchorElement> = {
 	click: CustomEventHandler<MouseEvent, T>;

--- a/src/lib/bits/link-preview/types.ts
+++ b/src/lib/bits/link-preview/types.ts
@@ -1,19 +1,19 @@
 import type { CustomEventHandler } from "$lib/index.js";
-import type { DOMEl, HTMLDivAttributes, Transition } from "$lib/internal/index.js";
+import type { HTMLDivAttributes, Transition } from "$lib/internal/index.js";
 import type { HTMLAnchorAttributes } from "svelte/elements";
 import type * as I from "./_types.js";
 
 type Props = I.Props;
 
-type TriggerProps = I.TriggerProps & HTMLAnchorAttributes & DOMEl<HTMLAnchorElement>;
+type TriggerProps = I.TriggerProps & HTMLAnchorAttributes;
 
 type ContentProps<
 	T extends Transition = Transition,
 	In extends Transition = Transition,
 	Out extends Transition = Transition
-> = I.ContentProps<T, In, Out> & HTMLDivAttributes & DOMEl;
+> = I.ContentProps<T, In, Out> & HTMLDivAttributes;
 
-type ArrowProps = I.ArrowProps & HTMLDivAttributes & DOMEl;
+type ArrowProps = I.ArrowProps & HTMLDivAttributes;
 
 type TriggerEvents<T extends Element = HTMLAnchorElement> = {
 	click: CustomEventHandler<MouseEvent, T>;

--- a/src/lib/bits/menu/_types.ts
+++ b/src/lib/bits/menu/_types.ts
@@ -1,7 +1,7 @@
 /**
  * Shared internal types for the various menu components.
  */
-import type { AsChild, OmitChecked, OmitFloating, OnChangeFn } from "$lib/internal/index.js";
+import type { DOMElement, OmitChecked, OmitFloating, OnChangeFn } from "$lib/internal/index.js";
 import type {
 	CreateContextMenuCheckboxItemProps,
 	CreateContextMenuRadioGroupProps,
@@ -36,7 +36,7 @@ export type SubTriggerProps = Expand<
 		 * @defaultValue false;
 		 */
 		disabled?: boolean;
-	} & AsChild
+	} & DOMElement
 >;
 
 export type CheckboxItemProps = Expand<
@@ -53,7 +53,7 @@ export type CheckboxItemProps = Expand<
 		 * A callback function called when the checked state changes.
 		 */
 		onCheckedChange?: OnChangeFn<boolean | "indeterminate">;
-	} & AsChild
+	} & DOMElement
 >;
 
 export type RadioGroupProps = Expand<
@@ -69,10 +69,10 @@ export type RadioGroupProps = Expand<
 		 * A callback function called when the value changes.
 		 */
 		onValueChange?: OnChangeFn<CreateContextMenuRadioGroupProps["defaultValue"]>;
-	} & AsChild
+	} & DOMElement
 >;
 
-export type RadioItemProps = Expand<ContextMenuRadioItemProps & AsChild>;
+export type RadioItemProps = Expand<ContextMenuRadioItemProps & DOMElement>;
 
 export type SubProps = Expand<
 	OmitFloating<CreateContextSubmenuProps> & {
@@ -99,15 +99,15 @@ export type ItemProps = Expand<
 		 * @defaultValue false
 		 */
 		disabled?: boolean;
-	} & AsChild
+	} & DOMElement
 >;
 
 export type ArrowProps = FloatingArrowProps;
-export type GroupProps = AsChild;
-export type CheckboxIndicatorProps = AsChild;
-export type RadioIndicatorProps = AsChild;
-export type LabelProps = AsChild;
-export type SeparatorProps = AsChild;
-export type TriggerProps = AsChild;
+export type GroupProps = DOMElement;
+export type CheckboxIndicatorProps = DOMElement;
+export type RadioIndicatorProps = DOMElement;
+export type LabelProps = DOMElement;
+export type SeparatorProps = DOMElement;
+export type TriggerProps = DOMElement<HTMLElement>;
 
 export { ContentProps, ContentProps as SubContentProps };

--- a/src/lib/bits/menu/components/menu-arrow.svelte
+++ b/src/lib/bits/menu/components/menu-arrow.svelte
@@ -7,6 +7,7 @@
 
 	export let size: $$Props["size"] = 8;
 	export let asChild: $$Props["asChild"] = false;
+	export let el: $$Props["el"] = undefined;
 
 	const {
 		elements: { arrow }
@@ -21,5 +22,5 @@
 {#if asChild}
 	<slot {builder} />
 {:else}
-	<div use:melt={builder} {...$$restProps} />
+	<div bind:this={el} use:melt={builder} {...$$restProps} />
 {/if}

--- a/src/lib/bits/menu/components/menu-checkbox-indicator.svelte
+++ b/src/lib/bits/menu/components/menu-checkbox-indicator.svelte
@@ -4,6 +4,7 @@
 
 	type $$Props = CheckboxIndicatorProps;
 	export let asChild: $$Props["asChild"] = false;
+	export let el: $$Props["el"] = undefined;
 
 	const checked = getCheckboxIndicator();
 	const attrs = getAttrs("checkbox-indicator");
@@ -12,7 +13,7 @@
 {#if asChild}
 	<slot {attrs} checked={$checked} />
 {:else}
-	<div {...$$restProps} {...attrs}>
+	<div bind:this={el} {...$$restProps} {...attrs}>
 		{#if $checked}
 			<slot {attrs} checked={$checked} />
 		{/if}

--- a/src/lib/bits/menu/components/menu-checkbox-item.svelte
+++ b/src/lib/bits/menu/components/menu-checkbox-item.svelte
@@ -11,6 +11,7 @@
 	export let onCheckedChange: $$Props["onCheckedChange"] = undefined;
 	export let disabled: $$Props["disabled"] = undefined;
 	export let asChild: $$Props["asChild"] = false;
+	export let el: $$Props["el"] = undefined;
 
 	const {
 		elements: { checkboxItem },
@@ -42,6 +43,7 @@
 	<slot {builder} />
 {:else}
 	<div
+		bind:this={el}
 		use:melt={builder}
 		{...$$restProps}
 		on:m-click={dispatch}

--- a/src/lib/bits/menu/components/menu-content.svelte
+++ b/src/lib/bits/menu/components/menu-content.svelte
@@ -30,6 +30,7 @@
 	export let fitViewport: $$Props["fitViewport"] = false;
 	export let strategy: $$Props["strategy"] = "absolute";
 	export let overlap: $$Props["overlap"] = false;
+	export let el: $$Props["el"] = undefined;
 
 	const {
 		elements: { menu },
@@ -65,6 +66,7 @@
 	<slot {builder} />
 {:else if transition && $open}
 	<div
+		bind:this={el}
 		transition:transition={transitionConfig}
 		use:melt={builder}
 		{...$$restProps}
@@ -74,6 +76,7 @@
 	</div>
 {:else if inTransition && outTransition && $open}
 	<div
+		bind:this={el}
 		in:inTransition={inTransitionConfig}
 		out:outTransition={outTransitionConfig}
 		use:melt={builder}
@@ -84,6 +87,7 @@
 	</div>
 {:else if inTransition && $open}
 	<div
+		bind:this={el}
 		in:inTransition={inTransitionConfig}
 		use:melt={builder}
 		{...$$restProps}
@@ -93,6 +97,7 @@
 	</div>
 {:else if outTransition && $open}
 	<div
+		bind:this={el}
 		out:outTransition={outTransitionConfig}
 		use:melt={builder}
 		{...$$restProps}
@@ -101,7 +106,12 @@
 		<slot {builder} />
 	</div>
 {:else if $open}
-	<div use:melt={builder} {...$$restProps} on:m-keydown={dispatch}>
+	<div
+		bind:this={el}
+		use:melt={builder}
+		{...$$restProps}
+		on:m-keydown={dispatch}
+	>
 		<slot {builder} />
 	</div>
 {/if}

--- a/src/lib/bits/menu/components/menu-group.svelte
+++ b/src/lib/bits/menu/components/menu-group.svelte
@@ -4,6 +4,7 @@
 	import type { GroupProps } from "../types.js";
 	type $$Props = GroupProps;
 	export let asChild: $$Props["asChild"] = false;
+	export let el: $$Props["el"] = undefined;
 
 	const { group, id } = setGroupCtx();
 	const attrs = getAttrs("group");
@@ -15,7 +16,7 @@
 {#if asChild}
 	<slot {builder} />
 {:else}
-	<div use:melt={builder} {...$$restProps}>
+	<div bind:this={el} use:melt={builder} {...$$restProps}>
 		<slot {builder} />
 	</div>
 {/if}

--- a/src/lib/bits/menu/components/menu-item.svelte
+++ b/src/lib/bits/menu/components/menu-item.svelte
@@ -11,6 +11,7 @@
 	export let href: $$Props["href"] = undefined;
 	export let asChild: $$Props["asChild"] = false;
 	export let disabled: $$Props["disabled"] = false;
+	export let el: $$Props["el"] = undefined;
 
 	const {
 		elements: { item }
@@ -26,6 +27,7 @@
 	<slot {builder} />
 {:else}
 	<svelte:element
+		bind:this={el}
 		this={href ? "a" : "div"}
 		{href}
 		use:melt={builder}

--- a/src/lib/bits/menu/components/menu-item.svelte
+++ b/src/lib/bits/menu/components/menu-item.svelte
@@ -27,8 +27,8 @@
 	<slot {builder} />
 {:else}
 	<svelte:element
-		bind:this={el}
 		this={href ? "a" : "div"}
+		bind:this={el}
 		{href}
 		use:melt={builder}
 		{...$$restProps}

--- a/src/lib/bits/menu/components/menu-label.svelte
+++ b/src/lib/bits/menu/components/menu-label.svelte
@@ -6,6 +6,7 @@
 	type $$Props = LabelProps;
 
 	export let asChild: $$Props["asChild"] = false;
+	export let el: $$Props["el"] = undefined;
 
 	const { groupLabel, id } = getGroupLabel();
 	const attrs = getAttrs("label");
@@ -17,7 +18,7 @@
 {#if asChild}
 	<slot {builder} />
 {:else}
-	<div use:melt={builder} {...$$restProps}>
+	<div bind:this={el} use:melt={builder} {...$$restProps}>
 		<slot {builder} />
 	</div>
 {/if}

--- a/src/lib/bits/menu/components/menu-radio-group.svelte
+++ b/src/lib/bits/menu/components/menu-radio-group.svelte
@@ -8,6 +8,7 @@
 	export let value: $$Props["value"] = undefined;
 	export let onValueChange: $$Props["onValueChange"] = undefined;
 	export let asChild: $$Props["asChild"] = false;
+	export let el: $$Props["el"] = undefined;
 
 	const {
 		elements: { radioGroup },
@@ -33,7 +34,7 @@
 {#if asChild}
 	<slot {builder} />
 {:else}
-	<div use:melt={builder} {...$$restProps}>
+	<div bind:this={el} use:melt={builder} {...$$restProps}>
 		<slot {builder} />
 	</div>
 {/if}

--- a/src/lib/bits/menu/components/menu-radio-indicator.svelte
+++ b/src/lib/bits/menu/components/menu-radio-indicator.svelte
@@ -4,6 +4,7 @@
 
 	type $$Props = RadioIndicatorProps;
 	export let asChild: $$Props["asChild"] = false;
+	export let el: $$Props["el"] = undefined;
 
 	const { isChecked, value } = getRadioIndicator();
 	const attrs = getAttrs("radio-indicator");
@@ -13,7 +14,7 @@
 {#if asChild}
 	<slot {attrs} {checked} />
 {:else}
-	<div {...$$restProps} {...attrs}>
+	<div bind:this={el} {...$$restProps} {...attrs}>
 		{#if checked}
 			<slot {attrs} {checked} />
 		{/if}

--- a/src/lib/bits/menu/components/menu-radio-item.svelte
+++ b/src/lib/bits/menu/components/menu-radio-item.svelte
@@ -9,6 +9,7 @@
 	export let value: $$Props["value"];
 	export let disabled = false;
 	export let asChild: $$Props["asChild"] = false;
+	export let el: $$Props["el"] = undefined;
 
 	const {
 		elements: { radioItem }
@@ -25,6 +26,7 @@
 	<slot {builder} />
 {:else}
 	<div
+		bind:this={el}
 		use:melt={builder}
 		{...$$restProps}
 		on:m-click={dispatch}

--- a/src/lib/bits/menu/components/menu-separator.svelte
+++ b/src/lib/bits/menu/components/menu-separator.svelte
@@ -6,6 +6,7 @@
 	type $$Props = SeparatorProps;
 
 	export let asChild: $$Props["asChild"] = false;
+	export let el: $$Props["el"] = undefined;
 
 	const {
 		elements: { separator }
@@ -20,5 +21,5 @@
 {#if asChild}
 	<slot {builder} />
 {:else}
-	<div use:melt={$separator} {...$$restProps} />
+	<div bind:this={el} use:melt={$separator} {...$$restProps} />
 {/if}

--- a/src/lib/bits/menu/components/menu-sub-content.svelte
+++ b/src/lib/bits/menu/components/menu-sub-content.svelte
@@ -29,6 +29,7 @@
 	export let fitViewport: $$Props["fitViewport"] = false;
 	export let strategy: $$Props["strategy"] = "absolute";
 	export let overlap: $$Props["overlap"] = false;
+	export let el: $$Props["el"] = undefined;
 
 	const {
 		elements: { subMenu },
@@ -65,6 +66,7 @@
 	<slot {builder} />
 {:else if transition && $subOpen}
 	<div
+		bind:this={el}
 		transition:transition={transitionConfig}
 		use:melt={builder}
 		{...$$restProps}
@@ -76,6 +78,7 @@
 	</div>
 {:else if inTransition && outTransition && $subOpen}
 	<div
+		bind:this={el}
 		in:inTransition={inTransitionConfig}
 		out:outTransition={outTransitionConfig}
 		use:melt={builder}
@@ -88,6 +91,7 @@
 	</div>
 {:else if inTransition && $subOpen}
 	<div
+		bind:this={el}
 		in:inTransition={inTransitionConfig}
 		use:melt={builder}
 		{...$$restProps}
@@ -99,6 +103,7 @@
 	</div>
 {:else if outTransition && $subOpen}
 	<div
+		bind:this={el}
 		out:outTransition={outTransitionConfig}
 		use:melt={builder}
 		{...$$restProps}
@@ -110,6 +115,7 @@
 	</div>
 {:else if $subOpen}
 	<div
+		bind:this={el}
 		use:melt={builder}
 		{...$$restProps}
 		on:m-focusout={dispatch}

--- a/src/lib/bits/menu/components/menu-sub-trigger.svelte
+++ b/src/lib/bits/menu/components/menu-sub-trigger.svelte
@@ -12,6 +12,7 @@
 	export let disabled: $$Props["disabled"] = false;
 	export let asChild: $$Props["asChild"] = false;
 	export let id: $$Props["id"] = undefined;
+	export let el: $$Props["el"] = undefined;
 
 	const {
 		elements: { subTrigger },
@@ -33,6 +34,7 @@
 	<slot {builder} />
 {:else}
 	<div
+		bind:this={el}
 		use:melt={builder}
 		{...$$restProps}
 		on:m-click={dispatch}

--- a/src/lib/bits/menu/components/menu-trigger.svelte
+++ b/src/lib/bits/menu/components/menu-trigger.svelte
@@ -12,6 +12,7 @@
 
 	export let asChild: $$Props["asChild"] = false;
 	export let id: $$Props["id"] = undefined;
+	export let el: $$Props["el"] = undefined;
 
 	const {
 		elements: { trigger },
@@ -32,6 +33,7 @@
 	<slot {builder} />
 {:else}
 	<button
+		bind:this={el}
 		use:melt={builder}
 		type="button"
 		{...$$restProps}

--- a/src/lib/bits/menu/types.ts
+++ b/src/lib/bits/menu/types.ts
@@ -9,15 +9,15 @@ import type { HTMLAnchorAttributes, HTMLButtonAttributes } from "svelte/elements
 import type * as I from "$lib/bits/menu/_types.js";
 import type { ContentProps } from "$lib/bits/floating/types.js";
 
-type Props = I.Props & DOMEl;
+type Props = I.Props;
 
-type CheckboxItemProps = I.CheckboxItemProps & HTMLDivAttributes & DOMEl;
+type CheckboxItemProps = I.CheckboxItemProps & HTMLDivAttributes;
 
-type RadioGroupProps = I.RadioGroupProps & HTMLDivAttributes & DOMEl;
+type RadioGroupProps = I.RadioGroupProps & HTMLDivAttributes;
 
-type RadioItemProps = I.RadioItemProps & HTMLDivAttributes & DOMEl;
+type RadioItemProps = I.RadioItemProps & HTMLDivAttributes;
 
-type GroupProps = I.GroupProps & HTMLDivAttributes & DOMEl;
+type GroupProps = I.GroupProps & HTMLDivAttributes;
 
 type AnchorElement = HTMLAnchorAttributes & {
 	href?: HTMLAnchorAttributes["href"];
@@ -27,27 +27,29 @@ type DivElement = HTMLDivAttributes & {
 	href?: never;
 } & DOMEl;
 
-type ItemProps = I.ItemProps & (AnchorElement | DivElement);
+type ItemProps = Omit<I.ItemProps, "el"> & (AnchorElement | DivElement);
 
-type CheckboxIndicatorProps = I.CheckboxIndicatorProps & HTMLDivAttributes & DOMEl;
+type CheckboxIndicatorProps = I.CheckboxIndicatorProps & HTMLDivAttributes;
 
-type RadioIndicatorProps = I.RadioIndicatorProps & HTMLDivAttributes & DOMEl;
+type RadioIndicatorProps = I.RadioIndicatorProps & HTMLDivAttributes;
 
-type LabelProps = I.LabelProps & HTMLDivAttributes & DOMEl;
+type LabelProps = I.LabelProps & HTMLDivAttributes;
 
-type SeparatorProps = I.SeparatorProps & HTMLDivAttributes & DOMEl;
+type SeparatorProps = I.SeparatorProps & HTMLDivAttributes;
 
-type SubProps = I.SubProps & DOMEl;
+type SubProps = I.SubProps;
 
-type SubTriggerProps = I.SubTriggerProps & HTMLDivAttributes & DOMEl;
+type SubTriggerProps = I.SubTriggerProps & HTMLDivAttributes;
 
 // Trigger for context menu
-type ContextTriggerProps = I.TriggerProps & HTMLDivAttributes & DOMEl;
+type ContextTriggerProps = Omit<I.TriggerProps, "el"> & HTMLDivAttributes & DOMEl;
 
 // Trigger for dropdown menu & menubar menu
-type DropdownTriggerProps = I.TriggerProps & HTMLButtonAttributes & DOMEl<HTMLButtonElement>;
+type DropdownTriggerProps = Omit<I.TriggerProps, "el"> &
+	HTMLButtonAttributes &
+	DOMEl<HTMLButtonElement>;
 
-type ArrowProps = I.ArrowProps & HTMLDivAttributes & DOMEl;
+type ArrowProps = I.ArrowProps & HTMLDivAttributes;
 
 type ItemEvents<T extends Element = HTMLDivElement> = {
 	click: CustomEventHandler<MouseEvent, T>;

--- a/src/lib/bits/menu/types.ts
+++ b/src/lib/bits/menu/types.ts
@@ -3,51 +3,51 @@
  * such as `DropdownMenu`, `Menubar` & `ContextMenu`.
  */
 
-import type { HTMLDivAttributes } from "$lib/internal/index.js";
+import type { DOMEl, HTMLDivAttributes } from "$lib/internal/index.js";
 import type { CustomEventHandler } from "$lib";
 import type { HTMLAnchorAttributes, HTMLButtonAttributes } from "svelte/elements";
 import type * as I from "$lib/bits/menu/_types.js";
 import type { ContentProps } from "$lib/bits/floating/types.js";
 
-type Props = I.Props;
+type Props = I.Props & DOMEl<HTMLDivElement>;
 
-type CheckboxItemProps = I.CheckboxItemProps & HTMLDivAttributes;
+type CheckboxItemProps = I.CheckboxItemProps & HTMLDivAttributes & DOMEl<HTMLDivElement>;
 
-type RadioGroupProps = I.RadioGroupProps & HTMLDivAttributes;
+type RadioGroupProps = I.RadioGroupProps & HTMLDivAttributes & DOMEl<HTMLDivElement>;
 
-type RadioItemProps = I.RadioItemProps & HTMLDivAttributes;
+type RadioItemProps = I.RadioItemProps & HTMLDivAttributes & DOMEl<HTMLDivElement>;
 
-type GroupProps = I.GroupProps & HTMLDivAttributes;
+type GroupProps = I.GroupProps & HTMLDivAttributes & DOMEl<HTMLDivElement>;
 
 type AnchorElement = HTMLAnchorAttributes & {
 	href?: HTMLAnchorAttributes["href"];
-};
+} & DOMEl<HTMLAnchorElement>;
 
 type DivElement = HTMLDivAttributes & {
 	href?: never;
-};
+} & DOMEl<HTMLDivElement>;
 
 type ItemProps = I.ItemProps & (AnchorElement | DivElement);
 
-type CheckboxIndicatorProps = I.CheckboxIndicatorProps & HTMLDivAttributes;
+type CheckboxIndicatorProps = I.CheckboxIndicatorProps & HTMLDivAttributes & DOMEl<HTMLDivElement>;
 
-type RadioIndicatorProps = I.RadioIndicatorProps & HTMLDivAttributes;
+type RadioIndicatorProps = I.RadioIndicatorProps & HTMLDivAttributes & DOMEl<HTMLDivElement>;
 
-type LabelProps = I.LabelProps & HTMLDivAttributes;
+type LabelProps = I.LabelProps & HTMLDivAttributes & DOMEl<HTMLDivElement>;
 
-type SeparatorProps = I.SeparatorProps & HTMLDivAttributes;
+type SeparatorProps = I.SeparatorProps & HTMLDivAttributes & DOMEl<HTMLDivElement>;
 
-type SubProps = I.SubProps;
+type SubProps = I.SubProps & DOMEl<HTMLDivElement>;
 
-type SubTriggerProps = I.SubTriggerProps & HTMLDivAttributes;
+type SubTriggerProps = I.SubTriggerProps & HTMLDivAttributes & DOMEl<HTMLDivElement>;
 
 // Trigger for context menu
-type ContextTriggerProps = I.TriggerProps & HTMLDivAttributes;
+type ContextTriggerProps = I.TriggerProps & HTMLDivAttributes & DOMEl<HTMLDivElement>;
 
 // Trigger for dropdown menu & menubar menu
-type DropdownTriggerProps = I.TriggerProps & HTMLButtonAttributes;
+type DropdownTriggerProps = I.TriggerProps & HTMLButtonAttributes & DOMEl<HTMLButtonElement>;
 
-type ArrowProps = I.ArrowProps & HTMLDivAttributes;
+type ArrowProps = I.ArrowProps & HTMLDivAttributes & DOMEl<HTMLDivElement>;
 
 type ItemEvents<T extends Element = HTMLDivElement> = {
 	click: CustomEventHandler<MouseEvent, T>;

--- a/src/lib/bits/menu/types.ts
+++ b/src/lib/bits/menu/types.ts
@@ -9,15 +9,15 @@ import type { HTMLAnchorAttributes, HTMLButtonAttributes } from "svelte/elements
 import type * as I from "$lib/bits/menu/_types.js";
 import type { ContentProps } from "$lib/bits/floating/types.js";
 
-type Props = I.Props & DOMEl<HTMLDivElement>;
+type Props = I.Props & DOMEl;
 
-type CheckboxItemProps = I.CheckboxItemProps & HTMLDivAttributes & DOMEl<HTMLDivElement>;
+type CheckboxItemProps = I.CheckboxItemProps & HTMLDivAttributes & DOMEl;
 
-type RadioGroupProps = I.RadioGroupProps & HTMLDivAttributes & DOMEl<HTMLDivElement>;
+type RadioGroupProps = I.RadioGroupProps & HTMLDivAttributes & DOMEl;
 
-type RadioItemProps = I.RadioItemProps & HTMLDivAttributes & DOMEl<HTMLDivElement>;
+type RadioItemProps = I.RadioItemProps & HTMLDivAttributes & DOMEl;
 
-type GroupProps = I.GroupProps & HTMLDivAttributes & DOMEl<HTMLDivElement>;
+type GroupProps = I.GroupProps & HTMLDivAttributes & DOMEl;
 
 type AnchorElement = HTMLAnchorAttributes & {
 	href?: HTMLAnchorAttributes["href"];
@@ -25,29 +25,29 @@ type AnchorElement = HTMLAnchorAttributes & {
 
 type DivElement = HTMLDivAttributes & {
 	href?: never;
-} & DOMEl<HTMLDivElement>;
+} & DOMEl;
 
 type ItemProps = I.ItemProps & (AnchorElement | DivElement);
 
-type CheckboxIndicatorProps = I.CheckboxIndicatorProps & HTMLDivAttributes & DOMEl<HTMLDivElement>;
+type CheckboxIndicatorProps = I.CheckboxIndicatorProps & HTMLDivAttributes & DOMEl;
 
-type RadioIndicatorProps = I.RadioIndicatorProps & HTMLDivAttributes & DOMEl<HTMLDivElement>;
+type RadioIndicatorProps = I.RadioIndicatorProps & HTMLDivAttributes & DOMEl;
 
-type LabelProps = I.LabelProps & HTMLDivAttributes & DOMEl<HTMLDivElement>;
+type LabelProps = I.LabelProps & HTMLDivAttributes & DOMEl;
 
-type SeparatorProps = I.SeparatorProps & HTMLDivAttributes & DOMEl<HTMLDivElement>;
+type SeparatorProps = I.SeparatorProps & HTMLDivAttributes & DOMEl;
 
-type SubProps = I.SubProps & DOMEl<HTMLDivElement>;
+type SubProps = I.SubProps & DOMEl;
 
-type SubTriggerProps = I.SubTriggerProps & HTMLDivAttributes & DOMEl<HTMLDivElement>;
+type SubTriggerProps = I.SubTriggerProps & HTMLDivAttributes & DOMEl;
 
 // Trigger for context menu
-type ContextTriggerProps = I.TriggerProps & HTMLDivAttributes & DOMEl<HTMLDivElement>;
+type ContextTriggerProps = I.TriggerProps & HTMLDivAttributes & DOMEl;
 
 // Trigger for dropdown menu & menubar menu
 type DropdownTriggerProps = I.TriggerProps & HTMLButtonAttributes & DOMEl<HTMLButtonElement>;
 
-type ArrowProps = I.ArrowProps & HTMLDivAttributes & DOMEl<HTMLDivElement>;
+type ArrowProps = I.ArrowProps & HTMLDivAttributes & DOMEl;
 
 type ItemEvents<T extends Element = HTMLDivElement> = {
 	click: CustomEventHandler<MouseEvent, T>;

--- a/src/lib/bits/menubar/_types.ts
+++ b/src/lib/bits/menubar/_types.ts
@@ -4,9 +4,9 @@
  * but we don't want to document the HTML attributes.
  */
 
-import type { AsChild, Expand, OmitIds } from "$lib/internal/index.js";
+import type { DOMElement, Expand, OmitIds } from "$lib/internal/index.js";
 import type { CreateMenubarProps } from "@melt-ui/svelte";
 
-type Props = Expand<OmitIds<CreateMenubarProps> & AsChild>;
+type Props = Expand<OmitIds<CreateMenubarProps> & DOMElement>;
 
 export type { Props };

--- a/src/lib/bits/menubar/components/menubar-trigger.svelte
+++ b/src/lib/bits/menubar/components/menubar-trigger.svelte
@@ -9,6 +9,7 @@
 
 	export let asChild: $$Props["asChild"] = false;
 	export let id: $$Props["id"] = undefined;
+	export let el: $$Props["el"] = undefined;
 
 	const {
 		elements: { trigger },
@@ -29,6 +30,7 @@
 	<slot {builder} />
 {:else}
 	<button
+		bind:this={el}
 		use:melt={builder}
 		type="button"
 		{...$$restProps}

--- a/src/lib/bits/menubar/components/menubar.svelte
+++ b/src/lib/bits/menubar/components/menubar.svelte
@@ -10,6 +10,7 @@
 	export let closeOnEscape: $$Props["closeOnEscape"] = true;
 	export let asChild: $$Props["asChild"] = false;
 	export let id: $$Props["id"] = undefined;
+	export let el: $$Props["el"] = undefined;
 
 	const {
 		elements: { menubar },
@@ -35,7 +36,7 @@
 {#if asChild}
 	<slot {builder} ids={$idValues} />
 {:else}
-	<div use:melt={builder} {...$$restProps}>
+	<div bind:this={el} use:melt={builder} {...$$restProps}>
 		<slot {builder} ids={$idValues} />
 	</div>
 {/if}

--- a/src/lib/bits/menubar/types.ts
+++ b/src/lib/bits/menubar/types.ts
@@ -1,4 +1,4 @@
-import type { HTMLDivAttributes } from "$lib/internal/index.js";
+import type { DOMEl, HTMLDivAttributes } from "$lib/internal/index.js";
 import type { Props as MenubarProps } from "./_types.js";
 
 import type {
@@ -28,7 +28,7 @@ import type {
 	SubContentEvents
 } from "$lib/bits/menu/types.js";
 
-type Props = MenubarProps & HTMLDivAttributes;
+type Props = MenubarProps & HTMLDivAttributes & DOMEl<HTMLDivElement>;
 
 export type {
 	Props,

--- a/src/lib/bits/menubar/types.ts
+++ b/src/lib/bits/menubar/types.ts
@@ -28,7 +28,7 @@ import type {
 	SubContentEvents
 } from "$lib/bits/menu/types.js";
 
-type Props = MenubarProps & HTMLDivAttributes & DOMEl<HTMLDivElement>;
+type Props = MenubarProps & HTMLDivAttributes & DOMEl;
 
 export type {
 	Props,

--- a/src/lib/bits/menubar/types.ts
+++ b/src/lib/bits/menubar/types.ts
@@ -1,4 +1,4 @@
-import type { DOMEl, HTMLDivAttributes } from "$lib/internal/index.js";
+import type { HTMLDivAttributes } from "$lib/internal/index.js";
 import type { Props as MenubarProps } from "./_types.js";
 
 import type {
@@ -28,7 +28,7 @@ import type {
 	SubContentEvents
 } from "$lib/bits/menu/types.js";
 
-type Props = MenubarProps & HTMLDivAttributes & DOMEl;
+type Props = MenubarProps & HTMLDivAttributes;
 
 export type {
 	Props,

--- a/src/lib/bits/pagination/_types.ts
+++ b/src/lib/bits/pagination/_types.ts
@@ -4,7 +4,7 @@
  * but we don't want to document the HTML attributes.
  */
 
-import type { AsChild, Expand, OnChangeFn } from "$lib/internal";
+import type { DOMElement, Expand, OnChangeFn } from "$lib/internal";
 import type { CreatePaginationProps, Page } from "@melt-ui/svelte";
 
 type OmitPaginationProps<T> = Omit<T, "page" | "defaultPage" | "onPageChange">;
@@ -22,15 +22,15 @@ type Props = Expand<
 		 * A callback function called when the page changes.
 		 */
 		onPageChange?: OnChangeFn<number>;
-	} & AsChild
+	} & DOMElement
 >;
 
 type PageProps = {
 	page: Page;
-} & AsChild;
+} & DOMElement<HTMLButtonElement>;
 
-type PrevButtonProps = AsChild;
+type PrevButtonProps = DOMElement<HTMLButtonElement>;
 
-type NextButtonProps = AsChild;
+type NextButtonProps = DOMElement<HTMLButtonElement>;
 
 export type { Props, PrevButtonProps, NextButtonProps, PageProps };

--- a/src/lib/bits/pagination/components/pagination-next-button.svelte
+++ b/src/lib/bits/pagination/components/pagination-next-button.svelte
@@ -8,6 +8,7 @@
 	type $$Events = NextButtonEvents;
 
 	export let asChild: $$Props["asChild"] = undefined;
+	export let el: $$Props["el"] = undefined;
 
 	const {
 		elements: { nextButton }
@@ -25,6 +26,7 @@
 	<slot {builder} />
 {:else}
 	<button
+		bind:this={el}
 		use:melt={builder}
 		type="button"
 		{...$$restProps}

--- a/src/lib/bits/pagination/components/pagination-page.svelte
+++ b/src/lib/bits/pagination/components/pagination-page.svelte
@@ -9,6 +9,7 @@
 
 	export let asChild: $$Props["asChild"] = undefined;
 	export let page: $$Props["page"];
+	export let el: $$Props["el"] = undefined;
 
 	const {
 		elements: { pageTrigger }
@@ -26,6 +27,7 @@
 	<slot {builder} />
 {:else}
 	<button
+		bind:this={el}
 		type="button"
 		use:melt={builder}
 		on:m-click={dispatch}

--- a/src/lib/bits/pagination/components/pagination-prev-button.svelte
+++ b/src/lib/bits/pagination/components/pagination-prev-button.svelte
@@ -8,6 +8,7 @@
 	type $$Events = PrevButtonEvents;
 
 	export let asChild: $$Props["asChild"] = undefined;
+	export let el: $$Props["el"] = undefined;
 
 	const {
 		elements: { prevButton }
@@ -25,6 +26,7 @@
 	<slot {builder} />
 {:else}
 	<button
+		bind:this={el}
 		use:melt={builder}
 		type="button"
 		{...$$restProps}

--- a/src/lib/bits/pagination/components/pagination.svelte
+++ b/src/lib/bits/pagination/components/pagination.svelte
@@ -11,6 +11,7 @@
 	export let perPage: $$Props["perPage"] = undefined;
 	export let siblingCount: $$Props["siblingCount"] = undefined;
 	export let asChild: $$Props["asChild"] = false;
+	export let el: $$Props["el"] = undefined;
 
 	const {
 		elements: { root },
@@ -39,7 +40,7 @@
 {#if asChild}
 	<slot {builder} pages={$pages} range={$range} />
 {:else}
-	<div use:melt={builder} {...$$restProps}>
+	<div bind:this={el} use:melt={builder} {...$$restProps}>
 		<slot {builder} pages={$pages} range={$range} />
 	</div>
 {/if}

--- a/src/lib/bits/pagination/types.ts
+++ b/src/lib/bits/pagination/types.ts
@@ -3,7 +3,7 @@ import type { CustomEventHandler } from "$lib";
 import type * as I from "./_types.js";
 import type { DOMEl, HTMLDivAttributes } from "$lib/internal/types.js";
 
-type Props = I.Props & HTMLDivAttributes & DOMEl<HTMLDivElement>;
+type Props = I.Props & HTMLDivAttributes & DOMEl;
 
 type PrevButtonProps = I.PrevButtonProps & HTMLButtonAttributes & DOMEl<HTMLButtonElement>;
 

--- a/src/lib/bits/pagination/types.ts
+++ b/src/lib/bits/pagination/types.ts
@@ -1,15 +1,15 @@
 import type { HTMLButtonAttributes } from "svelte/elements";
 import type { CustomEventHandler } from "$lib";
 import type * as I from "./_types.js";
-import type { HTMLDivAttributes } from "$lib/internal/types.js";
+import type { DOMEl, HTMLDivAttributes } from "$lib/internal/types.js";
 
-type Props = I.Props & HTMLDivAttributes;
+type Props = I.Props & HTMLDivAttributes & DOMEl<HTMLDivElement>;
 
-type PrevButtonProps = I.PrevButtonProps & HTMLButtonAttributes;
+type PrevButtonProps = I.PrevButtonProps & HTMLButtonAttributes & DOMEl<HTMLButtonElement>;
 
-type NextButtonProps = I.NextButtonProps & HTMLButtonAttributes;
+type NextButtonProps = I.NextButtonProps & HTMLButtonAttributes & DOMEl<HTMLButtonElement>;
 
-type PageProps = I.PageProps & HTMLButtonAttributes;
+type PageProps = I.PageProps & HTMLButtonAttributes & DOMEl<HTMLButtonElement>;
 
 /**
  * Events

--- a/src/lib/bits/pagination/types.ts
+++ b/src/lib/bits/pagination/types.ts
@@ -1,15 +1,15 @@
 import type { HTMLButtonAttributes } from "svelte/elements";
 import type { CustomEventHandler } from "$lib";
 import type * as I from "./_types.js";
-import type { DOMEl, HTMLDivAttributes } from "$lib/internal/types.js";
+import type { HTMLDivAttributes } from "$lib/internal/types.js";
 
-type Props = I.Props & HTMLDivAttributes & DOMEl;
+type Props = I.Props & HTMLDivAttributes;
 
-type PrevButtonProps = I.PrevButtonProps & HTMLButtonAttributes & DOMEl<HTMLButtonElement>;
+type PrevButtonProps = I.PrevButtonProps & HTMLButtonAttributes;
 
-type NextButtonProps = I.NextButtonProps & HTMLButtonAttributes & DOMEl<HTMLButtonElement>;
+type NextButtonProps = I.NextButtonProps & HTMLButtonAttributes;
 
-type PageProps = I.PageProps & HTMLButtonAttributes & DOMEl<HTMLButtonElement>;
+type PageProps = I.PageProps & HTMLButtonAttributes;
 
 /**
  * Events

--- a/src/lib/bits/pin-input/_types.ts
+++ b/src/lib/bits/pin-input/_types.ts
@@ -4,7 +4,7 @@
  * but we don't want to document the HTML attributes.
  */
 import type { CreatePinInputProps } from "@melt-ui/svelte";
-import type { AsChild, Expand, OmitIds, OmitValue, OnChangeFn } from "$lib/internal/index.js";
+import type { DOMElement, Expand, OmitIds, OmitValue, OnChangeFn } from "$lib/internal/index.js";
 
 type Props = Expand<
 	OmitIds<
@@ -20,12 +20,12 @@ type Props = Expand<
 			 * A callback function called when the value changes.
 			 */
 			onValueChange?: OnChangeFn<CreatePinInputProps["defaultValue"]>;
-		} & AsChild
+		} & DOMElement
 	>
 >;
 
-type InputProps = AsChild;
+type InputProps = DOMElement<HTMLInputElement>;
 
-type HiddenInputProps = AsChild;
+type HiddenInputProps = DOMElement<HTMLInputElement>;
 
 export type { Props, InputProps, HiddenInputProps };

--- a/src/lib/bits/pin-input/components/pin-input-hidden-input.svelte
+++ b/src/lib/bits/pin-input/components/pin-input-hidden-input.svelte
@@ -6,6 +6,7 @@
 	type $$Props = HiddenInputProps;
 
 	export let asChild: $$Props["asChild"] = false;
+	export let el: $$Props["el"] = undefined;
 
 	const {
 		elements: { hiddenInput },
@@ -24,5 +25,5 @@
 {#if asChild}
 	<slot {builder} />
 {:else}
-	<input use:melt={builder} {...$$restProps} />
+	<input bind:this={el} use:melt={builder} {...$$restProps} />
 {/if}

--- a/src/lib/bits/pin-input/components/pin-input-input.svelte
+++ b/src/lib/bits/pin-input/components/pin-input-input.svelte
@@ -8,6 +8,7 @@
 	type $$Events = InputEvents;
 
 	export let asChild: $$Props["asChild"] = false;
+	export let el: $$Props["el"] = undefined;
 
 	const {
 		elements: { input }
@@ -24,6 +25,7 @@
 	<slot {builder} />
 {:else}
 	<input
+		bind:this={el}
 		use:melt={builder}
 		{...$$restProps}
 		on:m-keydown={dispatch}

--- a/src/lib/bits/pin-input/components/pin-input.svelte
+++ b/src/lib/bits/pin-input/components/pin-input.svelte
@@ -14,6 +14,7 @@
 	export let onValueChange: $$Props["onValueChange"] = undefined;
 	export let id: $$Props["id"] = undefined;
 	export let asChild: $$Props["asChild"] = false;
+	export let el: $$Props["el"] = undefined;
 
 	const {
 		elements: { root },
@@ -64,7 +65,7 @@
 {#if asChild}
 	<slot {...slotProps} />
 {:else}
-	<div use:melt={builder} {...$$restProps}>
+	<div bind:this={el} use:melt={builder} {...$$restProps}>
 		<slot {...slotProps} />
 	</div>
 {/if}

--- a/src/lib/bits/pin-input/types.ts
+++ b/src/lib/bits/pin-input/types.ts
@@ -1,13 +1,13 @@
-import type { DOMEl, HTMLDivAttributes } from "$lib/internal/index.js";
+import type { HTMLDivAttributes } from "$lib/internal/index.js";
 import type { CustomEventHandler } from "$lib";
 import type { HTMLInputAttributes } from "svelte/elements";
 import type * as I from "./_types.js";
 
-type Props = I.Props & HTMLDivAttributes & DOMEl;
+type Props = I.Props & HTMLDivAttributes;
 
-type InputProps = I.InputProps & HTMLInputAttributes & DOMEl<HTMLInputElement>;
+type InputProps = I.InputProps & HTMLInputAttributes;
 
-type HiddenInputProps = I.HiddenInputProps & HTMLInputAttributes & DOMEl<HTMLInputElement>;
+type HiddenInputProps = I.HiddenInputProps & HTMLInputAttributes;
 
 type InputEvents = {
 	keydown: CustomEventHandler<KeyboardEvent, HTMLInputElement>;

--- a/src/lib/bits/pin-input/types.ts
+++ b/src/lib/bits/pin-input/types.ts
@@ -1,11 +1,13 @@
-import type { HTMLDivAttributes } from "$lib/internal/index.js";
+import type { DOMEl, HTMLDivAttributes } from "$lib/internal/index.js";
 import type { CustomEventHandler } from "$lib";
 import type { HTMLInputAttributes } from "svelte/elements";
 import type * as I from "./_types.js";
 
-type Props = I.Props & HTMLDivAttributes;
+type Props = I.Props & HTMLDivAttributes & DOMEl<HTMLDivElement>;
 
-type InputProps = I.InputProps & HTMLInputAttributes;
+type InputProps = I.InputProps & HTMLInputAttributes & DOMEl<HTMLInputElement>;
+
+type HiddenInputProps = I.HiddenInputProps & HTMLInputAttributes & DOMEl<HTMLInputElement>;
 
 type InputEvents = {
 	keydown: CustomEventHandler<KeyboardEvent, HTMLInputElement>;
@@ -15,8 +17,6 @@ type InputEvents = {
 	focus: CustomEventHandler<FocusEvent, HTMLInputElement>;
 	blur: CustomEventHandler<FocusEvent, HTMLInputElement>;
 };
-
-type HiddenInputProps = I.HiddenInputProps & HTMLInputAttributes;
 
 export type {
 	Props,

--- a/src/lib/bits/pin-input/types.ts
+++ b/src/lib/bits/pin-input/types.ts
@@ -3,7 +3,7 @@ import type { CustomEventHandler } from "$lib";
 import type { HTMLInputAttributes } from "svelte/elements";
 import type * as I from "./_types.js";
 
-type Props = I.Props & HTMLDivAttributes & DOMEl<HTMLDivElement>;
+type Props = I.Props & HTMLDivAttributes & DOMEl;
 
 type InputProps = I.InputProps & HTMLInputAttributes & DOMEl<HTMLInputElement>;
 

--- a/src/lib/bits/popover/_types.ts
+++ b/src/lib/bits/popover/_types.ts
@@ -3,7 +3,7 @@
  * to type-check our API documentation, which requires we document each prop,
  * but we don't want to document the HTML attributes.
  */
-import type { Expand, OnChangeFn, AsChild, OmitFloating } from "$lib/internal/index.js";
+import type { Expand, OnChangeFn, OmitFloating, DOMElement } from "$lib/internal/index.js";
 import type { ArrowProps, ContentProps } from "$lib/bits/floating/_types.js";
 import type { CreatePopoverProps } from "@melt-ui/svelte";
 
@@ -24,7 +24,7 @@ type Props = Expand<
 	}
 >;
 
-type TriggerProps = AsChild;
-type CloseProps = AsChild;
+type TriggerProps = DOMElement<HTMLButtonElement>;
+type CloseProps = DOMElement<HTMLButtonElement>;
 
 export type { Props, CloseProps, ArrowProps, ContentProps, TriggerProps };

--- a/src/lib/bits/popover/components/popover-arrow.svelte
+++ b/src/lib/bits/popover/components/popover-arrow.svelte
@@ -6,6 +6,7 @@
 	type $$Props = ArrowProps;
 
 	export let asChild: $$Props["asChild"] = false;
+	export let el: $$Props["el"] = undefined;
 	export let size = 8;
 
 	const {
@@ -21,5 +22,5 @@
 {#if asChild}
 	<slot {builder} />
 {:else}
-	<div use:melt={builder} {...$$restProps} />
+	<div bind:this={el} use:melt={builder} {...$$restProps} />
 {/if}

--- a/src/lib/bits/popover/components/popover-close.svelte
+++ b/src/lib/bits/popover/components/popover-close.svelte
@@ -8,6 +8,7 @@
 	type $$Events = CloseEvents;
 
 	export let asChild: $$Props["asChild"] = false;
+	export let el: $$Props["el"] = undefined;
 
 	const {
 		elements: { close }
@@ -24,6 +25,7 @@
 	<slot {builder} />
 {:else}
 	<button
+		bind:this={el}
 		use:melt={builder}
 		type="button"
 		{...$$restProps}

--- a/src/lib/bits/popover/components/popover-content.svelte
+++ b/src/lib/bits/popover/components/popover-content.svelte
@@ -27,6 +27,7 @@
 	export let collisionBoundary: $$Props["collisionBoundary"] = undefined;
 	export let sameWidth: $$Props["sameWidth"] = false;
 	export let fitViewport: $$Props["fitViewport"] = false;
+	export let el: $$Props["el"] = undefined;
 
 	const {
 		elements: { content },
@@ -59,6 +60,7 @@
 	<slot {builder} />
 {:else if transition && $open}
 	<div
+		bind:this={el}
 		transition:transition={transitionConfig}
 		use:melt={builder}
 		{...$$restProps}
@@ -67,6 +69,7 @@
 	</div>
 {:else if inTransition && outTransition && $open}
 	<div
+		bind:this={el}
 		in:inTransition={inTransitionConfig}
 		out:outTransition={outTransitionConfig}
 		use:melt={builder}
@@ -75,11 +78,17 @@
 		<slot {builder} />
 	</div>
 {:else if inTransition && $open}
-	<div in:inTransition={inTransitionConfig} use:melt={builder} {...$$restProps}>
+	<div
+		bind:this={el}
+		in:inTransition={inTransitionConfig}
+		use:melt={builder}
+		{...$$restProps}
+	>
 		<slot {builder} />
 	</div>
 {:else if outTransition && $open}
 	<div
+		bind:this={el}
 		out:outTransition={outTransitionConfig}
 		use:melt={builder}
 		{...$$restProps}
@@ -87,7 +96,7 @@
 		<slot {builder} />
 	</div>
 {:else if $open}
-	<div use:melt={builder} {...$$restProps}>
+	<div bind:this={el} use:melt={builder} {...$$restProps}>
 		<slot {builder} />
 	</div>
 {/if}

--- a/src/lib/bits/popover/components/popover-trigger.svelte
+++ b/src/lib/bits/popover/components/popover-trigger.svelte
@@ -9,6 +9,7 @@
 
 	export let asChild: $$Props["asChild"] = false;
 	export let id: $$Props["id"] = undefined;
+	export let el: $$Props["el"] = undefined;
 
 	const {
 		elements: { trigger },
@@ -29,6 +30,7 @@
 	<slot {builder} />
 {:else}
 	<button
+		bind:this={el}
 		use:melt={builder}
 		type="button"
 		{...$$restProps}

--- a/src/lib/bits/popover/types.ts
+++ b/src/lib/bits/popover/types.ts
@@ -1,4 +1,4 @@
-import type { HTMLDivAttributes } from "$lib/internal/index.js";
+import type { DOMEl, HTMLDivAttributes } from "$lib/internal/index.js";
 import type { CustomEventHandler } from "$lib/index.js";
 import type { HTMLButtonAttributes } from "svelte/elements";
 import type * as I from "./_types.js";
@@ -6,11 +6,11 @@ import type { ContentProps } from "$lib/bits/floating/types.js";
 
 type Props = I.Props;
 
-type TriggerProps = I.TriggerProps & HTMLButtonAttributes;
+type TriggerProps = I.TriggerProps & HTMLButtonAttributes & DOMEl<HTMLButtonElement>;
 
-type CloseProps = I.ContentProps & HTMLButtonAttributes;
+type CloseProps = I.ContentProps & HTMLButtonAttributes & DOMEl<HTMLButtonElement>;
 
-type ArrowProps = I.ArrowProps & HTMLDivAttributes;
+type ArrowProps = I.ArrowProps & HTMLDivAttributes & DOMEl<HTMLDivElement>;
 
 type TriggerEvents<T extends Element = HTMLButtonElement> = {
 	click: CustomEventHandler<MouseEvent, T>;

--- a/src/lib/bits/popover/types.ts
+++ b/src/lib/bits/popover/types.ts
@@ -10,7 +10,7 @@ type TriggerProps = I.TriggerProps & HTMLButtonAttributes & DOMEl<HTMLButtonElem
 
 type CloseProps = I.ContentProps & HTMLButtonAttributes & DOMEl<HTMLButtonElement>;
 
-type ArrowProps = I.ArrowProps & HTMLDivAttributes & DOMEl<HTMLDivElement>;
+type ArrowProps = I.ArrowProps & HTMLDivAttributes & DOMEl;
 
 type TriggerEvents<T extends Element = HTMLButtonElement> = {
 	click: CustomEventHandler<MouseEvent, T>;

--- a/src/lib/bits/popover/types.ts
+++ b/src/lib/bits/popover/types.ts
@@ -1,4 +1,4 @@
-import type { DOMEl, HTMLDivAttributes } from "$lib/internal/index.js";
+import type { HTMLDivAttributes } from "$lib/internal/index.js";
 import type { CustomEventHandler } from "$lib/index.js";
 import type { HTMLButtonAttributes } from "svelte/elements";
 import type * as I from "./_types.js";
@@ -6,11 +6,11 @@ import type { ContentProps } from "$lib/bits/floating/types.js";
 
 type Props = I.Props;
 
-type TriggerProps = I.TriggerProps & HTMLButtonAttributes & DOMEl<HTMLButtonElement>;
+type TriggerProps = I.TriggerProps & HTMLButtonAttributes;
 
-type CloseProps = I.ContentProps & HTMLButtonAttributes & DOMEl<HTMLButtonElement>;
+type CloseProps = I.CloseProps & HTMLButtonAttributes;
 
-type ArrowProps = I.ArrowProps & HTMLDivAttributes & DOMEl;
+type ArrowProps = I.ArrowProps & HTMLDivAttributes;
 
 type TriggerEvents<T extends Element = HTMLButtonElement> = {
 	click: CustomEventHandler<MouseEvent, T>;

--- a/src/lib/bits/progress/_types.ts
+++ b/src/lib/bits/progress/_types.ts
@@ -3,7 +3,7 @@
  * to type-check our API documentation, which requires we document each prop,
  * but we don't want to document the HTML attributes.
  */
-import type { AsChild, Expand, OmitValue, OnChangeFn } from "$lib/internal/index.js";
+import type { DOMElement, Expand, OmitValue, OnChangeFn } from "$lib/internal/index.js";
 import type { CreateProgressProps } from "@melt-ui/svelte";
 
 type Props = Expand<
@@ -18,7 +18,7 @@ type Props = Expand<
 		 * A callback function called when the value changes.
 		 */
 		onValueChange?: OnChangeFn<number>;
-	} & AsChild
+	} & DOMElement
 >;
 
 export type { Props };

--- a/src/lib/bits/progress/components/progress.svelte
+++ b/src/lib/bits/progress/components/progress.svelte
@@ -9,6 +9,7 @@
 	export let value: $$Props["value"] = undefined;
 	export let onValueChange: $$Props["onValueChange"] = undefined;
 	export let asChild: $$Props["asChild"] = false;
+	export let el: $$Props["el"] = undefined;
 
 	const {
 		elements: { root },
@@ -36,7 +37,7 @@
 {#if asChild}
 	<slot {builder} />
 {:else}
-	<div use:melt={builder} {...$$restProps}>
+	<div bind:this={el} use:melt={builder} {...$$restProps}>
 		<slot {builder} />
 	</div>
 {/if}

--- a/src/lib/bits/progress/types.ts
+++ b/src/lib/bits/progress/types.ts
@@ -1,6 +1,6 @@
 import type { DOMEl, HTMLDivAttributes } from "$lib/internal/index.js";
 import type * as I from "./_types.js";
 
-type Props = I.Props & HTMLDivAttributes & DOMEl<HTMLDivElement>;
+type Props = I.Props & HTMLDivAttributes & DOMEl;
 
 export type { Props };

--- a/src/lib/bits/progress/types.ts
+++ b/src/lib/bits/progress/types.ts
@@ -1,6 +1,6 @@
-import type { DOMEl, HTMLDivAttributes } from "$lib/internal/index.js";
+import type { HTMLDivAttributes } from "$lib/internal/index.js";
 import type * as I from "./_types.js";
 
-type Props = I.Props & HTMLDivAttributes & DOMEl;
+type Props = I.Props & HTMLDivAttributes;
 
 export type { Props };

--- a/src/lib/bits/progress/types.ts
+++ b/src/lib/bits/progress/types.ts
@@ -1,6 +1,6 @@
-import type { HTMLDivAttributes } from "$lib/internal/index.js";
+import type { DOMEl, HTMLDivAttributes } from "$lib/internal/index.js";
 import type * as I from "./_types.js";
 
-type Props = I.Props & HTMLDivAttributes;
+type Props = I.Props & HTMLDivAttributes & DOMEl<HTMLDivElement>;
 
 export type { Props };

--- a/src/lib/bits/radio-group/_types.ts
+++ b/src/lib/bits/radio-group/_types.ts
@@ -8,7 +8,7 @@ import type {
 	OmitValue,
 	OnChangeFn,
 	ObjectVariation,
-	AsChild
+	DOMElement
 } from "$lib/internal/index.js";
 import type { CreateRadioGroupProps, RadioGroupItemProps } from "@melt-ui/svelte";
 
@@ -26,13 +26,13 @@ type Props = Expand<
 		 * A callback function called when the value changes.
 		 */
 		onValueChange?: OnChangeFn<CreateRadioGroupProps["defaultValue"] & {}>;
-	} & AsChild
+	} & DOMElement
 >;
 
-type InputProps = AsChild;
+type InputProps = DOMElement<HTMLInputElement>;
 
-type ItemProps = Expand<ObjectVariation<RadioGroupItemProps> & AsChild>;
+type ItemProps = Expand<ObjectVariation<RadioGroupItemProps> & DOMElement<HTMLButtonElement>>;
 
-type ItemIndicatorProps = AsChild;
+type ItemIndicatorProps = DOMElement;
 
 export type { Props, InputProps, ItemProps, ItemIndicatorProps };

--- a/src/lib/bits/radio-group/components/radio-group-input.svelte
+++ b/src/lib/bits/radio-group/components/radio-group-input.svelte
@@ -6,6 +6,7 @@
 	type $$Props = InputProps;
 
 	export let asChild: $$Props["asChild"] = false;
+	export let el: $$Props["el"] = undefined;
 
 	const {
 		elements: { hiddenInput }
@@ -20,5 +21,5 @@
 {#if asChild}
 	<slot {builder} />
 {:else}
-	<input use:melt={builder} {...$$restProps} />
+	<input bind:this={el} use:melt={builder} {...$$restProps} />
 {/if}

--- a/src/lib/bits/radio-group/components/radio-group-item-indicator.svelte
+++ b/src/lib/bits/radio-group/components/radio-group-item-indicator.svelte
@@ -5,6 +5,7 @@
 	type $$Props = ItemIndicatorProps;
 
 	export let asChild = false;
+	export let el: $$Props["el"] = undefined;
 
 	const { isChecked, value } = getRadioIndicator();
 
@@ -15,7 +16,7 @@
 {#if asChild}
 	<slot {checked} {attrs} />
 {:else}
-	<div {...attrs} {...$$restProps}>
+	<div bind:this={el} {...attrs} {...$$restProps}>
 		{#if checked}
 			<slot {checked} {attrs} />
 		{/if}

--- a/src/lib/bits/radio-group/components/radio-group-item.svelte
+++ b/src/lib/bits/radio-group/components/radio-group-item.svelte
@@ -10,6 +10,7 @@
 	export let value: $$Props["value"];
 	export let disabled: $$Props["disabled"] = false;
 	export let asChild: $$Props["asChild"] = false;
+	export let el: $$Props["el"] = undefined;
 
 	const {
 		elements: { item }
@@ -26,6 +27,7 @@
 	<slot {builder} />
 {:else}
 	<button
+		bind:this={el}
 		use:melt={builder}
 		type="button"
 		{...$$restProps}

--- a/src/lib/bits/radio-group/components/radio-group.svelte
+++ b/src/lib/bits/radio-group/components/radio-group.svelte
@@ -11,6 +11,7 @@
 	export let loop: $$Props["loop"] = undefined;
 	export let orientation: $$Props["orientation"] = undefined;
 	export let asChild: $$Props["asChild"] = false;
+	export let el: $$Props["el"] = undefined;
 
 	const {
 		elements: { root },
@@ -46,7 +47,7 @@
 {#if asChild}
 	<slot {builder} />
 {:else}
-	<div use:melt={builder} {...$$restProps}>
+	<div bind:this={el} use:melt={builder} {...$$restProps}>
 		<slot {builder} />
 	</div>
 {/if}

--- a/src/lib/bits/radio-group/types.ts
+++ b/src/lib/bits/radio-group/types.ts
@@ -1,15 +1,15 @@
-import type { DOMEl, HTMLDivAttributes } from "$lib/internal/index.js";
+import type { HTMLDivAttributes } from "$lib/internal/index.js";
 import type { CustomEventHandler } from "$lib/index.js";
 import type { HTMLButtonAttributes, HTMLInputAttributes } from "svelte/elements";
 import type * as I from "./_types.js";
 
-type Props = I.Props & HTMLDivAttributes & DOMEl;
+type Props = I.Props & HTMLDivAttributes;
 
-type InputProps = I.InputProps & HTMLInputAttributes & DOMEl<HTMLInputElement>;
+type InputProps = I.InputProps & HTMLInputAttributes;
 
-type ItemProps = I.ItemProps & HTMLButtonAttributes & DOMEl<HTMLButtonElement>;
+type ItemProps = I.ItemProps & HTMLButtonAttributes;
 
-type ItemIndicatorProps = I.ItemIndicatorProps & HTMLDivAttributes & DOMEl;
+type ItemIndicatorProps = I.ItemIndicatorProps & HTMLDivAttributes;
 
 type ItemEvents<T extends Element = HTMLButtonElement> = {
 	click: CustomEventHandler<MouseEvent, T>;

--- a/src/lib/bits/radio-group/types.ts
+++ b/src/lib/bits/radio-group/types.ts
@@ -1,15 +1,15 @@
-import type { HTMLDivAttributes } from "$lib/internal/index.js";
+import type { DOMEl, HTMLDivAttributes } from "$lib/internal/index.js";
 import type { CustomEventHandler } from "$lib/index.js";
 import type { HTMLButtonAttributes, HTMLInputAttributes } from "svelte/elements";
 import type * as I from "./_types.js";
 
-type Props = I.Props & HTMLDivAttributes;
+type Props = I.Props & HTMLDivAttributes & DOMEl<HTMLDivElement>;
 
-type InputProps = I.InputProps & HTMLInputAttributes;
+type InputProps = I.InputProps & HTMLInputAttributes & DOMEl<HTMLInputElement>;
 
-type ItemProps = I.ItemProps & HTMLButtonAttributes;
+type ItemProps = I.ItemProps & HTMLButtonAttributes & DOMEl<HTMLButtonElement>;
 
-type ItemIndicatorProps = I.ItemIndicatorProps & HTMLDivAttributes;
+type ItemIndicatorProps = I.ItemIndicatorProps & HTMLDivAttributes & DOMEl<HTMLDivElement>;
 
 type ItemEvents<T extends Element = HTMLButtonElement> = {
 	click: CustomEventHandler<MouseEvent, T>;

--- a/src/lib/bits/radio-group/types.ts
+++ b/src/lib/bits/radio-group/types.ts
@@ -3,13 +3,13 @@ import type { CustomEventHandler } from "$lib/index.js";
 import type { HTMLButtonAttributes, HTMLInputAttributes } from "svelte/elements";
 import type * as I from "./_types.js";
 
-type Props = I.Props & HTMLDivAttributes & DOMEl<HTMLDivElement>;
+type Props = I.Props & HTMLDivAttributes & DOMEl;
 
 type InputProps = I.InputProps & HTMLInputAttributes & DOMEl<HTMLInputElement>;
 
 type ItemProps = I.ItemProps & HTMLButtonAttributes & DOMEl<HTMLButtonElement>;
 
-type ItemIndicatorProps = I.ItemIndicatorProps & HTMLDivAttributes & DOMEl<HTMLDivElement>;
+type ItemIndicatorProps = I.ItemIndicatorProps & HTMLDivAttributes & DOMEl;
 
 type ItemEvents<T extends Element = HTMLButtonElement> = {
 	click: CustomEventHandler<MouseEvent, T>;

--- a/src/lib/bits/range-calendar/_types.ts
+++ b/src/lib/bits/range-calendar/_types.ts
@@ -4,7 +4,7 @@
  * but we don't want to document the HTML attributes.
  */
 
-import type { AsChild, OnChangeFn } from "$lib/internal/index.js";
+import type { DOMElement, OnChangeFn } from "$lib/internal/index.js";
 import type { DateRange } from "$lib/shared/index.js";
 import type { DateValue } from "@internationalized/date";
 import type { CreateRangeCalendarProps } from "@melt-ui/svelte";
@@ -75,44 +75,42 @@ type Props = Expand<
 		 * the `value` is set.
 		 */
 		startValue?: DateValue | undefined;
-	} & AsChild
+	} & DOMElement
 >;
 
-type PrevButtonProps = AsChild;
+type PrevButtonProps = DOMElement<HTMLButtonElement>;
 
-type NextButtonProps = AsChild;
+type NextButtonProps = DOMElement<HTMLButtonElement>;
 
-type HeadingProps = AsChild;
+type HeadingProps = DOMElement;
 
-type HeaderProps = AsChild;
+type HeaderProps = DOMElement<HTMLElement>;
 
-type GridHeadProps = AsChild;
+type GridHeadProps = DOMElement<HTMLTableSectionElement>;
 
-type HeadCellProps = AsChild;
+type HeadCellProps = DOMElement<HTMLTableCellElement>;
 
-type GridProps = AsChild;
+type GridProps = DOMElement<HTMLTableElement>;
 
-type GridBodyProps = AsChild;
+type GridBodyProps = DOMElement<HTMLTableSectionElement>;
 
-type GridRowProps = AsChild;
+type GridRowProps = DOMElement<HTMLTableRowElement>;
 
-type BaseDayProps = Expand<
-	{
-		/**
-		 * The date value of the cell.
-		 */
-		date: DateValue;
+type BaseDayProps = Expand<{
+	/**
+	 * The date value of the cell.
+	 */
+	date: DateValue;
 
-		/**
-		 * The month value that the cell belongs to.
-		 */
-		month: DateValue;
-	} & AsChild
->;
+	/**
+	 * The month value that the cell belongs to.
+	 */
+	month: DateValue;
+}>;
 
-type CellProps = Expand<Omit<BaseDayProps, "month">>;
+type CellProps = Expand<Omit<BaseDayProps, "month"> & DOMElement<HTMLTableCellElement>>;
 
-type DayProps = Expand<BaseDayProps>;
+type DayProps = Expand<BaseDayProps & DOMElement>;
 
 export type {
 	Props,

--- a/src/lib/bits/range-calendar/components/range-calendar-cell.svelte
+++ b/src/lib/bits/range-calendar/components/range-calendar-cell.svelte
@@ -6,6 +6,7 @@
 
 	export let date: $$Props["date"];
 	export let asChild: $$Props["asChild"] = false;
+	export let el: $$Props["el"] = undefined;
 
 	const {
 		helpers: { isDateDisabled, isDateUnavailable }
@@ -21,7 +22,7 @@
 {#if asChild}
 	<slot {attrs} />
 {:else}
-	<td {...$$restProps} {...attrs}>
+	<td bind:this={el} {...$$restProps} {...attrs}>
 		<slot {attrs} />
 	</td>
 {/if}

--- a/src/lib/bits/range-calendar/components/range-calendar-day.svelte
+++ b/src/lib/bits/range-calendar/components/range-calendar-day.svelte
@@ -10,6 +10,7 @@
 	export let date: $$Props["date"];
 	export let month: $$Props["month"];
 	export let asChild: $$Props["asChild"] = false;
+	export let el: $$Props["el"] = undefined;
 
 	const {
 		elements: { cell },
@@ -29,6 +30,7 @@
 	<slot {builder} {disabled} {unavailable} />
 {:else}
 	<div
+		bind:this={el}
 		use:melt={builder}
 		{...$$restProps}
 		on:m-click={dispatch}

--- a/src/lib/bits/range-calendar/components/range-calendar-grid-body.svelte
+++ b/src/lib/bits/range-calendar/components/range-calendar-grid-body.svelte
@@ -4,6 +4,7 @@
 
 	type $$Props = GridBodyProps;
 	export let asChild: $$Props["asChild"] = false;
+	export let el: $$Props["el"] = undefined;
 
 	const attrs = getAttrs("grid-body");
 </script>
@@ -11,7 +12,7 @@
 {#if asChild}
 	<slot {attrs} />
 {:else}
-	<tbody {...$$restProps} {...attrs}>
+	<tbody bind:this={el} {...$$restProps} {...attrs}>
 		<slot />
 	</tbody>
 {/if}

--- a/src/lib/bits/range-calendar/components/range-calendar-grid-head.svelte
+++ b/src/lib/bits/range-calendar/components/range-calendar-grid-head.svelte
@@ -4,6 +4,7 @@
 
 	type $$Props = GridHeadProps;
 	export let asChild: $$Props["asChild"] = false;
+	export let el: $$Props["el"] = undefined;
 
 	const attrs = { ...getAttrs("grid-head"), "aria-hidden": true };
 </script>
@@ -11,7 +12,7 @@
 {#if asChild}
 	<slot {attrs} />
 {:else}
-	<thead {...$$restProps} {...attrs}>
+	<thead bind:this={el} {...$$restProps} {...attrs}>
 		<slot />
 	</thead>
 {/if}

--- a/src/lib/bits/range-calendar/components/range-calendar-grid-row.svelte
+++ b/src/lib/bits/range-calendar/components/range-calendar-grid-row.svelte
@@ -5,6 +5,7 @@
 	type $$Props = GridRowProps;
 
 	export let asChild: $$Props["asChild"] = false;
+	export let el: $$Props["el"] = undefined;
 
 	const attrs = getAttrs("grid-row");
 </script>
@@ -12,7 +13,7 @@
 {#if asChild}
 	<slot {attrs} />
 {:else}
-	<tr {...$$restProps} {...attrs}>
+	<tr bind:this={el} {...$$restProps} {...attrs}>
 		<slot {attrs} />
 	</tr>
 {/if}

--- a/src/lib/bits/range-calendar/components/range-calendar-grid.svelte
+++ b/src/lib/bits/range-calendar/components/range-calendar-grid.svelte
@@ -6,6 +6,7 @@
 	type $$Props = GridProps;
 
 	export let asChild: $$Props["asChild"] = false;
+	export let el: $$Props["el"] = undefined;
 
 	const {
 		elements: { grid }
@@ -19,7 +20,7 @@
 {#if asChild}
 	<slot {builder} />
 {:else}
-	<table use:melt={builder} {...$$restProps}>
+	<table bind:this={el} use:melt={builder} {...$$restProps}>
 		<slot {builder} />
 	</table>
 {/if}

--- a/src/lib/bits/range-calendar/components/range-calendar-head-cell.svelte
+++ b/src/lib/bits/range-calendar/components/range-calendar-head-cell.svelte
@@ -4,6 +4,7 @@
 
 	type $$Props = HeadCellProps;
 	export let asChild: $$Props["asChild"] = false;
+	export let el: $$Props["el"] = undefined;
 
 	const attrs = getAttrs("head-cell");
 </script>
@@ -11,7 +12,7 @@
 {#if asChild}
 	<slot {attrs} />
 {:else}
-	<th {...$$restProps} {...attrs}>
+	<th bind:this={el} {...$$restProps} {...attrs}>
 		<slot />
 	</th>
 {/if}

--- a/src/lib/bits/range-calendar/components/range-calendar-header.svelte
+++ b/src/lib/bits/range-calendar/components/range-calendar-header.svelte
@@ -1,8 +1,10 @@
 <script lang="ts">
 	import { getAttrs } from "../ctx.js";
 	import type { HeaderProps } from "../types.js";
+
 	type $$Props = HeaderProps;
 	export let asChild: $$Props["asChild"] = false;
+	export let el: $$Props["el"] = undefined;
 
 	const attrs = getAttrs("header");
 </script>
@@ -10,7 +12,7 @@
 {#if asChild}
 	<slot {attrs} />
 {:else}
-	<header {...$$restProps} {...attrs}>
+	<header bind:this={el} {...$$restProps} {...attrs}>
 		<slot {attrs} />
 	</header>
 {/if}

--- a/src/lib/bits/range-calendar/components/range-calendar-heading.svelte
+++ b/src/lib/bits/range-calendar/components/range-calendar-heading.svelte
@@ -6,6 +6,7 @@
 	type $$Props = HeadingProps;
 
 	export let asChild: $$Props["asChild"] = false;
+	export let el: $$Props["el"] = undefined;
 
 	const {
 		elements: { heading },
@@ -21,7 +22,7 @@
 {#if asChild}
 	<slot {builder} headingValue={$headingValue} />
 {:else}
-	<div use:melt={builder} {...$$restProps}>
+	<div bind:this={el} use:melt={builder} {...$$restProps}>
 		<slot {builder} headingValue={$headingValue}>
 			{$headingValue}
 		</slot>

--- a/src/lib/bits/range-calendar/components/range-calendar-next-button.svelte
+++ b/src/lib/bits/range-calendar/components/range-calendar-next-button.svelte
@@ -8,6 +8,7 @@
 	type $$Events = NextButtonEvents;
 
 	export let asChild: $$Props["asChild"] = false;
+	export let el: $$Props["el"] = undefined;
 
 	const {
 		elements: { nextButton }
@@ -24,6 +25,7 @@
 	<slot {builder} />
 {:else}
 	<button
+		bind:this={el}
 		use:melt={builder}
 		type="button"
 		{...$$restProps}

--- a/src/lib/bits/range-calendar/components/range-calendar-prev-button.svelte
+++ b/src/lib/bits/range-calendar/components/range-calendar-prev-button.svelte
@@ -8,6 +8,7 @@
 	type $$Events = PrevButtonEvents;
 
 	export let asChild: $$Props["asChild"] = false;
+	export let el: $$Props["el"] = undefined;
 
 	const {
 		elements: { prevButton }
@@ -24,6 +25,7 @@
 	<slot {builder} />
 {:else}
 	<button
+		bind:this={el}
 		use:melt={builder}
 		type="button"
 		{...$$restProps}

--- a/src/lib/bits/range-calendar/components/range-calendar.svelte
+++ b/src/lib/bits/range-calendar/components/range-calendar.svelte
@@ -32,8 +32,7 @@
 	export let initialFocus: $$Props["initialFocus"] = false;
 	export let startValue: $$Props["startValue"] = undefined;
 	export let numberOfMonths: $$Props["numberOfMonths"] = undefined;
-
-	let el: HTMLElement | undefined = undefined;
+	export let el: $$Props["el"] = undefined;
 
 	onMount(() => {
 		if (!initialFocus || !el) return;

--- a/src/lib/bits/range-calendar/types.ts
+++ b/src/lib/bits/range-calendar/types.ts
@@ -21,13 +21,19 @@ type HeaderProps = I.HeaderProps & HTMLDivAttributes & DOMEl;
 
 type GridProps = I.GridProps & HTMLTableAttributes & DOMEl<HTMLTableElement>;
 
-type GridHeadProps = I.GridHeadProps & HTMLAttributes<HTMLTableSectionElement> & DOMEl<HTMLTableSectionElement>;
+type GridHeadProps = I.GridHeadProps &
+	HTMLAttributes<HTMLTableSectionElement> &
+	DOMEl<HTMLTableSectionElement>;
 
 type HeadCellProps = I.HeadCellProps & HTMLThAttributes & DOMEl<HTMLTableCellElement>;
 
-type GridBodyProps = I.GridBodyProps & HTMLAttributes<HTMLTableSectionElement> & DOMEl<HTMLTableSectionElement>;
+type GridBodyProps = I.GridBodyProps &
+	HTMLAttributes<HTMLTableSectionElement> &
+	DOMEl<HTMLTableSectionElement>;
 
-type GridRowProps = I.GridRowProps & HTMLAttributes<HTMLTableRowElement> & DOMEl<HTMLTableRowElement>;
+type GridRowProps = I.GridRowProps &
+	HTMLAttributes<HTMLTableRowElement> &
+	DOMEl<HTMLTableRowElement>;
 
 type CellProps = I.CellProps & HTMLTdAttributes & DOMEl<HTMLTableCellElement>;
 

--- a/src/lib/bits/range-calendar/types.ts
+++ b/src/lib/bits/range-calendar/types.ts
@@ -1,4 +1,4 @@
-import type { HTMLDivAttributes } from "$lib/internal";
+import type { DOMEl, HTMLDivAttributes } from "$lib/internal";
 import type {
 	HTMLAttributes,
 	HTMLButtonAttributes,
@@ -9,29 +9,29 @@ import type {
 import type * as I from "./_types.js";
 import type { CustomEventHandler } from "$lib";
 
-type Props = I.Props & Omit<HTMLDivAttributes, "placeholder">;
+type Props = I.Props & Omit<HTMLDivAttributes, "placeholder"> & DOMEl<HTMLDivElement>;
 
-type PrevButtonProps = I.PrevButtonProps & HTMLButtonAttributes;
+type PrevButtonProps = I.PrevButtonProps & HTMLButtonAttributes & DOMEl<HTMLButtonElement>;
 
-type NextButtonProps = I.NextButtonProps & HTMLButtonAttributes;
+type NextButtonProps = I.NextButtonProps & HTMLButtonAttributes & DOMEl<HTMLButtonElement>;
 
-type HeadingProps = I.HeadingProps & HTMLDivAttributes;
+type HeadingProps = I.HeadingProps & HTMLDivAttributes & DOMEl<HTMLDivElement>;
 
-type HeaderProps = I.HeaderProps & HTMLDivAttributes;
+type HeaderProps = I.HeaderProps & HTMLDivAttributes & DOMEl;
 
-type GridProps = I.GridProps & HTMLTableAttributes;
+type GridProps = I.GridProps & HTMLTableAttributes & DOMEl<HTMLTableElement>;
 
-type GridHeadProps = I.GridHeadProps & HTMLAttributes<HTMLTableSectionElement>;
+type GridHeadProps = I.GridHeadProps & HTMLAttributes<HTMLTableSectionElement> & DOMEl<HTMLTableSectionElement>;
 
-type HeadCellProps = I.HeadCellProps & HTMLThAttributes;
+type HeadCellProps = I.HeadCellProps & HTMLThAttributes & DOMEl<HTMLTableCellElement>;
 
-type GridBodyProps = I.GridBodyProps & HTMLAttributes<HTMLTableSectionElement>;
+type GridBodyProps = I.GridBodyProps & HTMLAttributes<HTMLTableSectionElement> & DOMEl<HTMLTableSectionElement>;
 
-type GridRowProps = I.GridRowProps & HTMLAttributes<HTMLTableRowElement>;
+type GridRowProps = I.GridRowProps & HTMLAttributes<HTMLTableRowElement> & DOMEl<HTMLTableRowElement>;
 
-type CellProps = I.CellProps & HTMLTdAttributes;
+type CellProps = I.CellProps & HTMLTdAttributes & DOMEl<HTMLTableCellElement>;
 
-type DayProps = I.DayProps & HTMLDivAttributes;
+type DayProps = I.DayProps & HTMLDivAttributes & DOMEl<HTMLDivElement>;
 
 /**
  * Events

--- a/src/lib/bits/range-calendar/types.ts
+++ b/src/lib/bits/range-calendar/types.ts
@@ -1,4 +1,4 @@
-import type { DOMEl, HTMLDivAttributes } from "$lib/internal";
+import type { HTMLDivAttributes } from "$lib/internal";
 import type {
 	HTMLAttributes,
 	HTMLButtonAttributes,
@@ -9,35 +9,29 @@ import type {
 import type * as I from "./_types.js";
 import type { CustomEventHandler } from "$lib";
 
-type Props = I.Props & Omit<HTMLDivAttributes, "placeholder"> & DOMEl;
+type Props = I.Props & Omit<HTMLDivAttributes, "placeholder">;
 
-type PrevButtonProps = I.PrevButtonProps & HTMLButtonAttributes & DOMEl<HTMLButtonElement>;
+type PrevButtonProps = I.PrevButtonProps & HTMLButtonAttributes;
 
-type NextButtonProps = I.NextButtonProps & HTMLButtonAttributes & DOMEl<HTMLButtonElement>;
+type NextButtonProps = I.NextButtonProps & HTMLButtonAttributes;
 
-type HeadingProps = I.HeadingProps & HTMLDivAttributes & DOMEl;
+type HeadingProps = I.HeadingProps & HTMLDivAttributes;
 
-type HeaderProps = I.HeaderProps & HTMLDivAttributes & DOMEl<Element>;
+type HeaderProps = I.HeaderProps & HTMLDivAttributes;
 
-type GridProps = I.GridProps & HTMLTableAttributes & DOMEl<HTMLTableElement>;
+type GridProps = I.GridProps & HTMLTableAttributes;
 
-type GridHeadProps = I.GridHeadProps &
-	HTMLAttributes<HTMLTableSectionElement> &
-	DOMEl<HTMLTableSectionElement>;
+type GridHeadProps = I.GridHeadProps & HTMLAttributes<HTMLTableSectionElement>;
 
-type HeadCellProps = I.HeadCellProps & HTMLThAttributes & DOMEl<HTMLTableCellElement>;
+type HeadCellProps = I.HeadCellProps & HTMLThAttributes;
 
-type GridBodyProps = I.GridBodyProps &
-	HTMLAttributes<HTMLTableSectionElement> &
-	DOMEl<HTMLTableSectionElement>;
+type GridBodyProps = I.GridBodyProps & HTMLAttributes<HTMLTableSectionElement>;
 
-type GridRowProps = I.GridRowProps &
-	HTMLAttributes<HTMLTableRowElement> &
-	DOMEl<HTMLTableRowElement>;
+type GridRowProps = I.GridRowProps & HTMLAttributes<HTMLTableRowElement>;
 
-type CellProps = I.CellProps & HTMLTdAttributes & DOMEl<HTMLTableCellElement>;
+type CellProps = I.CellProps & HTMLTdAttributes;
 
-type DayProps = I.DayProps & HTMLDivAttributes & DOMEl;
+type DayProps = I.DayProps & HTMLDivAttributes;
 
 /**
  * Events

--- a/src/lib/bits/range-calendar/types.ts
+++ b/src/lib/bits/range-calendar/types.ts
@@ -9,15 +9,15 @@ import type {
 import type * as I from "./_types.js";
 import type { CustomEventHandler } from "$lib";
 
-type Props = I.Props & Omit<HTMLDivAttributes, "placeholder"> & DOMEl<HTMLDivElement>;
+type Props = I.Props & Omit<HTMLDivAttributes, "placeholder"> & DOMEl;
 
 type PrevButtonProps = I.PrevButtonProps & HTMLButtonAttributes & DOMEl<HTMLButtonElement>;
 
 type NextButtonProps = I.NextButtonProps & HTMLButtonAttributes & DOMEl<HTMLButtonElement>;
 
-type HeadingProps = I.HeadingProps & HTMLDivAttributes & DOMEl<HTMLDivElement>;
+type HeadingProps = I.HeadingProps & HTMLDivAttributes & DOMEl;
 
-type HeaderProps = I.HeaderProps & HTMLDivAttributes & DOMEl;
+type HeaderProps = I.HeaderProps & HTMLDivAttributes & DOMEl<Element>;
 
 type GridProps = I.GridProps & HTMLTableAttributes & DOMEl<HTMLTableElement>;
 
@@ -37,7 +37,7 @@ type GridRowProps = I.GridRowProps &
 
 type CellProps = I.CellProps & HTMLTdAttributes & DOMEl<HTMLTableCellElement>;
 
-type DayProps = I.DayProps & HTMLDivAttributes & DOMEl<HTMLDivElement>;
+type DayProps = I.DayProps & HTMLDivAttributes & DOMEl;
 
 /**
  * Events

--- a/src/lib/bits/select/_types.ts
+++ b/src/lib/bits/select/_types.ts
@@ -4,7 +4,7 @@
  * but we don't want to document the HTML attributes.
  */
 import type { CreateSelectProps, SelectOptionProps } from "@melt-ui/svelte";
-import type { AsChild, Expand, OmitFloating, OnChangeFn } from "$lib/internal/index.js";
+import type { DOMElement, Expand, OmitFloating, OnChangeFn } from "$lib/internal/index.js";
 import type { ContentProps, ArrowProps } from "$lib/bits/floating/_types.js";
 import type { Selected } from "$lib";
 
@@ -61,15 +61,15 @@ type Props<T = unknown, Multiple extends boolean = false> = Expand<
 	}
 >;
 
-type GroupProps = AsChild;
-type InputProps = AsChild;
-type LabelProps = AsChild;
-type ItemProps = Expand<SelectOptionProps & AsChild>;
-type SeparatorProps = AsChild;
+type GroupProps = DOMElement;
+type InputProps = DOMElement<HTMLInputElement>;
+type LabelProps = DOMElement;
+type ItemProps = Expand<SelectOptionProps & DOMElement>;
+type SeparatorProps = DOMElement;
 
-type IndicatorProps = AsChild;
+type IndicatorProps = DOMElement;
 
-type TriggerProps = AsChild;
+type TriggerProps = DOMElement<HTMLButtonElement>;
 
 type ValueProps = Expand<
 	{
@@ -79,7 +79,7 @@ type ValueProps = Expand<
 		 * @defaultValue ""
 		 */
 		placeholder?: string;
-	} & AsChild
+	} & DOMElement<HTMLSpanElement>
 >;
 
 export type {

--- a/src/lib/bits/select/components/select-arrow.svelte
+++ b/src/lib/bits/select/components/select-arrow.svelte
@@ -6,6 +6,7 @@
 	type $$Props = ArrowProps;
 
 	export let asChild: $$Props["asChild"] = false;
+	export let el: $$Props["el"] = undefined;
 	export let size = 8;
 
 	const {
@@ -21,5 +22,5 @@
 {#if asChild}
 	<slot {builder} />
 {:else}
-	<div use:melt={builder} {...$$restProps} />
+	<div bind:this={el} use:melt={builder} {...$$restProps} />
 {/if}

--- a/src/lib/bits/select/components/select-content.svelte
+++ b/src/lib/bits/select/components/select-content.svelte
@@ -29,6 +29,7 @@
 	export let collisionBoundary: $$Props["collisionBoundary"] = undefined;
 	export let sameWidth: $$Props["sameWidth"] = true;
 	export let fitViewport: $$Props["fitViewport"] = false;
+	export let el: $$Props["el"] = undefined;
 
 	const {
 		elements: { menu },
@@ -64,6 +65,7 @@
 	<slot {builder} />
 {:else if transition && $open}
 	<div
+		bind:this={el}
 		transition:transition={transitionConfig}
 		use:melt={builder}
 		{...$$restProps}
@@ -74,6 +76,7 @@
 	</div>
 {:else if inTransition && outTransition && $open}
 	<div
+		bind:this={el}
 		in:inTransition={inTransitionConfig}
 		out:outTransition={outTransitionConfig}
 		use:melt={builder}
@@ -85,6 +88,7 @@
 	</div>
 {:else if inTransition && $open}
 	<div
+		bind:this={el}
 		in:inTransition={inTransitionConfig}
 		use:melt={builder}
 		{...$$restProps}
@@ -95,6 +99,7 @@
 	</div>
 {:else if outTransition && $open}
 	<div
+		bind:this={el}
 		out:outTransition={outTransitionConfig}
 		use:melt={builder}
 		{...$$restProps}
@@ -105,6 +110,7 @@
 	</div>
 {:else if $open}
 	<div
+		bind:this={el}
 		use:melt={builder}
 		{...$$restProps}
 		on:m-pointerleave={dispatch}

--- a/src/lib/bits/select/components/select-group.svelte
+++ b/src/lib/bits/select/components/select-group.svelte
@@ -5,6 +5,7 @@
 
 	type $$Props = GroupProps;
 	export let asChild: $$Props["asChild"] = false;
+	export let el: $$Props["el"] = undefined;
 
 	const { group, id } = setGroupCtx();
 	const attrs = getAttrs("group");
@@ -16,7 +17,7 @@
 {#if asChild}
 	<slot {builder} />
 {:else}
-	<div use:melt={builder} {...$$restProps}>
+	<div bind:this={el} use:melt={builder} {...$$restProps}>
 		<slot {builder} />
 	</div>
 {/if}

--- a/src/lib/bits/select/components/select-input.svelte
+++ b/src/lib/bits/select/components/select-input.svelte
@@ -6,6 +6,7 @@
 	type $$Props = InputProps;
 
 	export let asChild: $$Props["asChild"] = false;
+	export let el: $$Props["el"] = undefined;
 
 	const {
 		elements: { hiddenInput },
@@ -24,5 +25,5 @@
 {#if asChild}
 	<slot {builder} />
 {:else}
-	<input use:melt={builder} {...$$restProps} />
+	<input bind:this={el} use:melt={builder} {...$$restProps} />
 {/if}

--- a/src/lib/bits/select/components/select-item-indicator.svelte
+++ b/src/lib/bits/select/components/select-item-indicator.svelte
@@ -5,6 +5,7 @@
 	type $$Props = IndicatorProps;
 
 	export let asChild: $$Props["asChild"] = false;
+	export let el: $$Props["el"] = undefined;
 
 	const { isSelected, value } = getItemIndicator();
 	const attrs = getAttrs("indicator");
@@ -13,7 +14,7 @@
 {#if asChild}
 	<slot {attrs} isSelected={$isSelected(value)} />
 {:else}
-	<div {...$$restProps} {...attrs}>
+	<div bind:this={el} {...$$restProps} {...attrs}>
 		{#if $isSelected(value)}
 			<slot {attrs} isSelected={$isSelected(value)} />
 		{/if}

--- a/src/lib/bits/select/components/select-item.svelte
+++ b/src/lib/bits/select/components/select-item.svelte
@@ -11,6 +11,7 @@
 	export let disabled: $$Props["disabled"] = undefined;
 	export let label: $$Props["label"] = undefined;
 	export let asChild: $$Props["asChild"] = false;
+	export let el: $$Props["el"] = undefined;
 
 	const {
 		elements: { option: item }
@@ -29,6 +30,7 @@
 	<slot {builder} />
 {:else}
 	<div
+		bind:this={el}
 		use:melt={builder}
 		{...$$restProps}
 		on:m-click={dispatch}

--- a/src/lib/bits/select/components/select-label.svelte
+++ b/src/lib/bits/select/components/select-label.svelte
@@ -8,6 +8,7 @@
 
 	export let asChild: $$Props["asChild"] = false;
 	export let id: $$Props["id"] = undefined;
+	export let el: $$Props["el"] = undefined;
 
 	const { ids } = getCtx();
 	const { groupLabel, id: groupId } = getGroupLabel();
@@ -23,7 +24,7 @@
 {#if asChild}
 	<slot {builder} />
 {:else}
-	<div use:melt={builder} {...$$restProps}>
+	<div bind:this={el} use:melt={builder} {...$$restProps}>
 		<slot {builder} />
 	</div>
 {/if}

--- a/src/lib/bits/select/components/select-trigger.svelte
+++ b/src/lib/bits/select/components/select-trigger.svelte
@@ -9,6 +9,7 @@
 
 	export let asChild: $$Props["asChild"] = false;
 	export let id: $$Props["id"] = undefined;
+	export let el: $$Props["el"] = undefined;
 
 	const {
 		elements: { trigger },
@@ -29,6 +30,7 @@
 	<slot {builder} />
 {:else}
 	<button
+		bind:this={el}
 		use:melt={builder}
 		type="button"
 		{...$$restProps}

--- a/src/lib/bits/select/components/select-value.svelte
+++ b/src/lib/bits/select/components/select-value.svelte
@@ -6,6 +6,7 @@
 
 	export let placeholder: $$Props["placeholder"] = "";
 	export let asChild: $$Props["asChild"] = false;
+	export let el: $$Props["el"] = undefined;
 
 	const {
 		states: { selectedLabel }
@@ -18,7 +19,7 @@
 {#if asChild}
 	<slot {label} {attrs} />
 {:else}
-	<span {...$$restProps} {...attrs}>
+	<span bind:this={el} {...$$restProps} {...attrs}>
 		{label ? label : placeholder}
 	</span>
 {/if}

--- a/src/lib/bits/select/types.ts
+++ b/src/lib/bits/select/types.ts
@@ -1,4 +1,4 @@
-import type { HTMLDivAttributes, Transition } from "$lib/internal/index.js";
+import type { DOMEl, HTMLDivAttributes, Transition } from "$lib/internal/index.js";
 import type {
 	EventHandler,
 	HTMLAttributes,
@@ -14,20 +14,20 @@ type ContentProps<
 	T extends Transition = Transition,
 	In extends Transition = Transition,
 	Out extends Transition = Transition
-> = I.ContentProps<T, In, Out> & HTMLDivAttributes;
+> = I.ContentProps<T, In, Out> & HTMLDivAttributes & DOMEl;
 
-type GroupProps = I.GroupProps & HTMLDivAttributes;
-type InputProps = I.InputProps & HTMLInputAttributes;
-type LabelProps = I.LabelProps & HTMLDivAttributes;
-type ItemProps = I.ItemProps & HTMLDivAttributes;
-type SeparatorProps = I.SeparatorProps & HTMLDivAttributes;
-type TriggerProps = I.TriggerProps & HTMLButtonAttributes;
+type GroupProps = I.GroupProps & HTMLDivAttributes & DOMEl;
+type InputProps = I.InputProps & HTMLInputAttributes & DOMEl<HTMLInputElement>;
+type LabelProps = I.LabelProps & HTMLDivAttributes & DOMEl;
+type ItemProps = I.ItemProps & HTMLDivAttributes & DOMEl;
+type SeparatorProps = I.SeparatorProps & HTMLDivAttributes & DOMEl;
+type TriggerProps = I.TriggerProps & HTMLButtonAttributes & DOMEl<HTMLButtonElement>;
 
-type ValueProps = I.ValueProps & HTMLAttributes<HTMLSpanElement>;
+type ValueProps = I.ValueProps & HTMLAttributes<HTMLSpanElement> & DOMEl<HTMLSpanElement>;
 
-type ArrowProps = I.ArrowProps & HTMLDivAttributes;
+type ArrowProps = I.ArrowProps & HTMLDivAttributes & DOMEl;
 
-type IndicatorProps = I.IndicatorProps & HTMLDivAttributes;
+type IndicatorProps = I.IndicatorProps & HTMLDivAttributes & DOMEl;
 
 type ItemEvents<T extends Element = HTMLDivElement> = {
 	click: CustomEventHandler<MouseEvent, T>;

--- a/src/lib/bits/select/types.ts
+++ b/src/lib/bits/select/types.ts
@@ -1,4 +1,4 @@
-import type { DOMEl, HTMLDivAttributes, Transition } from "$lib/internal/index.js";
+import type { HTMLDivAttributes, Transition } from "$lib/internal/index.js";
 import type {
 	EventHandler,
 	HTMLAttributes,
@@ -14,20 +14,20 @@ type ContentProps<
 	T extends Transition = Transition,
 	In extends Transition = Transition,
 	Out extends Transition = Transition
-> = I.ContentProps<T, In, Out> & HTMLDivAttributes & DOMEl;
+> = I.ContentProps<T, In, Out> & HTMLDivAttributes;
 
-type GroupProps = I.GroupProps & HTMLDivAttributes & DOMEl;
-type InputProps = I.InputProps & HTMLInputAttributes & DOMEl<HTMLInputElement>;
-type LabelProps = I.LabelProps & HTMLDivAttributes & DOMEl;
-type ItemProps = I.ItemProps & HTMLDivAttributes & DOMEl;
-type SeparatorProps = I.SeparatorProps & HTMLDivAttributes & DOMEl;
-type TriggerProps = I.TriggerProps & HTMLButtonAttributes & DOMEl<HTMLButtonElement>;
+type GroupProps = I.GroupProps & HTMLDivAttributes;
+type InputProps = I.InputProps & HTMLInputAttributes;
+type LabelProps = I.LabelProps & HTMLDivAttributes;
+type ItemProps = I.ItemProps & HTMLDivAttributes;
+type SeparatorProps = I.SeparatorProps & HTMLDivAttributes;
+type TriggerProps = I.TriggerProps & HTMLButtonAttributes;
 
-type ValueProps = I.ValueProps & HTMLAttributes<HTMLSpanElement> & DOMEl<HTMLSpanElement>;
+type ValueProps = I.ValueProps & HTMLAttributes<HTMLSpanElement>;
 
-type ArrowProps = I.ArrowProps & HTMLDivAttributes & DOMEl;
+type ArrowProps = I.ArrowProps & HTMLDivAttributes;
 
-type IndicatorProps = I.IndicatorProps & HTMLDivAttributes & DOMEl;
+type IndicatorProps = I.IndicatorProps & HTMLDivAttributes;
 
 type ItemEvents<T extends Element = HTMLDivElement> = {
 	click: CustomEventHandler<MouseEvent, T>;

--- a/src/lib/bits/separator/_types.ts
+++ b/src/lib/bits/separator/_types.ts
@@ -3,9 +3,9 @@
  * to type-check our API documentation, which requires we document each prop,
  * but we don't want to document the HTML attributes.
  */
-import type { AsChild, Expand } from "$lib/internal/index.js";
+import type { DOMElement, Expand } from "$lib/internal/index.js";
 import type { CreateSeparatorProps } from "@melt-ui/svelte";
 
-type Props = Expand<CreateSeparatorProps & AsChild>;
+type Props = Expand<CreateSeparatorProps & DOMElement>;
 
 export type { Props };

--- a/src/lib/bits/separator/components/separator.svelte
+++ b/src/lib/bits/separator/components/separator.svelte
@@ -8,6 +8,7 @@
 	export let orientation: $$Props["orientation"] = "horizontal";
 	export let decorative: $$Props["decorative"] = true;
 	export let asChild: $$Props["asChild"] = false;
+	export let el: $$Props["el"] = undefined;
 
 	const {
 		elements: { root },
@@ -26,5 +27,5 @@
 {#if asChild}
 	<slot {builder} />
 {:else}
-	<div use:melt={builder} {...$$restProps} />
+	<div bind:this={el} use:melt={builder} {...$$restProps} />
 {/if}

--- a/src/lib/bits/separator/types.ts
+++ b/src/lib/bits/separator/types.ts
@@ -1,6 +1,6 @@
-import type { DOMEl, HTMLDivAttributes } from "$lib/internal/index.js";
+import type { HTMLDivAttributes } from "$lib/internal/index.js";
 import type * as I from "./_types.js";
 
-type Props = I.Props & HTMLDivAttributes & DOMEl;
+type Props = I.Props & HTMLDivAttributes;
 
 export type { Props };

--- a/src/lib/bits/separator/types.ts
+++ b/src/lib/bits/separator/types.ts
@@ -1,6 +1,6 @@
-import type { HTMLDivAttributes } from "$lib/internal/index.js";
+import type { DOMEl, HTMLDivAttributes } from "$lib/internal/index.js";
 import type * as I from "./_types.js";
 
-type Props = I.Props & HTMLDivAttributes;
+type Props = I.Props & HTMLDivAttributes & DOMEl;
 
 export type { Props };

--- a/src/lib/bits/slider/_types.ts
+++ b/src/lib/bits/slider/_types.ts
@@ -4,7 +4,7 @@
  * but we don't want to document the HTML attributes.
  */
 import type { CreateSliderProps } from "@melt-ui/svelte";
-import type { Expand, OmitValue, OnChangeFn, AsChild } from "$lib/internal/index.js";
+import type { Expand, OmitValue, OnChangeFn, DOMElement } from "$lib/internal/index.js";
 
 type Props = Expand<
 	OmitValue<CreateSliderProps> & {
@@ -18,13 +18,13 @@ type Props = Expand<
 		 * A callback function called when the value changes.
 		 */
 		onValueChange?: OnChangeFn<number[]>;
-	} & AsChild
+	} & DOMElement<HTMLSpanElement>
 >;
 
-type RangeProps = AsChild;
+type RangeProps = DOMElement<HTMLSpanElement>;
 
-type ThumbProps = AsChild;
+type ThumbProps = DOMElement<HTMLSpanElement>;
 
-type TickProps = AsChild;
+type TickProps = DOMElement<HTMLSpanElement>;
 
 export type { Props, RangeProps, ThumbProps, TickProps };

--- a/src/lib/bits/slider/components/slider-input.svelte
+++ b/src/lib/bits/slider/components/slider-input.svelte
@@ -4,6 +4,7 @@
 	import { srOnlyStyles } from "$lib/internal/style.js";
 
 	type $$Props = InputProps;
+	export let el: $$Props["el"] = undefined;
 
 	const {
 		states: { value }
@@ -25,4 +26,4 @@
 	$: inputValue = getValue($value);
 </script>
 
-<input {...$$restProps} value={inputValue} {...attrs} />
+<input bind:this={el} {...$$restProps} value={inputValue} {...attrs} />

--- a/src/lib/bits/slider/components/slider-range.svelte
+++ b/src/lib/bits/slider/components/slider-range.svelte
@@ -6,6 +6,7 @@
 	type $$Props = RangeProps;
 
 	export let asChild: $$Props["asChild"] = false;
+	export let el: $$Props["el"] = undefined;
 
 	const {
 		elements: { range }
@@ -20,5 +21,5 @@
 {#if asChild}
 	<slot {builder} />
 {:else}
-	<span use:melt={builder} {...$$restProps} />
+	<span bind:this={el} use:melt={builder} {...$$restProps} />
 {/if}

--- a/src/lib/bits/slider/components/slider-thumb.svelte
+++ b/src/lib/bits/slider/components/slider-thumb.svelte
@@ -8,6 +8,7 @@
 	type $$Events = ThumbEvents;
 
 	export let asChild: $$Props["asChild"] = false;
+	export let el: $$Props["el"] = undefined;
 
 	const {
 		elements: { thumb }
@@ -23,5 +24,10 @@
 {#if asChild}
 	<slot {builder} />
 {:else}
-	<span use:melt={builder} {...$$restProps} on:m-keydown={dispatch} />
+	<span
+		bind:this={el}
+		use:melt={builder}
+		{...$$restProps}
+		on:m-keydown={dispatch}
+	/>
 {/if}

--- a/src/lib/bits/slider/components/slider-tick.svelte
+++ b/src/lib/bits/slider/components/slider-tick.svelte
@@ -6,6 +6,7 @@
 	type $$Props = TickProps;
 
 	export let asChild: $$Props["asChild"] = false;
+	export let el: $$Props["el"] = undefined;
 
 	const {
 		elements: { tick }
@@ -20,5 +21,5 @@
 {#if asChild}
 	<slot {builder} />
 {:else}
-	<span use:melt={builder} {...$$restProps} />
+	<span bind:this={el} use:melt={builder} {...$$restProps} />
 {/if}

--- a/src/lib/bits/slider/components/slider.svelte
+++ b/src/lib/bits/slider/components/slider.svelte
@@ -13,6 +13,7 @@
 	export let value: $$Props["value"] = undefined;
 	export let onValueChange: $$Props["onValueChange"] = undefined;
 	export let asChild: $$Props["asChild"] = false;
+	export let el: $$Props["el"] = undefined;
 
 	const {
 		elements: { root },
@@ -50,7 +51,7 @@
 {#if asChild}
 	<slot {builder} ticks={$ticks} />
 {:else}
-	<span use:melt={builder} {...$$restProps}>
+	<span bind:this={el} use:melt={builder} {...$$restProps}>
 		<slot {builder} ticks={$ticks} />
 	</span>
 {/if}

--- a/src/lib/bits/slider/types.ts
+++ b/src/lib/bits/slider/types.ts
@@ -3,13 +3,13 @@ import type { CustomEventHandler } from "$lib/index.js";
 import type { HTMLInputAttributes } from "svelte/elements";
 import type * as I from "./_types.js";
 
-type Props = I.Props & HTMLSpanAttributes & DOMEl<HTMLSpanElement>;
+type Props = I.Props & HTMLSpanAttributes;
 
-type RangeProps = I.RangeProps & HTMLSpanAttributes & DOMEl<HTMLSpanElement>;
+type RangeProps = I.RangeProps & HTMLSpanAttributes;
 
-type ThumbProps = I.ThumbProps & HTMLSpanAttributes & DOMEl<HTMLSpanElement>;
+type ThumbProps = I.ThumbProps & HTMLSpanAttributes;
 
-type TickProps = I.TickProps & HTMLSpanAttributes & DOMEl<HTMLSpanElement>;
+type TickProps = I.TickProps & HTMLSpanAttributes;
 
 type InputProps = Omit<HTMLInputAttributes, "value"> & DOMEl<HTMLInputElement>;
 

--- a/src/lib/bits/slider/types.ts
+++ b/src/lib/bits/slider/types.ts
@@ -1,21 +1,21 @@
-import type { HTMLSpanAttributes } from "$lib/internal/index.js";
+import type { DOMEl, HTMLSpanAttributes } from "$lib/internal/index.js";
 import type { CustomEventHandler } from "$lib/index.js";
 import type { HTMLInputAttributes } from "svelte/elements";
 import type * as I from "./_types.js";
 
-type Props = I.Props & HTMLSpanAttributes;
+type Props = I.Props & HTMLSpanAttributes & DOMEl<HTMLSpanElement>;
 
-type RangeProps = I.RangeProps & HTMLSpanAttributes;
+type RangeProps = I.RangeProps & HTMLSpanAttributes & DOMEl<HTMLSpanElement>;
 
-type ThumbProps = I.ThumbProps & HTMLSpanAttributes;
+type ThumbProps = I.ThumbProps & HTMLSpanAttributes & DOMEl<HTMLSpanElement>;
 
-type TickProps = I.TickProps & HTMLSpanAttributes;
+type TickProps = I.TickProps & HTMLSpanAttributes & DOMEl<HTMLSpanElement>;
+
+type InputProps = Omit<HTMLInputAttributes, "value"> & DOMEl<HTMLInputElement>;
 
 type ThumbEvents<T extends Element = HTMLSpanElement> = {
 	keydown: CustomEventHandler<KeyboardEvent, T>;
 };
-
-type InputProps = Omit<HTMLInputAttributes, "value">;
 
 export type {
 	Props,

--- a/src/lib/bits/switch/_types.ts
+++ b/src/lib/bits/switch/_types.ts
@@ -4,7 +4,7 @@
  * but we don't want to document the HTML attributes.
  */
 import type { CreateSwitchProps } from "@melt-ui/svelte";
-import type { AsChild, Expand, OmitChecked, OnChangeFn } from "$lib/internal/index.js";
+import type { DOMElement, Expand, OmitChecked, OnChangeFn } from "$lib/internal/index.js";
 import type { HTMLInputAttributes } from "svelte/elements";
 
 type Props = Expand<
@@ -33,9 +33,9 @@ type Props = Expand<
 		 * Switch props and cannot be overridden.
 		 */
 		inputAttrs?: Partial<Omit<HTMLInputAttributes, "value" | "name" | "type" | "checked">>;
-	} & AsChild
+	} & DOMElement<HTMLButtonElement>
 >;
 
-type ThumbProps = AsChild;
+type ThumbProps = DOMElement<HTMLSpanElement>;
 
 export type { Props, ThumbProps };

--- a/src/lib/bits/switch/components/switch-input.svelte
+++ b/src/lib/bits/switch/components/switch-input.svelte
@@ -4,6 +4,7 @@
 	import type { InputProps } from "../types.js";
 
 	type $$Props = InputProps;
+	export let el: $$Props["el"] = undefined;
 
 	const {
 		elements: { input },
@@ -14,6 +15,7 @@
 </script>
 
 <input
+	bind:this={el}
 	use:melt={$input}
 	name={$name}
 	disabled={$disabled}

--- a/src/lib/bits/switch/components/switch-thumb.svelte
+++ b/src/lib/bits/switch/components/switch-thumb.svelte
@@ -5,6 +5,7 @@
 	type $$Props = ThumbProps;
 
 	export let asChild: $$Props["asChild"] = false;
+	export let el: $$Props["el"] = undefined;
 
 	const {
 		states: { checked }
@@ -20,5 +21,5 @@
 {#if asChild}
 	<slot {attrs} checked={$checked} />
 {:else}
-	<span {...$$restProps} {...attrs} />
+	<span bind:this={el} {...$$restProps} {...attrs} />
 {/if}

--- a/src/lib/bits/switch/components/switch.svelte
+++ b/src/lib/bits/switch/components/switch.svelte
@@ -16,6 +16,7 @@
 	export let required: $$Props["required"] = undefined;
 	export let asChild: $$Props["asChild"] = false;
 	export let inputAttrs: $$Props["inputAttrs"] = undefined;
+	export let el: $$Props["el"] = undefined;
 
 	const {
 		elements: { root },
@@ -53,6 +54,7 @@
 	<slot {builder} />
 {:else}
 	<button
+		bind:this={el}
 		use:melt={builder}
 		type="button"
 		{...$$restProps}

--- a/src/lib/bits/switch/types.ts
+++ b/src/lib/bits/switch/types.ts
@@ -1,13 +1,13 @@
-import type { HTMLSpanAttributes } from "$lib/internal/index.js";
+import type { DOMEl, HTMLSpanAttributes } from "$lib/internal/index.js";
 import type { HTMLButtonAttributes, HTMLInputAttributes } from "svelte/elements";
 import type { CustomEventHandler } from "$lib/index.js";
 import type * as I from "./_types.js";
 
-type Props = I.Props & HTMLButtonAttributes;
+type Props = I.Props & HTMLButtonAttributes & DOMEl<HTMLButtonElement>;
 
-type ThumbProps = I.ThumbProps & HTMLSpanAttributes;
+type ThumbProps = I.ThumbProps & HTMLSpanAttributes & DOMEl<HTMLSpanElement>;
 
-type InputProps = HTMLInputAttributes;
+type InputProps = HTMLInputAttributes & DOMEl<HTMLInputElement>;
 
 type Events<T extends Element = HTMLButtonElement> = {
 	click: CustomEventHandler<MouseEvent, T>;

--- a/src/lib/bits/switch/types.ts
+++ b/src/lib/bits/switch/types.ts
@@ -3,9 +3,9 @@ import type { HTMLButtonAttributes, HTMLInputAttributes } from "svelte/elements"
 import type { CustomEventHandler } from "$lib/index.js";
 import type * as I from "./_types.js";
 
-type Props = I.Props & HTMLButtonAttributes & DOMEl<HTMLButtonElement>;
+type Props = I.Props & HTMLButtonAttributes;
 
-type ThumbProps = I.ThumbProps & HTMLSpanAttributes & DOMEl<HTMLSpanElement>;
+type ThumbProps = I.ThumbProps & HTMLSpanAttributes;
 
 type InputProps = HTMLInputAttributes & DOMEl<HTMLInputElement>;
 

--- a/src/lib/bits/tabs/_types.ts
+++ b/src/lib/bits/tabs/_types.ts
@@ -6,7 +6,7 @@
 
 import type { CreateTabsProps, TabsTriggerProps } from "@melt-ui/svelte";
 import type {
-	AsChild,
+	DOMElement,
 	Expand,
 	ObjectVariation,
 	OmitValue,
@@ -32,17 +32,17 @@ type Props = Expand<
 		 * @defaultValue "horizontal"
 		 */
 		orientation?: CreateTabsProps["orientation"] & {};
-	} & AsChild
+	} & DOMElement
 >;
 
 type ContentProps = Expand<
 	{
 		value: string;
-	} & AsChild
+	} & DOMElement
 >;
 
-type TriggerProps = Expand<ObjectVariation<TabsTriggerProps> & AsChild>;
+type TriggerProps = Expand<ObjectVariation<TabsTriggerProps> & DOMElement<HTMLButtonElement>>;
 
-type ListProps = AsChild;
+type ListProps = DOMElement;
 
 export type { Props, ContentProps, TriggerProps, ListProps };

--- a/src/lib/bits/tabs/components/tabs-content.svelte
+++ b/src/lib/bits/tabs/components/tabs-content.svelte
@@ -7,6 +7,7 @@
 
 	export let value: $$Props["value"];
 	export let asChild: $$Props["asChild"] = false;
+	export let el: $$Props["el"] = undefined;
 
 	const {
 		elements: { content }
@@ -20,7 +21,7 @@
 {#if asChild}
 	<slot {builder} />
 {:else}
-	<div use:melt={builder} {...$$restProps}>
+	<div bind:this={el} use:melt={builder} {...$$restProps}>
 		<slot {builder} />
 	</div>
 {/if}

--- a/src/lib/bits/tabs/components/tabs-list.svelte
+++ b/src/lib/bits/tabs/components/tabs-list.svelte
@@ -6,6 +6,7 @@
 	type $$Props = ListProps;
 
 	export let asChild: $$Props["asChild"] = false;
+	export let el: $$Props["el"] = undefined;
 
 	const {
 		elements: { list }
@@ -20,7 +21,7 @@
 {#if asChild}
 	<slot {builder} />
 {:else}
-	<div use:melt={builder} {...$$restProps}>
+	<div bind:this={el} use:melt={builder} {...$$restProps}>
 		<slot {builder} />
 	</div>
 {/if}

--- a/src/lib/bits/tabs/components/tabs-trigger.svelte
+++ b/src/lib/bits/tabs/components/tabs-trigger.svelte
@@ -10,6 +10,7 @@
 	export let value: $$Props["value"];
 	export let disabled: $$Props["disabled"] = undefined;
 	export let asChild: $$Props["asChild"] = false;
+	export let el: $$Props["el"] = undefined;
 
 	const {
 		elements: { trigger }
@@ -26,6 +27,7 @@
 	<slot {builder} />
 {:else}
 	<button
+		bind:this={el}
 		use:melt={builder}
 		type="button"
 		{...$$restProps}

--- a/src/lib/bits/tabs/components/tabs.svelte
+++ b/src/lib/bits/tabs/components/tabs.svelte
@@ -11,6 +11,7 @@
 	export let value: $$Props["value"] = undefined;
 	export let onValueChange: $$Props["onValueChange"] = undefined;
 	export let asChild: $$Props["asChild"] = false;
+	export let el: $$Props["el"] = undefined;
 
 	const {
 		elements: { root },
@@ -46,7 +47,7 @@
 {#if asChild}
 	<slot {builder} value={$localValue} />
 {:else}
-	<div use:melt={builder} {...$$restProps}>
+	<div bind:this={el} use:melt={builder} {...$$restProps}>
 		<slot {builder} value={$localValue} />
 	</div>
 {/if}

--- a/src/lib/bits/tabs/types.ts
+++ b/src/lib/bits/tabs/types.ts
@@ -1,15 +1,15 @@
-import type { DOMEl, HTMLDivAttributes } from "$lib/internal/index.js";
+import type { HTMLDivAttributes } from "$lib/internal/index.js";
 import type { HTMLButtonAttributes } from "svelte/elements";
 import type { CustomEventHandler } from "$lib/index.js";
 import type * as I from "./_types.js";
 
-type Props = I.Props & HTMLDivAttributes & DOMEl;
+type Props = I.Props & HTMLDivAttributes;
 
-type ContentProps = I.ContentProps & HTMLDivAttributes & DOMEl;
+type ContentProps = I.ContentProps & HTMLDivAttributes;
 
-type TriggerProps = I.TriggerProps & HTMLButtonAttributes & DOMEl<HTMLButtonElement>;
+type TriggerProps = I.TriggerProps & HTMLButtonAttributes;
 
-type ListProps = I.ListProps & HTMLDivAttributes & DOMEl;
+type ListProps = I.ListProps & HTMLDivAttributes;
 
 type TriggerEvents<T extends Element = HTMLButtonElement> = {
 	click: CustomEventHandler<MouseEvent, T>;

--- a/src/lib/bits/tabs/types.ts
+++ b/src/lib/bits/tabs/types.ts
@@ -1,15 +1,15 @@
-import type { HTMLDivAttributes } from "$lib/internal/index.js";
+import type { DOMEl, HTMLDivAttributes } from "$lib/internal/index.js";
 import type { HTMLButtonAttributes } from "svelte/elements";
 import type { CustomEventHandler } from "$lib/index.js";
 import type * as I from "./_types.js";
 
-type Props = I.Props & HTMLDivAttributes;
+type Props = I.Props & HTMLDivAttributes & DOMEl;
 
-type ContentProps = I.ContentProps & HTMLDivAttributes;
+type ContentProps = I.ContentProps & HTMLDivAttributes & DOMEl;
 
-type TriggerProps = I.TriggerProps & HTMLButtonAttributes;
+type TriggerProps = I.TriggerProps & HTMLButtonAttributes & DOMEl<HTMLButtonElement>;
 
-type ListProps = I.ListProps & HTMLDivAttributes;
+type ListProps = I.ListProps & HTMLDivAttributes & DOMEl;
 
 type TriggerEvents<T extends Element = HTMLButtonElement> = {
 	click: CustomEventHandler<MouseEvent, T>;

--- a/src/lib/bits/toggle-group/_types.ts
+++ b/src/lib/bits/toggle-group/_types.ts
@@ -4,7 +4,7 @@
  * but we don't want to document the HTML attributes.
  */
 import type { CreateToggleGroupProps } from "@melt-ui/svelte";
-import type { AsChild, Expand, OmitValue, OnChangeFn } from "$lib/internal/index.js";
+import type { DOMElement, Expand, OmitValue, OnChangeFn } from "$lib/internal/index.js";
 
 type Props<T extends "single" | "multiple"> = Expand<
 	OmitValue<CreateToggleGroupProps<T>> & {
@@ -29,7 +29,7 @@ type Props<T extends "single" | "multiple"> = Expand<
 		 * to be selected at a time.
 		 */
 		type?: T;
-	} & AsChild
+	} & DOMElement
 >;
 
 type ItemProps = Expand<
@@ -49,7 +49,7 @@ type ItemProps = Expand<
 		 * @defaultValue false
 		 */
 		disabled?: boolean;
-	} & AsChild
+	} & DOMElement<HTMLButtonElement>
 >;
 
 export type { Props, ItemProps };

--- a/src/lib/bits/toggle-group/components/toggle-group-item.svelte
+++ b/src/lib/bits/toggle-group/components/toggle-group-item.svelte
@@ -10,6 +10,7 @@
 	export let value: $$Props["value"];
 	export let disabled: $$Props["disabled"] = false;
 	export let asChild: $$Props["asChild"] = false;
+	export let el: $$Props["el"] = undefined;
 
 	const {
 		elements: { item }
@@ -26,6 +27,7 @@
 	<slot {builder} />
 {:else}
 	<button
+		bind:this={el}
 		use:melt={builder}
 		{...$$restProps}
 		on:m-click={dispatch}

--- a/src/lib/bits/toggle-group/components/toggle-group.svelte
+++ b/src/lib/bits/toggle-group/components/toggle-group.svelte
@@ -13,6 +13,7 @@
 	export let orientation: $$Props["orientation"] = undefined;
 	export let onValueChange: $$Props["onValueChange"] = undefined;
 	export let asChild: $$Props["asChild"] = false;
+	export let el: $$Props["el"] = undefined;
 
 	const {
 		elements: { root },
@@ -59,7 +60,7 @@
 {#if asChild}
 	<slot {builder} />
 {:else}
-	<div use:melt={builder} {...$$restProps}>
+	<div bind:this={el} use:melt={builder} {...$$restProps}>
 		<slot {builder} />
 	</div>
 {/if}

--- a/src/lib/bits/toggle-group/types.ts
+++ b/src/lib/bits/toggle-group/types.ts
@@ -1,11 +1,11 @@
-import type { DOMEl, HTMLDivAttributes } from "$lib/internal/index.js";
+import type { HTMLDivAttributes } from "$lib/internal/index.js";
 import type { HTMLButtonAttributes } from "svelte/elements";
 import type { CustomEventHandler } from "$lib/index.js";
 import type * as I from "./_types.js";
 
-type Props<T extends "single" | "multiple"> = I.Props<T> & HTMLDivAttributes & DOMEl;
+type Props<T extends "single" | "multiple"> = I.Props<T> & HTMLDivAttributes;
 
-type ItemProps = I.ItemProps & HTMLButtonAttributes & DOMEl<HTMLButtonElement>;
+type ItemProps = I.ItemProps & HTMLButtonAttributes;
 
 type ItemEvents<T extends Element = HTMLButtonElement> = {
 	click: CustomEventHandler<MouseEvent, T>;

--- a/src/lib/bits/toggle-group/types.ts
+++ b/src/lib/bits/toggle-group/types.ts
@@ -1,11 +1,11 @@
-import type { HTMLDivAttributes } from "$lib/internal/index.js";
+import type { DOMEl, HTMLDivAttributes } from "$lib/internal/index.js";
 import type { HTMLButtonAttributes } from "svelte/elements";
 import type { CustomEventHandler } from "$lib/index.js";
 import type * as I from "./_types.js";
 
-type Props<T extends "single" | "multiple"> = I.Props<T> & HTMLDivAttributes;
+type Props<T extends "single" | "multiple"> = I.Props<T> & HTMLDivAttributes & DOMEl;
 
-type ItemProps = I.ItemProps & HTMLButtonAttributes;
+type ItemProps = I.ItemProps & HTMLButtonAttributes & DOMEl<HTMLButtonElement>;
 
 type ItemEvents<T extends Element = HTMLButtonElement> = {
 	click: CustomEventHandler<MouseEvent, T>;

--- a/src/lib/bits/toggle/_types.ts
+++ b/src/lib/bits/toggle/_types.ts
@@ -4,7 +4,7 @@
  * but we don't want to document the HTML attributes.
  */
 import type { CreateToggleProps } from "@melt-ui/svelte";
-import type { AsChild, Expand, OmitPressed, OnChangeFn } from "$lib/internal/index.js";
+import type { DOMElement, Expand, OmitPressed, OnChangeFn } from "$lib/internal/index.js";
 
 type Props = Expand<
 	OmitPressed<CreateToggleProps> & {
@@ -20,7 +20,7 @@ type Props = Expand<
 		 * A callback function called when the pressed state changes.
 		 */
 		onPressedChange?: OnChangeFn<boolean>;
-	} & AsChild
+	} & DOMElement<HTMLButtonElement>
 >;
 
 export type {

--- a/src/lib/bits/toggle/components/toggle.svelte
+++ b/src/lib/bits/toggle/components/toggle.svelte
@@ -11,6 +11,7 @@
 	export let pressed: $$Props["pressed"] = undefined;
 	export let onPressedChange: $$Props["onPressedChange"] = undefined;
 	export let asChild: $$Props["asChild"] = false;
+	export let el: $$Props["el"] = undefined;
 
 	const {
 		elements: { root },
@@ -42,6 +43,7 @@
 	<slot {builder} />
 {:else}
 	<button
+		bind:this={el}
 		use:melt={builder}
 		type="button"
 		{...$$restProps}

--- a/src/lib/bits/toggle/types.ts
+++ b/src/lib/bits/toggle/types.ts
@@ -1,9 +1,8 @@
 import type { HTMLButtonAttributes } from "svelte/elements";
 import type { CustomEventHandler } from "$lib/index.js";
 import type * as I from "./_types.js";
-import type { DOMEl } from "$lib/internal/types.js";
 
-type Props = I.Props & HTMLButtonAttributes & DOMEl<HTMLButtonElement>;
+type Props = I.Props & HTMLButtonAttributes;
 
 type Events<T extends Element = HTMLButtonElement> = {
 	click: CustomEventHandler<MouseEvent, T>;

--- a/src/lib/bits/toggle/types.ts
+++ b/src/lib/bits/toggle/types.ts
@@ -1,8 +1,9 @@
 import type { HTMLButtonAttributes } from "svelte/elements";
 import type { CustomEventHandler } from "$lib/index.js";
 import type * as I from "./_types.js";
+import type { DOMEl } from "$lib/internal/types.js";
 
-type Props = I.Props & HTMLButtonAttributes;
+type Props = I.Props & HTMLButtonAttributes & DOMEl<HTMLButtonElement>;
 
 type Events<T extends Element = HTMLButtonElement> = {
 	click: CustomEventHandler<MouseEvent, T>;

--- a/src/lib/bits/toolbar/_types.ts
+++ b/src/lib/bits/toolbar/_types.ts
@@ -4,13 +4,13 @@
  * but we don't want to document the HTML attributes.
  */
 import type { CreateToolbarProps, CreateToolbarGroupProps } from "@melt-ui/svelte";
-import type { AsChild, Expand, OmitValue, OnChangeFn } from "$lib/internal/index.js";
+import type { DOMElement, Expand, OmitValue, OnChangeFn } from "$lib/internal/index.js";
 
-type Props = Expand<CreateToolbarProps & AsChild>;
+type Props = Expand<CreateToolbarProps & DOMElement>;
 
-type ButtonProps = AsChild;
+type ButtonProps = DOMElement<HTMLButtonElement>;
 
-type LinkProps = AsChild;
+type LinkProps = DOMElement<HTMLAnchorElement>;
 
 type GroupProps<T extends "single" | "multiple"> = Expand<
 	OmitValue<CreateToolbarGroupProps<T>> & {
@@ -35,7 +35,7 @@ type GroupProps<T extends "single" | "multiple"> = Expand<
 		 * to be selected at a time.
 		 */
 		type?: T;
-	} & AsChild
+	} & DOMElement
 >;
 
 type GroupItemProps = Expand<
@@ -55,7 +55,7 @@ type GroupItemProps = Expand<
 		 * @defaultValue false
 		 */
 		disabled?: boolean;
-	} & AsChild
+	} & DOMElement<HTMLButtonElement>
 >;
 
 export type { Props, ButtonProps, LinkProps, GroupProps, GroupItemProps };

--- a/src/lib/bits/toolbar/components/toolbar-button.svelte
+++ b/src/lib/bits/toolbar/components/toolbar-button.svelte
@@ -8,6 +8,7 @@
 	type $$Events = ButtonEvents;
 
 	export let asChild: $$Props["asChild"] = false;
+	export let el: $$Props["el"] = undefined;
 
 	const {
 		elements: { button }
@@ -24,6 +25,7 @@
 	<slot {builder} />
 {:else}
 	<button
+		bind:this={el}
 		use:melt={builder}
 		type="button"
 		{...$$restProps}

--- a/src/lib/bits/toolbar/components/toolbar-group-item.svelte
+++ b/src/lib/bits/toolbar/components/toolbar-group-item.svelte
@@ -10,6 +10,7 @@
 	export let value: $$Props["value"];
 	export let disabled: $$Props["disabled"] = false;
 	export let asChild: $$Props["asChild"] = false;
+	export let el: $$Props["el"] = undefined;
 
 	const {
 		elements: { item }
@@ -26,6 +27,7 @@
 	<slot {builder} />
 {:else}
 	<button
+		bind:this={el}
 		use:melt={builder}
 		{...$$restProps}
 		on:m-click={dispatch}

--- a/src/lib/bits/toolbar/components/toolbar-group.svelte
+++ b/src/lib/bits/toolbar/components/toolbar-group.svelte
@@ -11,6 +11,7 @@
 	export let value: $$Props["value"] = undefined;
 	export let onValueChange: $$Props["onValueChange"] = undefined;
 	export let asChild: $$Props["asChild"] = false;
+	export let el: $$Props["el"] = undefined;
 
 	const {
 		elements: { group },
@@ -50,7 +51,7 @@
 {#if asChild}
 	<slot {builder} />
 {:else}
-	<div use:melt={builder} {...$$restProps}>
+	<div bind:this={el} use:melt={builder} {...$$restProps}>
 		<slot {builder} />
 	</div>
 {/if}

--- a/src/lib/bits/toolbar/components/toolbar-link.svelte
+++ b/src/lib/bits/toolbar/components/toolbar-link.svelte
@@ -8,6 +8,7 @@
 	type $$Events = LinkEvents;
 
 	export let asChild: $$Props["asChild"] = false;
+	export let el: $$Props["el"] = undefined;
 
 	const {
 		elements: { link }
@@ -25,6 +26,7 @@
 {:else}
 	<svelte:element
 		this={"a"}
+		bind:this={el}
 		use:melt={builder}
 		{...$$restProps}
 		on:m-keydown={dispatch}

--- a/src/lib/bits/toolbar/components/toolbar.svelte
+++ b/src/lib/bits/toolbar/components/toolbar.svelte
@@ -8,6 +8,7 @@
 	export let loop: $$Props["loop"] = true;
 	export let orientation: $$Props["orientation"] = undefined;
 	export let asChild: $$Props["asChild"] = false;
+	export let el: $$Props["el"] = undefined;
 
 	const {
 		elements: { root },
@@ -29,7 +30,7 @@
 {#if asChild}
 	<slot {builder} />
 {:else}
-	<div use:melt={builder} {...$$restProps}>
+	<div bind:this={el} use:melt={builder} {...$$restProps}>
 		<slot {builder} />
 	</div>
 {/if}

--- a/src/lib/bits/toolbar/types.ts
+++ b/src/lib/bits/toolbar/types.ts
@@ -1,17 +1,17 @@
-import type { HTMLDivAttributes } from "$lib/internal/index.js";
+import type { DOMEl, HTMLDivAttributes } from "$lib/internal/index.js";
 import type { HTMLAnchorAttributes, HTMLButtonAttributes } from "svelte/elements";
 import type * as I from "$lib/bits/toolbar/_types.js";
 import type { CustomEventHandler } from "$lib/index.js";
 
-type Props = I.Props & HTMLDivAttributes;
+type Props = I.Props & HTMLDivAttributes & DOMEl;
 
-type ButtonProps = I.ButtonProps & HTMLButtonAttributes;
+type ButtonProps = I.ButtonProps & HTMLButtonAttributes & DOMEl<HTMLButtonElement>;
 
-type LinkProps = I.LinkProps & HTMLAnchorAttributes;
+type LinkProps = I.LinkProps & HTMLAnchorAttributes & DOMEl<HTMLAnchorElement>;
 
-type GroupProps<T extends "single" | "multiple"> = I.GroupProps<T> & HTMLDivAttributes;
+type GroupProps<T extends "single" | "multiple"> = I.GroupProps<T> & HTMLDivAttributes & DOMEl;
 
-type GroupItemProps = I.GroupItemProps & HTMLButtonAttributes;
+type GroupItemProps = I.GroupItemProps & HTMLButtonAttributes & DOMEl<HTMLButtonElement>;
 
 /**
  * Events

--- a/src/lib/bits/toolbar/types.ts
+++ b/src/lib/bits/toolbar/types.ts
@@ -1,17 +1,17 @@
-import type { DOMEl, HTMLDivAttributes } from "$lib/internal/index.js";
+import type { HTMLDivAttributes } from "$lib/internal/index.js";
 import type { HTMLAnchorAttributes, HTMLButtonAttributes } from "svelte/elements";
 import type * as I from "$lib/bits/toolbar/_types.js";
 import type { CustomEventHandler } from "$lib/index.js";
 
-type Props = I.Props & HTMLDivAttributes & DOMEl;
+type Props = I.Props & HTMLDivAttributes;
 
-type ButtonProps = I.ButtonProps & HTMLButtonAttributes & DOMEl<HTMLButtonElement>;
+type ButtonProps = I.ButtonProps & HTMLButtonAttributes;
 
-type LinkProps = I.LinkProps & HTMLAnchorAttributes & DOMEl<HTMLAnchorElement>;
+type LinkProps = I.LinkProps & HTMLAnchorAttributes;
 
-type GroupProps<T extends "single" | "multiple"> = I.GroupProps<T> & HTMLDivAttributes & DOMEl;
+type GroupProps<T extends "single" | "multiple"> = I.GroupProps<T> & HTMLDivAttributes;
 
-type GroupItemProps = I.GroupItemProps & HTMLButtonAttributes & DOMEl<HTMLButtonElement>;
+type GroupItemProps = I.GroupItemProps & HTMLButtonAttributes;
 
 /**
  * Events

--- a/src/lib/bits/tooltip/_types.ts
+++ b/src/lib/bits/tooltip/_types.ts
@@ -4,7 +4,7 @@
  * but we don't want to document the HTML attributes.
  */
 import type { CreateTooltipProps } from "@melt-ui/svelte";
-import type { Expand, OmitFloating, OnChangeFn, AsChild } from "$lib/internal/index.js";
+import type { Expand, OmitFloating, OnChangeFn, DOMElement } from "$lib/internal/index.js";
 import type { ArrowProps, ContentProps } from "$lib/bits/floating/_types.js";
 
 type Props = Expand<OmitFloating<CreateTooltipProps>> & {
@@ -36,6 +36,6 @@ type Props = Expand<OmitFloating<CreateTooltipProps>> & {
 	onOpenChange?: OnChangeFn<boolean>;
 };
 
-type TriggerProps = AsChild;
+type TriggerProps = DOMElement<HTMLButtonElement>;
 
 export type { Props, ArrowProps, TriggerProps, ContentProps };

--- a/src/lib/bits/tooltip/components/tooltip-arrow.svelte
+++ b/src/lib/bits/tooltip/components/tooltip-arrow.svelte
@@ -7,6 +7,7 @@
 
 	export let size = 8;
 	export let asChild: $$Props["asChild"] = false;
+	export let el: $$Props["el"] = undefined;
 
 	const {
 		elements: { arrow }
@@ -21,5 +22,5 @@
 {#if asChild}
 	<slot {builder} />
 {:else}
-	<div use:melt={builder} {...$$restProps} />
+	<div bind:this={el} use:melt={builder} {...$$restProps} />
 {/if}

--- a/src/lib/bits/tooltip/components/tooltip-content.svelte
+++ b/src/lib/bits/tooltip/components/tooltip-content.svelte
@@ -30,6 +30,7 @@
 	export let fitViewport: $$Props["fitViewport"] = false;
 	export let strategy: $$Props["strategy"] = "absolute";
 	export let overlap: $$Props["overlap"] = false;
+	export let el: $$Props["el"] = undefined;
 
 	const {
 		elements: { content },
@@ -64,6 +65,7 @@
 	<slot {builder} />
 {:else if transition && $open}
 	<div
+		bind:this={el}
 		use:melt={builder}
 		transition:transition={transitionConfig}
 		{...$$restProps}
@@ -74,6 +76,7 @@
 	</div>
 {:else if inTransition && outTransition && $open}
 	<div
+		bind:this={el}
 		use:melt={builder}
 		in:inTransition={inTransitionConfig}
 		out:outTransition={outTransitionConfig}
@@ -85,6 +88,7 @@
 	</div>
 {:else if inTransition && $open}
 	<div
+		bind:this={el}
 		use:melt={builder}
 		in:inTransition={inTransitionConfig}
 		{...$$restProps}
@@ -95,6 +99,7 @@
 	</div>
 {:else if outTransition && $open}
 	<div
+		bind:this={el}
 		use:melt={builder}
 		out:outTransition={outTransitionConfig}
 		{...$$restProps}
@@ -105,6 +110,7 @@
 	</div>
 {:else if $open}
 	<div
+		bind:this={el}
 		use:melt={builder}
 		{...$$restProps}
 		on:m-pointerdown={dispatch}

--- a/src/lib/bits/tooltip/components/tooltip-trigger.svelte
+++ b/src/lib/bits/tooltip/components/tooltip-trigger.svelte
@@ -9,6 +9,7 @@
 
 	export let asChild: $$Props["asChild"] = false;
 	export let id: $$Props["id"] = undefined;
+	export let el: $$Props["el"] = undefined;
 
 	const {
 		elements: { trigger },
@@ -29,6 +30,7 @@
 	<slot {builder} />
 {:else}
 	<button
+		bind:this={el}
 		use:melt={builder}
 		type="button"
 		{...$$restProps}

--- a/src/lib/bits/tooltip/types.ts
+++ b/src/lib/bits/tooltip/types.ts
@@ -1,4 +1,4 @@
-import type { HTMLDivAttributes, Transition } from "$lib/internal/index.js";
+import type { DOMEl, HTMLDivAttributes, Transition } from "$lib/internal/index.js";
 import type { HTMLButtonAttributes } from "svelte/elements";
 import type { CustomEventHandler } from "$lib";
 import type * as I from "./_types.js";
@@ -9,10 +9,10 @@ type ContentProps<
 	T extends Transition = Transition,
 	In extends Transition = Transition,
 	Out extends Transition = Transition
-> = I.ContentProps<T, In, Out> & HTMLDivAttributes;
+> = I.ContentProps<T, In, Out> & HTMLDivAttributes & DOMEl;
 
-type TriggerProps = I.TriggerProps & HTMLButtonAttributes;
-type ArrowProps = I.ArrowProps & HTMLDivAttributes;
+type TriggerProps = I.TriggerProps & HTMLButtonAttributes & DOMEl<HTMLButtonElement>;
+type ArrowProps = I.ArrowProps & HTMLDivAttributes & DOMEl;
 
 type TriggerEvents<T extends Element = HTMLButtonElement> = {
 	blur: CustomEventHandler<FocusEvent, T>;

--- a/src/lib/bits/tooltip/types.ts
+++ b/src/lib/bits/tooltip/types.ts
@@ -1,4 +1,4 @@
-import type { DOMEl, HTMLDivAttributes, Transition } from "$lib/internal/index.js";
+import type { HTMLDivAttributes, Transition } from "$lib/internal/index.js";
 import type { HTMLButtonAttributes } from "svelte/elements";
 import type { CustomEventHandler } from "$lib";
 import type * as I from "./_types.js";
@@ -9,10 +9,10 @@ type ContentProps<
 	T extends Transition = Transition,
 	In extends Transition = Transition,
 	Out extends Transition = Transition
-> = I.ContentProps<T, In, Out> & HTMLDivAttributes & DOMEl;
+> = I.ContentProps<T, In, Out> & HTMLDivAttributes;
 
-type TriggerProps = I.TriggerProps & HTMLButtonAttributes & DOMEl<HTMLButtonElement>;
-type ArrowProps = I.ArrowProps & HTMLDivAttributes & DOMEl;
+type TriggerProps = I.TriggerProps & HTMLButtonAttributes;
+type ArrowProps = I.ArrowProps & HTMLDivAttributes;
 
 type TriggerEvents<T extends Element = HTMLButtonElement> = {
 	blur: CustomEventHandler<FocusEvent, T>;

--- a/src/lib/internal/types.ts
+++ b/src/lib/internal/types.ts
@@ -63,7 +63,7 @@ export type KeydownClickEvents = {
 	keydown: KeyboardEvent;
 };
 
-export type DOMEl<T extends Element = HTMLElement> = Expand<{
+export type DOMEl<T extends Element = HTMLDivElement> = Expand<{
 	/**
 	 * Wheter to expose the underlying DOM element.
 	 */

--- a/src/lib/internal/types.ts
+++ b/src/lib/internal/types.ts
@@ -70,6 +70,21 @@ export type DOMEl<T extends Element = HTMLDivElement> = Expand<{
 	el?: T;
 }>;
 
+export type DOMElement<T extends Element = HTMLDivElement> = Expand<{
+	/**
+	 * Whether to delegate rendering the element to your own
+	 * custom element.
+	 *
+	 * @see https://www.bits-ui.com/docs/delegation
+	 */
+	asChild?: boolean;
+
+	/**
+	 * Bind to the underlying DOM element of the component.
+	 */
+	el?: T;
+}>
+
 export type AsChild = Expand<{
 	/**
 	 * Whether to delegate rendering the element to your own

--- a/src/lib/internal/types.ts
+++ b/src/lib/internal/types.ts
@@ -37,14 +37,14 @@ export type OnChangeFn<T> = (value: T) => void;
 
 export type Expand<T> = T extends object
 	? T extends infer O
-	? { [K in keyof O]: O[K] }
-	: never
+		? { [K in keyof O]: O[K] }
+		: never
 	: T;
 
 export type ExpandDeep<T> = T extends object
 	? T extends infer O
-	? { [K in keyof O]: ExpandDeep<O[K]> }
-	: never
+		? { [K in keyof O]: ExpandDeep<O[K]> }
+		: never
 	: T;
 
 export type Prettify<T> = {
@@ -67,8 +67,8 @@ export type DOMEl<T extends HTMLElement = HTMLDivElement> = Expand<{
 	/**
 	 * Wheter to expose the underlying DOM element.
 	 */
-	el?: T
-}>
+	el?: T;
+}>;
 
 export type AsChild = Expand<{
 	/**

--- a/src/lib/internal/types.ts
+++ b/src/lib/internal/types.ts
@@ -83,7 +83,7 @@ export type DOMElement<T extends Element = HTMLDivElement> = Expand<{
 	 * Bind to the underlying DOM element of the component.
 	 */
 	el?: T;
-}>
+}>;
 
 export type AsChild = Expand<{
 	/**

--- a/src/lib/internal/types.ts
+++ b/src/lib/internal/types.ts
@@ -63,7 +63,7 @@ export type KeydownClickEvents = {
 	keydown: KeyboardEvent;
 };
 
-export type DOMEl<T extends HTMLElement = HTMLDivElement> = Expand<{
+export type DOMEl<T extends Element = HTMLElement> = Expand<{
 	/**
 	 * Wheter to expose the underlying DOM element.
 	 */

--- a/src/lib/internal/types.ts
+++ b/src/lib/internal/types.ts
@@ -37,14 +37,14 @@ export type OnChangeFn<T> = (value: T) => void;
 
 export type Expand<T> = T extends object
 	? T extends infer O
-		? { [K in keyof O]: O[K] }
-		: never
+	? { [K in keyof O]: O[K] }
+	: never
 	: T;
 
 export type ExpandDeep<T> = T extends object
 	? T extends infer O
-		? { [K in keyof O]: ExpandDeep<O[K]> }
-		: never
+	? { [K in keyof O]: ExpandDeep<O[K]> }
+	: never
 	: T;
 
 export type Prettify<T> = {
@@ -62,6 +62,13 @@ export type KeydownClickEvents = {
 	click: MouseEvent;
 	keydown: KeyboardEvent;
 };
+
+export type DOMEl<T extends HTMLElement = HTMLDivElement> = Expand<{
+	/**
+	 * Wheter to expose the underlying DOM element.
+	 */
+	el?: T
+}>
 
 export type AsChild = Expand<{
 	/**


### PR DESCRIPTION
This is a starting point for exposing the DOM element as a prop. I just implemented for the *Accordion* component and would like some feedback regarding the code. I would also like to know if we have to expose the same prop in the child components (Accordion.Item, Accordion.Header, Accordion.Trigger...).

TODOs:

- [x] Accordion
- [x] Alert Dialog
- [x] Aspect Ratio
- [x] Avatar
- [x] Button
- [x] Calendar
- [x] Checkbox
- [x] Collapsible
- [x] Context Menu
- [x] Date Field
- [x] Date Picker
- [x] Date Range Field
- [x] Date Range Picker
- [x] Dialog
- [x] Dropdown Menu
- [x] Label
- [x] Link Preview
- [x] Menubar
- [x] Pagination
- [x] PIN Input
- [x] Popover
- [x] Progress
- [x] Radio Group
- [x] Range Calendar
- [x] Select
- [x] Separator
- [x] Slider
- [x] Switch
- [x] Tabs
- [x] Toggle
- [x] Toggle Group
- [x] Toolbar
- [x] Tooltip

This closes #237 