### PR TITLE
feat: forward events & update Melt UI

### DIFF
--- a/.changeset/forty-ants-turn.md
+++ b/.changeset/forty-ants-turn.md
@@ -1,0 +1,7 @@
+---
+"bits-ui": minor
+---
+
+- Forward pointerdown pointerup & pointermove events for AlertDialog.Content and Dialog.Content
+- Update Melt UI and add onOutsideClick prop to components that handle outside clicks. You can override the default behavior of closing the component by calling event.preventDefault() within that handler.
+- Added RTL support for the Slider via the dir prop which can be set to "ltr" | "rtl" defaulting to "ltr"

--- a/.eslintignore
+++ b/.eslintignore
@@ -6,7 +6,7 @@ node_modules
 .env
 .env.*
 !.env.example
-
+dist
 # Ignore files for PNPM, NPM and YARN
 pnpm-lock.yaml
 package-lock.json

--- a/package.json
+++ b/package.json
@@ -91,8 +91,8 @@
   "types": "./dist/index.d.ts",
   "type": "module",
   "dependencies": {
-    "@internationalized/date": "^3.5.0",
-    "@melt-ui/svelte": "0.65.2",
+    "@internationalized/date": "^3.5.1",
+    "@melt-ui/svelte": "0.67.0",
     "nanoid": "^5.0.4"
   },
   "peerDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,11 +6,11 @@ settings:
 
 dependencies:
   '@internationalized/date':
-    specifier: ^3.5.0
-    version: 3.5.0
+    specifier: ^3.5.1
+    version: 3.5.1
   '@melt-ui/svelte':
-    specifier: 0.65.2
-    version: 0.65.2(svelte@4.2.3)
+    specifier: 0.67.0
+    version: 0.67.0(svelte@4.2.3)
   nanoid:
     specifier: ^5.0.4
     version: 5.0.4
@@ -24,7 +24,7 @@ devDependencies:
     version: 0.16.5(svelte@4.2.3)
   '@melt-ui/pp':
     specifier: ^0.1.4
-    version: 0.1.4(@melt-ui/svelte@0.65.2)(svelte@4.2.3)
+    version: 0.1.4(@melt-ui/svelte@0.67.0)(svelte@4.2.3)
   '@playwright/test':
     specifier: ^1.28.1
     version: 1.36.2
@@ -922,8 +922,8 @@ packages:
       vfile-message: 2.0.4
     dev: true
 
-  /@internationalized/date@3.5.0:
-    resolution: {integrity: sha512-nw0Q+oRkizBWMioseI8+2TeUPEyopJVz5YxoYVzR0W1v+2YytiYah7s/ot35F149q/xAg4F1gT/6eTd+tsUpFQ==}
+  /@internationalized/date@3.5.1:
+    resolution: {integrity: sha512-LUQIfwU9e+Fmutc/DpRTGXSdgYZLBegi4wygCWDSVmUdLTaMHsQyASDiJtREwanwKuQLq0hY76fCJ9J/9I2xOQ==}
     dependencies:
       '@swc/helpers': 0.5.3
 
@@ -1064,26 +1064,26 @@ packages:
       - supports-color
     dev: true
 
-  /@melt-ui/pp@0.1.4(@melt-ui/svelte@0.65.2)(svelte@4.2.3):
+  /@melt-ui/pp@0.1.4(@melt-ui/svelte@0.67.0)(svelte@4.2.3):
     resolution: {integrity: sha512-zR+Kl3CZJPJBHW8V7YcdQCMI/dVcnW9Ct3yGbVaIywYVStVRS7F9uEDOea3xLLT2WTGodQePzPlUn53yKFu87g==}
     engines: {pnpm: '>=8.6.3'}
     peerDependencies:
       '@melt-ui/svelte': '>= 0.29.0'
       svelte: ^3.55.0 || ^4.0.0 || ^5.0.0-next.1
     dependencies:
-      '@melt-ui/svelte': 0.65.2(svelte@4.2.3)
+      '@melt-ui/svelte': 0.67.0(svelte@4.2.3)
       estree-walker: 3.0.3
       svelte: 4.2.3
     dev: true
 
-  /@melt-ui/svelte@0.65.2(svelte@4.2.3):
-    resolution: {integrity: sha512-BpsSl9Bjp1++8U3+LaDOFUoX/PFQ9N7QWFhlFdUEZduhrbVyU70v9A459SKrQ+esFSjvh1AvqJYkMAUJXJlAmQ==}
+  /@melt-ui/svelte@0.67.0(svelte@4.2.3):
+    resolution: {integrity: sha512-fd9PsDE6sKbeyExagqH0nOpZEnDqyr2efbkjfmCRRYXVW5vlDEOPaSB+mg4Tjch121102sFH1Od+MlXwmeHy3A==}
     peerDependencies:
       svelte: '>=3 <5'
     dependencies:
       '@floating-ui/core': 1.5.0
       '@floating-ui/dom': 1.5.3
-      '@internationalized/date': 3.5.0
+      '@internationalized/date': 3.5.1
       dequal: 2.0.3
       focus-trap: 7.5.4
       nanoid: 4.0.2

--- a/src/content/api-reference/alert-dialog.ts
+++ b/src/content/api-reference/alert-dialog.ts
@@ -5,7 +5,8 @@ import {
 	idsSlotProp,
 	portalProp,
 	transitionProps,
-	builderAndAttrsSlotProps
+	builderAndAttrsSlotProps,
+	onOutsideClickProp
 } from "@/content/api-reference/helpers.js";
 import * as C from "@/content/constants.js";
 import { focusProp } from "@/content/api-reference/extended-types/index.js";
@@ -53,7 +54,8 @@ const root: APISchema<AlertDialog.Props> = {
 			type: focusProp,
 			description: "Override the focus when the alert dialog is closed."
 		},
-		portal: { ...portalProp("alert dialog") }
+		portal: { ...portalProp("alert dialog") },
+		onOutsideClick: onOutsideClickProp
 	}
 };
 

--- a/src/content/api-reference/date-picker.ts
+++ b/src/content/api-reference/date-picker.ts
@@ -5,7 +5,8 @@ import {
 	enums,
 	monthsSlotProp,
 	union,
-	domElProps
+	domElProps,
+	onOutsideClickProp
 } from "@/content/api-reference/helpers.js";
 import type * as DatePicker from "$lib/bits/date-picker/_types.js";
 import { builderAndAttrsSlotProps, portalProp } from "./helpers";
@@ -205,7 +206,8 @@ const root: APISchema<DatePicker.Props> = {
 			type: focusProp,
 			description: "Override the focus when the popover is closed."
 		},
-		portal: { ...portalProp("popover") }
+		portal: { ...portalProp("popover") },
+		onOutsideClick: onOutsideClickProp
 	},
 	slotProps: {
 		months: monthsSlotProp,

--- a/src/content/api-reference/date-range-picker.ts
+++ b/src/content/api-reference/date-range-picker.ts
@@ -5,7 +5,8 @@ import {
 	enums,
 	monthsSlotProp,
 	union,
-	domElProps
+	domElProps,
+	onOutsideClickProp
 } from "@/content/api-reference/helpers.js";
 import type * as DateRangePicker from "$lib/bits/date-range-picker/_types.js";
 import { builderAndAttrsSlotProps, portalProp } from "./helpers";
@@ -211,7 +212,8 @@ const root: APISchema<DateRangePicker.Props> = {
 			},
 			description:
 				"The `start` value of the date range, which can exist prior to the true `value` being set, which is only set once a `start` and `end` value are selected. You can `bind:startValue` to a value to receive updates, but modifying this value outside the component will have no effect. To programmatically control the `start` value, use `bind:value` and update the `start` property of the `DateRange` object. This is provided as a convenience for use cases where you want to display the selected `start` value outside the component before the `value` is set."
-		}
+		},
+		onOutsideClick: onOutsideClickProp
 	},
 	slotProps: {
 		months: monthsSlotProp,

--- a/src/content/api-reference/dialog.ts
+++ b/src/content/api-reference/dialog.ts
@@ -2,6 +2,7 @@ import type { APISchema } from "@/types";
 import {
 	enums,
 	idsSlotProp,
+	onOutsideClickProp,
 	portalProp,
 	transitionProps
 } from "@/content/api-reference/helpers.js";
@@ -49,7 +50,8 @@ export const root: APISchema<Dialog.Props> = {
 			type: focusProp,
 			description: "Override the focus when the dialog is closed."
 		},
-		portal: { ...portalProp("dialog") }
+		portal: { ...portalProp("dialog") },
+		onOutsideClick: onOutsideClickProp
 	},
 	slotProps: {
 		ids: idsSlotProp

--- a/src/content/api-reference/helpers.ts
+++ b/src/content/api-reference/helpers.ts
@@ -146,3 +146,12 @@ export function escape(str: string): string {
 	}
 	return str;
 }
+
+export const onOutsideClickProp: PropSchema = {
+	type: {
+		type: C.FUNCTION,
+		definition: "(event: PointerEvent) => void"
+	},
+	description:
+		"A callback function called when a click occurs outside of the element. If `event.preventDefault()` is called, the default behavior of closing the element will be prevented."
+};

--- a/src/content/api-reference/link-preview.ts
+++ b/src/content/api-reference/link-preview.ts
@@ -6,7 +6,8 @@ import {
 	idsSlotProp,
 	portalProp,
 	transitionProps,
-	builderAndAttrsSlotProps
+	builderAndAttrsSlotProps,
+	onOutsideClickProp
 } from "@/content/api-reference/helpers.js";
 import { floatingPositioning } from "./floating.js";
 import type * as LinkPreview from "$lib/bits/link-preview/_types";
@@ -50,7 +51,8 @@ export const root: APISchema<LinkPreview.Props> = {
 			},
 			description: "A callback that fires when the open state changes."
 		},
-		portal: { ...portalProp("link preview") }
+		portal: { ...portalProp("link preview") },
+		onOutsideClick: onOutsideClickProp
 	},
 	slotProps: {
 		ids: idsSlotProp

--- a/src/content/api-reference/menu.ts
+++ b/src/content/api-reference/menu.ts
@@ -11,7 +11,7 @@ import {
 } from "@/content/api-reference/helpers.js";
 import type * as Menu from "$lib/bits/menu/_types";
 import * as C from "@/content/constants";
-import { builderAndAttrsSlotProps, domElProps } from "./helpers";
+import { builderAndAttrsSlotProps, domElProps, onOutsideClickProp } from "./helpers";
 
 const props = {
 	preventScroll: {
@@ -73,7 +73,8 @@ const props = {
 		type: C.BOOLEAN,
 		default: C.TRUE,
 		description: "Whether or not to close the menu when an item is clicked."
-	}
+	},
+	onOutsideClick: onOutsideClickProp
 } satisfies PropObj<Menu.Props>;
 
 const subProps = {

--- a/src/content/api-reference/popover.ts
+++ b/src/content/api-reference/popover.ts
@@ -9,7 +9,8 @@ import {
 	enums,
 	idsSlotProp,
 	domElProps,
-	builderAndAttrsSlotProps
+	builderAndAttrsSlotProps,
+	onOutsideClickProp
 } from "@/content/api-reference/helpers.js";
 import * as C from "@/content/constants.js";
 
@@ -58,7 +59,8 @@ export const root: APISchema<Popover.Props> = {
 			type: focusProp,
 			description: "Override the focus when the popover is closed."
 		},
-		portal: { ...portalProp("popover") }
+		portal: { ...portalProp("popover") },
+		onOutsideClick: onOutsideClickProp
 	},
 	slotProps: { ids: idsSlotProp }
 };

--- a/src/content/api-reference/select.ts
+++ b/src/content/api-reference/select.ts
@@ -8,7 +8,8 @@ import {
 	idsSlotProp,
 	portalProp,
 	transitionProps,
-	builderAndAttrsSlotProps
+	builderAndAttrsSlotProps,
+	onOutsideClickProp
 } from "@/content/api-reference/helpers.js";
 import { floatingPositioning } from "./floating.js";
 import * as C from "@/content/constants.js";
@@ -110,7 +111,8 @@ export const root: APISchema<Select.Props> = {
 				definition: "Array<{ value: T; label?: string }>"
 			},
 			description: "An array of items to add type-safety to the `onSelectedChange` callback."
-		}
+		},
+		onOutsideClick: onOutsideClickProp
 	},
 	slotProps: { ids: idsSlotProp }
 };

--- a/src/content/api-reference/slider.ts
+++ b/src/content/api-reference/slider.ts
@@ -47,6 +47,15 @@ const root: APISchema<Slider.Props> = {
 			type: C.NUMBER,
 			description: "The step value of the slider."
 		},
+		dir: {
+			default: '"ltr"',
+			type: {
+				type: C.ENUM,
+				definition: enums("ltr", "rtl")
+			},
+			description:
+				"The reading direction of the slider. If set to 'rtl', the slider will be reversed for both `'horizontal'` and `'vertical'` orientations."
+		},
 		...domElProps("HTMLSpanElement")
 	},
 	slotProps: {

--- a/src/lib/bits/alert-dialog/_export.types.ts
+++ b/src/lib/bits/alert-dialog/_export.types.ts
@@ -11,5 +11,6 @@ export type {
 	//
 	TriggerEvents as AlertDialogTriggerEvents,
 	CancelEvents as AlertDialogCancelEvents,
-	ActionEvents as AlertDialogActionEvents
+	ActionEvents as AlertDialogActionEvents,
+	ContentEvents as AlertDialogContentEvents
 } from "./types.js";

--- a/src/lib/bits/alert-dialog/components/alert-dialog-content.svelte
+++ b/src/lib/bits/alert-dialog/components/alert-dialog-content.svelte
@@ -42,6 +42,9 @@
 		bind:this={el}
 		transition:transition={transitionConfig}
 		use:melt={builder}
+		on:pointerdown
+		on:pointermove
+		on:pointerup
 		{...$$restProps}
 	>
 		<slot {builder} />
@@ -52,6 +55,9 @@
 		in:inTransition={inTransitionConfig}
 		out:outTransition={outTransitionConfig}
 		use:melt={builder}
+		on:pointerdown
+		on:pointermove
+		on:pointerup
 		{...$$restProps}
 	>
 		<slot {builder} />
@@ -61,6 +67,9 @@
 		bind:this={el}
 		in:inTransition={inTransitionConfig}
 		use:melt={builder}
+		on:pointerdown
+		on:pointermove
+		on:pointerup
 		{...$$restProps}
 	>
 		<slot {builder} />
@@ -70,12 +79,22 @@
 		bind:this={el}
 		out:outTransition={outTransitionConfig}
 		use:melt={builder}
+		on:pointerdown
+		on:pointermove
+		on:pointerup
 		{...$$restProps}
 	>
 		<slot {builder} />
 	</div>
 {:else if $open}
-	<div bind:this={el} use:melt={builder} {...$$restProps}>
+	<div
+		bind:this={el}
+		use:melt={builder}
+		on:pointerdown
+		on:pointermove
+		on:pointerup
+		{...$$restProps}
+	>
 		<slot {builder} />
 	</div>
 {/if}

--- a/src/lib/bits/alert-dialog/components/alert-dialog.svelte
+++ b/src/lib/bits/alert-dialog/components/alert-dialog.svelte
@@ -13,6 +13,7 @@
 	export let onOpenChange: $$Props["onOpenChange"] = undefined;
 	export let openFocus: $$Props["openFocus"] = undefined;
 	export let closeFocus: $$Props["closeFocus"] = undefined;
+	export let onOutsideClick: $$Props["onOutsideClick"] = undefined;
 
 	const {
 		states: { open: localOpen },
@@ -27,6 +28,7 @@
 		defaultOpen: open,
 		openFocus,
 		closeFocus,
+		onOutsideClick,
 		onOpenChange: ({ next }) => {
 			if (open !== next) {
 				onOpenChange?.(next);
@@ -53,6 +55,7 @@
 	$: updateOption("portal", portal);
 	$: updateOption("openFocus", openFocus);
 	$: updateOption("closeFocus", closeFocus);
+	$: updateOption("onOutsideClick", onOutsideClick);
 </script>
 
 <slot ids={$idValues} />

--- a/src/lib/bits/alert-dialog/types.ts
+++ b/src/lib/bits/alert-dialog/types.ts
@@ -1,4 +1,9 @@
-import type { HTMLDivAttributes, HTMLHeadingAttributes, Transition } from "$lib/internal/index.js";
+import type {
+	HTMLDivAttributes,
+	HTMLHeadingAttributes,
+	SvelteEvent,
+	Transition
+} from "$lib/internal/index.js";
 import type { HTMLButtonAttributes } from "svelte/elements";
 import type { CustomEventHandler } from "$lib/index.js";
 import type * as I from "./_types.js";
@@ -28,6 +33,12 @@ type TriggerEvents<T extends Element = HTMLButtonElement> = {
 	keydown: CustomEventHandler<KeyboardEvent, T>;
 };
 
+type ContentEvents<T extends Element = HTMLElement> = {
+	pointerdown: SvelteEvent<PointerEvent, T>;
+	pointerup: SvelteEvent<PointerEvent, T>;
+	pointermove: SvelteEvent<PointerEvent, T>;
+};
+
 type ActionEvents = TriggerEvents;
 type CancelEvents = TriggerEvents;
 
@@ -44,5 +55,6 @@ export type {
 	//
 	TriggerEvents,
 	CancelEvents,
-	ActionEvents
+	ActionEvents,
+	ContentEvents
 };

--- a/src/lib/bits/context-menu/components/context-menu.svelte
+++ b/src/lib/bits/context-menu/components/context-menu.svelte
@@ -16,6 +16,7 @@
 	export let closeFocus: $$Props["closeFocus"] = undefined;
 	export let disableFocusFirstItem: $$Props["disableFocusFirstItem"] =
 		undefined;
+	export let onOutsideClick: $$Props["onOutsideClick"] = undefined;
 
 	const {
 		states: { open: localOpen },
@@ -33,6 +34,7 @@
 		typeahead,
 		disableFocusFirstItem,
 		closeFocus,
+		onOutsideClick,
 		onOpenChange: ({ next }) => {
 			if (open !== next) {
 				onOpenChange?.(next);
@@ -61,6 +63,7 @@
 	$: updateOption("closeFocus", closeFocus);
 	$: updateOption("disableFocusFirstItem", disableFocusFirstItem);
 	$: updateOption("typeahead", typeahead);
+	$: updateOption("onOutsideClick", onOutsideClick);
 </script>
 
 <slot ids={$idValues} />

--- a/src/lib/bits/date-picker/components/date-picker.svelte
+++ b/src/lib/bits/date-picker/components/date-picker.svelte
@@ -28,6 +28,7 @@
 	export let calendarLabel: $$Props["calendarLabel"] = undefined;
 	export let weekdayFormat: $$Props["weekdayFormat"] = undefined;
 	export let numberOfMonths: $$Props["numberOfMonths"] = undefined;
+	export let onOutsideClick: $$Props["onOutsideClick"] = undefined;
 
 	const {
 		states: {
@@ -57,6 +58,7 @@
 		weekdayFormat,
 		numberOfMonths,
 		isDateUnavailable,
+		onOutsideClick,
 		onValueChange: ({ next }) => {
 			if (value !== next) {
 				onValueChange?.(next);
@@ -152,6 +154,7 @@
 	$: updateOption("calendarLabel", calendarLabel);
 	$: updateOption("weekdayFormat", weekdayFormat);
 	$: updateOption("numberOfMonths", numberOfMonths);
+	$: updateOption("onOutsideClick", onOutsideClick);
 </script>
 
 <slot ids={$idValues} isInvalid={$localIsInvalid} />

--- a/src/lib/bits/date-range-picker/components/date-range-picker.svelte
+++ b/src/lib/bits/date-range-picker/components/date-range-picker.svelte
@@ -29,6 +29,7 @@
 	export let weekdayFormat: $$Props["weekdayFormat"] = undefined;
 	export let startValue: $$Props["startValue"] = undefined;
 	export let numberOfMonths: $$Props["numberOfMonths"] = undefined;
+	export let onOutsideClick: $$Props["onOutsideClick"] = undefined;
 
 	const {
 		states: {
@@ -60,6 +61,7 @@
 		weekdayFormat,
 		numberOfMonths,
 		isDateUnavailable,
+		onOutsideClick,
 		onValueChange: ({ next }) => {
 			if (value !== next) {
 				onValueChange?.(next);
@@ -206,6 +208,7 @@
 	$: updateOption("calendarLabel", calendarLabel);
 	$: updateOption("weekdayFormat", weekdayFormat);
 	$: updateOption("numberOfMonths", numberOfMonths);
+	$: updateOption("onOutsideClick", onOutsideClick);
 </script>
 
 <slot

--- a/src/lib/bits/dialog/_export.types.ts
+++ b/src/lib/bits/dialog/_export.types.ts
@@ -9,5 +9,6 @@ export type {
 	DescriptionProps as DialogDescriptionProps,
 	//
 	TriggerEvents as DialogTriggerEvents,
-	CloseEvents as DialogCloseEvents
+	CloseEvents as DialogCloseEvents,
+	ContentEvents as DialogContentEvents
 } from "./types.js";

--- a/src/lib/bits/dialog/_types.ts
+++ b/src/lib/bits/dialog/_types.ts
@@ -4,6 +4,7 @@
  * but we don't want to document the HTML attributes.
  */
 
+import type { FocusProp } from "$lib/shared/index.js";
 import type {
 	DOMElement,
 	Expand,
@@ -15,7 +16,9 @@ import type {
 import type { CreateDialogProps } from "@melt-ui/svelte";
 
 type Props = Expand<
-	OmitOpen<Omit<CreateDialogProps, "role" | "ids" | "forceVisible">> & {
+	OmitOpen<
+		Omit<CreateDialogProps, "role" | "ids" | "forceVisible" | "openFocus" | "closeFocus">
+	> & {
 		/**
 		 * The open state of the dialog.
 		 * You can bind this to a boolean value to programmatically control the open state.
@@ -28,6 +31,16 @@ type Props = Expand<
 		 * A callback function called when the open state changes.
 		 */
 		onOpenChange?: OnChangeFn<boolean>;
+
+		/**
+		 * Override the default autofocus behavior of the dialog when it opens
+		 */
+		openFocus?: FocusProp;
+
+		/**
+		 * Override the default autofocus behavior of the dialog after close
+		 */
+		closeFocus?: FocusProp;
 	}
 >;
 

--- a/src/lib/bits/dialog/components/dialog-content.svelte
+++ b/src/lib/bits/dialog/components/dialog-content.svelte
@@ -2,13 +2,14 @@
 	import { melt } from "@melt-ui/svelte";
 	import type { Transition } from "$lib/internal/index.js";
 	import { getCtx, getAttrs } from "../ctx.js";
-	import type { ContentProps } from "../types.js";
+	import type { ContentEvents, ContentProps } from "../types.js";
 
 	type T = $$Generic<Transition>;
 	type In = $$Generic<Transition>;
 	type Out = $$Generic<Transition>;
 
 	type $$Props = ContentProps<T, In, Out>;
+	type $$Events = ContentEvents;
 
 	export let transition: $$Props["transition"] = undefined;
 	export let transitionConfig: $$Props["transitionConfig"] = undefined;
@@ -43,6 +44,9 @@
 		transition:transition={transitionConfig}
 		use:melt={builder}
 		{...$$restProps}
+		on:pointerdown
+		on:pointermove
+		on:pointerup
 	>
 		<slot {builder} />
 	</div>
@@ -52,6 +56,9 @@
 		in:inTransition={inTransitionConfig}
 		out:outTransition={outTransitionConfig}
 		use:melt={builder}
+		on:pointerdown
+		on:pointermove
+		on:pointerup
 		{...$$restProps}
 	>
 		<slot {builder} />
@@ -61,6 +68,9 @@
 		bind:this={el}
 		in:inTransition={inTransitionConfig}
 		use:melt={builder}
+		on:pointerdown
+		on:pointermove
+		on:pointerup
 		{...$$restProps}
 	>
 		<slot {builder} />
@@ -70,12 +80,22 @@
 		bind:this={el}
 		out:outTransition={outTransitionConfig}
 		use:melt={builder}
+		on:pointerdown
+		on:pointermove
+		on:pointerup
 		{...$$restProps}
 	>
 		<slot {builder} />
 	</div>
 {:else if $open}
-	<div bind:this={el} use:melt={builder} {...$$restProps}>
+	<div
+		bind:this={el}
+		use:melt={builder}
+		on:pointerdown
+		on:pointermove
+		on:pointerup
+		{...$$restProps}
+	>
 		<slot {builder} />
 	</div>
 {/if}

--- a/src/lib/bits/dialog/components/dialog-overlay.svelte
+++ b/src/lib/bits/dialog/components/dialog-overlay.svelte
@@ -2,13 +2,14 @@
 	import { melt } from "@melt-ui/svelte";
 	import type { Transition } from "$lib/internal/index.js";
 	import { getCtx, getAttrs } from "../ctx.js";
-	import type { OverlayProps } from "../types.js";
+	import type { OverlayEvents, OverlayProps } from "../types.js";
 
 	type T = $$Generic<Transition>;
 	type In = $$Generic<Transition>;
 	type Out = $$Generic<Transition>;
 
 	type $$Props = OverlayProps<T, In, Out>;
+	type $$Events = OverlayEvents;
 
 	export let transition: $$Props["transition"] = undefined;
 	export let transitionConfig: $$Props["transitionConfig"] = undefined;
@@ -32,34 +33,43 @@
 {#if asChild && $open}
 	<slot {builder} />
 {:else if transition && $open}
+	<!-- svelte-ignore a11y-no-static-element-interactions -->
 	<div
+		on:mouseup
 		bind:this={el}
 		transition:transition={transitionConfig}
 		use:melt={builder}
 		{...$$restProps}
 	/>
 {:else if inTransition && outTransition && $open}
+	<!-- svelte-ignore a11y-no-static-element-interactions -->
 	<div
 		bind:this={el}
 		in:inTransition={inTransitionConfig}
 		out:outTransition={outTransitionConfig}
 		use:melt={builder}
+		on:mouseup
 		{...$$restProps}
 	/>
 {:else if inTransition && $open}
+	<!-- svelte-ignore a11y-no-static-element-interactions -->
 	<div
 		bind:this={el}
 		in:inTransition={inTransitionConfig}
 		use:melt={builder}
+		on:mouseup
 		{...$$restProps}
 	/>
 {:else if outTransition && $open}
+	<!-- svelte-ignore a11y-no-static-element-interactions -->
 	<div
 		bind:this={el}
 		out:outTransition={outTransitionConfig}
 		use:melt={builder}
+		on:mouseup
 		{...$$restProps}
 	/>
 {:else if $open}
-	<div bind:this={el} use:melt={builder} {...$$restProps} />
+	<!-- svelte-ignore a11y-no-static-element-interactions -->
+	<div bind:this={el} use:melt={builder} on:mouseup {...$$restProps} />
 {/if}

--- a/src/lib/bits/dialog/components/dialog.svelte
+++ b/src/lib/bits/dialog/components/dialog.svelte
@@ -13,6 +13,7 @@
 	export let onOpenChange: $$Props["onOpenChange"] = undefined;
 	export let openFocus: $$Props["openFocus"] = undefined;
 	export let closeFocus: $$Props["closeFocus"] = undefined;
+	export let onOutsideClick: $$Props["onOutsideClick"] = undefined;
 
 	const {
 		states: { open: localOpen },
@@ -27,6 +28,7 @@
 		defaultOpen: open,
 		openFocus,
 		closeFocus,
+		onOutsideClick,
 		onOpenChange: ({ next }) => {
 			if (open !== next) {
 				onOpenChange?.(next);
@@ -53,6 +55,7 @@
 	$: updateOption("portal", portal);
 	$: updateOption("openFocus", openFocus);
 	$: updateOption("closeFocus", closeFocus);
+	$: updateOption("onOutsideClick", onOutsideClick);
 </script>
 
 <slot ids={$idValues} />

--- a/src/lib/bits/dialog/types.ts
+++ b/src/lib/bits/dialog/types.ts
@@ -1,4 +1,9 @@
-import type { HTMLDivAttributes, HTMLHeadingAttributes, Transition } from "$lib/internal/index.js";
+import type {
+	HTMLDivAttributes,
+	HTMLHeadingAttributes,
+	SvelteEvent,
+	Transition
+} from "$lib/internal/index.js";
 import type { HTMLButtonAttributes } from "svelte/elements";
 import type { CustomEventHandler } from "$lib/index.js";
 import type * as I from "./_types.js";
@@ -25,6 +30,16 @@ type OverlayProps<
 type PortalProps = I.PortalProps & HTMLDivAttributes;
 type TitleProps = I.TitleProps & HTMLHeadingAttributes;
 
+type OverlayEvents<T extends Element = HTMLElement> = {
+	mouseup: SvelteEvent<MouseEvent, T>;
+};
+
+type ContentEvents<T extends Element = HTMLElement> = {
+	pointerdown: SvelteEvent<PointerEvent, T>;
+	pointerup: SvelteEvent<PointerEvent, T>;
+	pointermove: SvelteEvent<PointerEvent, T>;
+};
+
 type TriggerEvents<T extends Element = HTMLButtonElement> = {
 	click: CustomEventHandler<MouseEvent, T>;
 	keydown: CustomEventHandler<KeyboardEvent, T>;
@@ -42,5 +57,7 @@ export type {
 	DescriptionProps,
 	//
 	TriggerEvents,
-	CloseEvents
+	CloseEvents,
+	ContentEvents,
+	OverlayEvents
 };

--- a/src/lib/bits/link-preview/components/link-preview.svelte
+++ b/src/lib/bits/link-preview/components/link-preview.svelte
@@ -11,6 +11,7 @@
 	export let closeOnOutsideClick: $$Props["closeOnOutsideClick"] = undefined;
 	export let closeOnEscape: $$Props["closeOnEscape"] = undefined;
 	export let portal: $$Props["portal"] = undefined;
+	export let onOutsideClick: $$Props["onOutsideClick"] = undefined;
 
 	const {
 		states: { open: localOpen },
@@ -23,6 +24,7 @@
 		closeOnOutsideClick,
 		closeOnEscape,
 		portal,
+		onOutsideClick,
 		onOpenChange: ({ next }) => {
 			if (open !== next) {
 				onOpenChange?.(next);
@@ -46,6 +48,7 @@
 	$: updateOption("closeOnOutsideClick", closeOnOutsideClick);
 	$: updateOption("closeOnEscape", closeOnEscape);
 	$: updateOption("portal", portal);
+	$: updateOption("onOutsideClick", onOutsideClick);
 </script>
 
 <slot ids={$idValues} />

--- a/src/lib/bits/menu/components/menu.svelte
+++ b/src/lib/bits/menu/components/menu.svelte
@@ -17,6 +17,7 @@
 	export let disableFocusFirstItem: $$Props["disableFocusFirstItem"] =
 		undefined;
 	export let closeOnItemClick: $$Props["closeOnItemClick"] = undefined;
+	export let onOutsideClick: $$Props["onOutsideClick"] = undefined;
 
 	const {
 		states: { open: localOpen },
@@ -35,6 +36,7 @@
 		closeFocus,
 		disableFocusFirstItem,
 		closeOnItemClick,
+		onOutsideClick,
 		onOpenChange: ({ next }) => {
 			if (open !== next) {
 				onOpenChange?.(next);
@@ -64,6 +66,7 @@
 	$: updateOption("disableFocusFirstItem", disableFocusFirstItem);
 	$: updateOption("typeahead", typeahead);
 	$: updateOption("closeOnItemClick", closeOnItemClick);
+	$: updateOption("onOutsideClick", onOutsideClick);
 </script>
 
 <slot ids={$idValues} />

--- a/src/lib/bits/menubar/components/menubar-menu.svelte
+++ b/src/lib/bits/menubar/components/menubar-menu.svelte
@@ -17,6 +17,7 @@
 	export let disableFocusFirstItem: $$Props["disableFocusFirstItem"] =
 		undefined;
 	export let closeOnItemClick: $$Props["closeOnItemClick"] = undefined;
+	export let onOutsideClick: $$Props["onOutsideClick"] = undefined;
 
 	const {
 		states: { open: localOpen },
@@ -33,6 +34,7 @@
 		closeFocus,
 		disableFocusFirstItem,
 		closeOnItemClick,
+		onOutsideClick,
 		onOpenChange: ({ next }) => {
 			if (open !== next) {
 				onOpenChange?.(next);
@@ -62,6 +64,7 @@
 	$: updateOption("disableFocusFirstItem", disableFocusFirstItem);
 	$: updateOption("typeahead", typeahead);
 	$: updateOption("closeOnItemClick", closeOnItemClick);
+	$: updateOption("onOutsideClick", onOutsideClick);
 </script>
 
 <slot menuIds={$idValues} />

--- a/src/lib/bits/popover/components/popover.svelte
+++ b/src/lib/bits/popover/components/popover.svelte
@@ -13,6 +13,7 @@
 	export let onOpenChange: $$Props["onOpenChange"] = undefined;
 	export let openFocus: $$Props["openFocus"] = undefined;
 	export let closeFocus: $$Props["closeFocus"] = undefined;
+	export let onOutsideClick: $$Props["onOutsideClick"] = undefined;
 
 	const {
 		updateOption,
@@ -27,6 +28,7 @@
 		defaultOpen: open,
 		openFocus,
 		closeFocus,
+		onOutsideClick,
 		onOpenChange: ({ next }) => {
 			if (open !== next) {
 				onOpenChange?.(next);
@@ -53,6 +55,7 @@
 	$: updateOption("portal", portal);
 	$: updateOption("openFocus", openFocus);
 	$: updateOption("closeFocus", closeFocus);
+	$: updateOption("onOutsideClick", onOutsideClick);
 </script>
 
 <slot ids={$idValues} />

--- a/src/lib/bits/select/components/select.svelte
+++ b/src/lib/bits/select/components/select.svelte
@@ -24,6 +24,7 @@
 	export let open: $$Props["open"] = undefined;
 	export let onOpenChange: $$Props["onOpenChange"] = undefined;
 	export let items: $$Props["items"] = [];
+	export let onOutsideClick: $$Props["onOutsideClick"] = undefined;
 
 	const {
 		states: { open: localOpen, selected: localSelected },
@@ -38,6 +39,7 @@
 		closeOnOutsideClick,
 		portal,
 		name,
+		onOutsideClick,
 		multiple: multiple as Multiple,
 		forceVisible: true,
 		defaultSelected: Array.isArray(selected)
@@ -98,6 +100,7 @@
 	$: updateOption("portal", portal);
 	$: updateOption("name", name);
 	$: updateOption("multiple", multiple);
+	$: updateOption("onOutsideClick", onOutsideClick);
 </script>
 
 <slot ids={$idValues} />

--- a/src/lib/internal/events.ts
+++ b/src/lib/internal/events.ts
@@ -8,6 +8,10 @@ type MeltEvent<T extends Event = Event> = {
 	preventDefault: () => void;
 };
 
+export type SvelteEvent<T extends Event = Event, U extends EventTarget = EventTarget> = T & {
+	currentTarget: EventTarget & U;
+};
+
 export function createDispatcher<M extends Element = Element>() {
 	const dispatch = createEventDispatcher();
 	return (e: MeltEvent) => {

--- a/src/lib/shared/index.ts
+++ b/src/lib/shared/index.ts
@@ -22,4 +22,7 @@ export type SegmentPart =
 	| "timeZoneName"
 	| "literal";
 
+export type FocusTarget = string | HTMLElement | SVGElement | null;
+export type FocusProp = FocusTarget | ((defaultEl?: HTMLElement | null) => FocusTarget);
+
 export type { Month, Page, PageItem, Ellipsis };


### PR DESCRIPTION
- Forward `pointerdown` `pointerup` & `pointermove` events for `AlertDialog.Content` and `Dialog.Content`
- Update Melt UI and add `onOutsideClick` prop to components that handle outside clicks. You can override the default behavior of closing the component by calling `event.preventDefault()` within that handler.
- Added RTL support for the `Slider` via the `dir` prop which can be set to `"ltr" | "rtl"` defaulting to `"ltr"` 
