### PR TITLE
docs: Don't include the word "Copy" when clicking the Copy button

### DIFF
--- a/src/components/copy-code-button.svelte
+++ b/src/components/copy-code-button.svelte
@@ -14,10 +14,10 @@
 		className
 	)}
 	on:click={copyCode}
+	aria-label="Copy"
 	{...$$restProps}
 	data-copy-code
 >
-	<span class="sr-only">Copy</span>
 	{#if copied}
 		<Check class="h-3 w-3" />
 	{:else}


### PR DESCRIPTION
When you click on the button to copy code in a document website, it will contain the word "Copy".

So, instead of using sr-only to hide the text, use aria-label.