### PR TITLE
fix: pagination prop reactivity

### DIFF
--- a/.changeset/kind-files-fold.md
+++ b/.changeset/kind-files-fold.md
@@ -1,0 +1,5 @@
+---
+"bits-ui": patch
+---
+
+fix: pagination prop reactivity 

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -51,7 +51,7 @@ module.exports = {
 					"warn",
 					{
 						argsIgnorePattern: "^_",
-						varsIgnorePattern: "^\\$\\$(Props|Events|Slots|Generic)$"
+						varsIgnorePattern: "^\\$\\$(Props|Events|Slots|Generic|_[^$])*$"
 					}
 				]
 			}

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,50 @@
+name: "🐛 Bug report"
+description: Report an issue with bits-ui
+labels: ["type: bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report!
+  - type: textarea
+    id: bug-description
+    attributes:
+      label: Describe the bug
+      description: A clear and concise description of what the bug is. If you intend to submit a PR for this issue, tell us how in the description. Thanks!
+      placeholder: Bug description
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction
+      description: Please provide a link to a repo or Stackblitz that can reproduce the problem you ran into. If a report is vague (e.g. just a generic error message) and has no reproduction, it will receive a "needs reproduction" label. If no reproduction is provided within a reasonable time-frame, the issue will be closed.
+      placeholder: Reproduction
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs
+      description: "Please include browser console and server logs around the time this bug occurred. Optional if provided reproduction. Please try not to insert an image but copy paste the log text."
+      render: bash
+  - type: textarea
+    id: system-info
+    attributes:
+      label: System Info
+      description: Output of `npx envinfo --system --npmPackages svelte,bits-ui,@sveltejs/kit --binaries --browsers`
+      render: bash
+      placeholder: System, Binaries, Browsers
+    validations:
+      required: true
+  - type: dropdown
+    id: severity
+    attributes:
+      label: Severity
+      description: Select the severity of this issue
+      options:
+        - annoyance
+        - blocking an upgrade
+        - blocking all usage of bits-ui
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/documentation_change.yml
+++ b/.github/ISSUE_TEMPLATE/documentation_change.yml
@@ -1,0 +1,22 @@
+name: 📖 Report Docs Issue
+description: Suggest an addition or modification to the documentation
+labels: ["type: documentation"]
+body:
+  - type: dropdown
+    attributes:
+      label: Change Type
+      description: What type of change are you proposing?
+      options:
+        - Addition
+        - Correction
+        - Removal
+        - Cleanup (formatting, typos, etc.)
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Proposed Changes
+      description: Describe the proposed changes and why they are necessary
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,26 @@
+# Borrowed from https://github.com/skeletonlabs/skeleton
+
+name: 🛠️ Request New Feature
+description: Let us know what you would like to see added.
+labels: ["type: feature"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Describe the feature in detail (code, mocks, or screenshots encouraged)
+    validations:
+      required: true
+  - type: dropdown
+    id: category
+    attributes:
+      label: What type of pull request would this be?
+      options:
+        - "New Feature"
+        - "Enhancement"
+        - "Guide"
+        - "Docs"
+        - "Other"
+  - type: textarea
+    id: references
+    attributes:
+      label: Provide relevant links or additional information.

--- a/src/lib/bits/pagination/components/pagination.svelte
+++ b/src/lib/bits/pagination/components/pagination.svelte
@@ -15,8 +15,9 @@
 
 	const {
 		elements: { root },
-		states: { pages, range },
-		getAttrs
+		states: { pages, range, page: localPage },
+		getAttrs,
+		updateOption
 	} = setCtx({
 		count,
 		perPage,
@@ -32,10 +33,16 @@
 		}
 	});
 
+	$: page !== undefined && localPage.set(page);
+
 	const attrs = getAttrs("root");
 
 	$: builder = $root;
 	$: Object.assign(builder, attrs);
+
+	$: updateOption("count", count);
+	$: updateOption("perPage", perPage);
+	$: updateOption("siblingCount", siblingCount);
 </script>
 
 {#if asChild}


### PR DESCRIPTION
This PR fixes an issue where the internal stores managed by melt weren't updated when the value of the props changed after the initial load.