### PR TITLE
fix: floating ui options

### DIFF
--- a/.changeset/calm-masks-camp.md
+++ b/.changeset/calm-masks-camp.md
@@ -1,0 +1,5 @@
+---
+"bits-ui": patch
+---
+
+fix: Floating UI options

--- a/src/lib/bits/context-menu/components/context-menu-content.svelte
+++ b/src/lib/bits/context-menu/components/context-menu-content.svelte
@@ -24,6 +24,8 @@
 	export let avoidCollisions: $$Props["avoidCollisions"] = true;
 	export let collisionBoundary: $$Props["collisionBoundary"] = undefined;
 	export let fitViewport: $$Props["fitViewport"] = false;
+	export let strategy: $$Props["strategy"] = "absolute";
+	export let overlap: $$Props["overlap"] = false;
 	export let el: $$Props["el"] = undefined;
 
 	const {
@@ -47,7 +49,9 @@
 		collisionPadding,
 		avoidCollisions,
 		collisionBoundary,
-		fitViewport
+		fitViewport,
+		strategy,
+		overlap
 	});
 </script>
 

--- a/src/lib/bits/floating/helpers.ts
+++ b/src/lib/bits/floating/helpers.ts
@@ -20,7 +20,9 @@ export function updatePositioning(store: Writable<FloatingConfig>, props: Floati
 		sameWidth: false,
 		avoidCollisions: true,
 		collisionPadding: 8,
-		fitViewport: false
+		fitViewport: false,
+		strategy: "absolute",
+		overlap: false
 	} satisfies FloatingProps;
 
 	const withDefaults = { ...defaultPositioningProps, ...props } satisfies FloatingProps;
@@ -37,7 +39,10 @@ export function updatePositioning(store: Writable<FloatingConfig>, props: Floati
 			sameWidth: withDefaults.sameWidth,
 			flip: withDefaults.avoidCollisions,
 			overflowPadding: withDefaults.collisionPadding,
-			boundary: withDefaults.collisionBoundary
+			boundary: withDefaults.collisionBoundary,
+			fitViewport: withDefaults.fitViewport,
+			strategy: withDefaults.strategy,
+			overlap: withDefaults.overlap
 		};
 	});
 }

--- a/src/lib/bits/popover/components/popover-content.svelte
+++ b/src/lib/bits/popover/components/popover-content.svelte
@@ -27,6 +27,8 @@
 	export let collisionBoundary: $$Props["collisionBoundary"] = undefined;
 	export let sameWidth: $$Props["sameWidth"] = false;
 	export let fitViewport: $$Props["fitViewport"] = false;
+	export let strategy: $$Props["strategy"] = "absolute";
+	export let overlap: $$Props["overlap"] = false;
 	export let el: $$Props["el"] = undefined;
 
 	const {
@@ -53,7 +55,9 @@
 		avoidCollisions,
 		collisionBoundary,
 		sameWidth,
-		fitViewport
+		fitViewport,
+		strategy,
+		overlap
 	});
 </script>
 

--- a/src/lib/bits/select/components/select-content.svelte
+++ b/src/lib/bits/select/components/select-content.svelte
@@ -29,6 +29,8 @@
 	export let collisionBoundary: $$Props["collisionBoundary"] = undefined;
 	export let sameWidth: $$Props["sameWidth"] = true;
 	export let fitViewport: $$Props["fitViewport"] = false;
+	export let strategy: $$Props["strategy"] = "absolute";
+	export let overlap: $$Props["overlap"] = false;
 	export let el: $$Props["el"] = undefined;
 
 	const {
@@ -57,7 +59,9 @@
 		avoidCollisions,
 		collisionBoundary,
 		sameWidth,
-		fitViewport
+		fitViewport,
+		strategy,
+		overlap
 	});
 </script>
 


### PR DESCRIPTION
Fixed `fitViewport`, `strategy` and `overlap` options as documented here: https://www.bits-ui.com/docs/components/popover#popovercontent