### PR TITLE
feat: `data-placeholder` attribute for `Select.Value`

### DIFF
--- a/.changeset/quick-pandas-explain.md
+++ b/.changeset/quick-pandas-explain.md
@@ -1,0 +1,5 @@
+---
+"bits-ui": minor
+---
+
+feat: adds `data-placeholder` attribute to `Select.Value` when no value is selected / when the placeholder is being displayed

--- a/src/content/api-reference/select.ts
+++ b/src/content/api-reference/select.ts
@@ -214,6 +214,11 @@ export const value: APISchema = {
 		{
 			name: "select-value",
 			description: "Present on the value element."
+		},
+		{
+			name: "placeholder",
+			description:
+				"Present when the placeholder is being displayed (there isn't a value selected). You can use this to style the placeholder differently than the selected value."
 		}
 	]
 };

--- a/src/lib/bits/select/components/select-value.svelte
+++ b/src/lib/bits/select/components/select-value.svelte
@@ -20,7 +20,12 @@
 {#if asChild}
 	<slot {label} {attrs} />
 {:else}
-	<span bind:this={el} {...$$restProps} {...attrs}>
+	<span
+		bind:this={el}
+		{...$$restProps}
+		{...attrs}
+		data-placeholder={!label ? "" : undefined}
+	>
 		{label ? label : placeholder}
 	</span>
 {/if}


### PR DESCRIPTION
Closes: #283 

This PR adds a `data-placeholder` attribute to the `<Select.Value />` element when a label is not present (when the placeholder is showing).

This enables you to style the element differently when in the placeholder state using that attribute.