### PR TITLE
fix: floating arrow shifting content

### DIFF
--- a/.changeset/tall-students-sleep.md
+++ b/.changeset/tall-students-sleep.md
@@ -1,0 +1,5 @@
+---
+"bits-ui": patch
+---
+
+fix: floating arrow shifting content

--- a/src/lib/bits/link-preview/components/link-preview-content.svelte
+++ b/src/lib/bits/link-preview/components/link-preview-content.svelte
@@ -49,19 +49,21 @@
 	$: builder = $content;
 	$: Object.assign(builder, attrs);
 
-	$: updatePositioning({
-		side,
-		align,
-		sideOffset,
-		alignOffset,
-		collisionPadding,
-		avoidCollisions,
-		collisionBoundary,
-		sameWidth,
-		fitViewport,
-		strategy,
-		overlap
-	});
+	$: if ($open) {
+		updatePositioning({
+			side,
+			align,
+			sideOffset,
+			alignOffset,
+			collisionPadding,
+			avoidCollisions,
+			collisionBoundary,
+			sameWidth,
+			fitViewport,
+			strategy,
+			overlap
+		});
+	}
 </script>
 
 {#if asChild && $open}

--- a/src/lib/bits/menu/components/menu-content.svelte
+++ b/src/lib/bits/menu/components/menu-content.svelte
@@ -48,19 +48,21 @@
 	$: builder = $menu;
 	$: Object.assign(builder, attrs);
 
-	$: updatePositioning({
-		side,
-		align,
-		sideOffset,
-		alignOffset,
-		collisionPadding,
-		avoidCollisions,
-		collisionBoundary,
-		sameWidth,
-		fitViewport,
-		strategy,
-		overlap
-	});
+	$: if ($open) {
+		updatePositioning({
+			side,
+			align,
+			sideOffset,
+			alignOffset,
+			collisionPadding,
+			avoidCollisions,
+			collisionBoundary,
+			sameWidth,
+			fitViewport,
+			strategy,
+			overlap
+		});
+	}
 </script>
 
 {#if asChild && $open}

--- a/src/lib/bits/popover/components/popover-content.svelte
+++ b/src/lib/bits/popover/components/popover-content.svelte
@@ -46,19 +46,21 @@
 	$: builder = $content;
 	$: Object.assign(builder, attrs);
 
-	$: updatePositioning({
-		side,
-		align,
-		sideOffset,
-		alignOffset,
-		collisionPadding,
-		avoidCollisions,
-		collisionBoundary,
-		sameWidth,
-		fitViewport,
-		strategy,
-		overlap
-	});
+	$: if ($open) {
+		updatePositioning({
+			side,
+			align,
+			sideOffset,
+			alignOffset,
+			collisionPadding,
+			avoidCollisions,
+			collisionBoundary,
+			sameWidth,
+			fitViewport,
+			strategy,
+			overlap
+		});
+	}
 </script>
 
 {#if asChild && $open}

--- a/src/lib/bits/popover/components/popover.svelte
+++ b/src/lib/bits/popover/components/popover.svelte
@@ -35,6 +35,12 @@
 				open = next;
 			}
 			return next;
+		},
+		positioning: {
+			gutter: 0,
+			offset: {
+				mainAxis: 1
+			}
 		}
 	});
 

--- a/src/lib/bits/popover/ctx.ts
+++ b/src/lib/bits/popover/ctx.ts
@@ -23,6 +23,10 @@ export function setCtx(props: CreatePopoverProps) {
 	const getAttrs = createBitAttrs(NAME, PARTS);
 	const popover = {
 		...createPopover({
+			positioning: {
+				placement: "bottom",
+				gutter: 0
+			},
 			...removeUndefined(props),
 			forceVisible: true
 		}),

--- a/src/lib/bits/select/components/select-content.svelte
+++ b/src/lib/bits/select/components/select-content.svelte
@@ -50,19 +50,21 @@
 	$: builder = $menu;
 	$: Object.assign(builder, attrs);
 
-	$: updatePositioning({
-		side,
-		align,
-		sideOffset,
-		alignOffset,
-		collisionPadding,
-		avoidCollisions,
-		collisionBoundary,
-		sameWidth,
-		fitViewport,
-		strategy,
-		overlap
-	});
+	$: if ($open) {
+		updatePositioning({
+			side,
+			align,
+			sideOffset,
+			alignOffset,
+			collisionPadding,
+			avoidCollisions,
+			collisionBoundary,
+			sameWidth,
+			fitViewport,
+			strategy,
+			overlap
+		});
+	}
 </script>
 
 <!-- svelte-ignore a11y-no-static-element-interactions / applied by melt's builder-->


### PR DESCRIPTION
Fixes a bug where when an `Arrow` component was used within one of the floating components, the content would shift further and further away from the trigger with each open/close.

Closes: #288 