### PR TITLE
docs: fix Alert Dialog closeOnOutsideClick default

### DIFF
--- a/src/content/api-reference/alert-dialog.ts
+++ b/src/content/api-reference/alert-dialog.ts
@@ -31,7 +31,7 @@ const root: APISchema<AlertDialog.Props> = {
 		},
 		closeOnOutsideClick: {
 			type: C.BOOLEAN,
-			default: C.TRUE,
+			default: C.FALSE,
 			description: "Whether to close the alert dialog when a click occurs outside of it."
 		},
 		open: {


### PR DESCRIPTION
The docs claim Alert Dialog's closeOnOutsideClick property is true by default but it is not:
https://github.com/huntabyte/bits-ui/blob/84930bafd1a11fcd901778f7c1e7441a296219bd/src/lib/bits/alert-dialog/components/alert-dialog.svelte#L10

I assume its behaving as intended, just like the radix primitives, so this PR just fixes the typo in the docs.