### PR TITLE
fix: menubar sub bug and update Melt UI to latest

### DIFF
--- a/.changeset/selfish-numbers-know.md
+++ b/.changeset/selfish-numbers-know.md
@@ -1,0 +1,5 @@
+---
+"bits-ui": patch
+---
+
+Menubar: fixed bug preventing submenus from being disabled

--- a/.changeset/stupid-lobsters-provide.md
+++ b/.changeset/stupid-lobsters-provide.md
@@ -1,0 +1,5 @@
+---
+"bits-ui": minor
+---
+
+Slider: `ticks` and `thumbs` are now arrays of builders passed via the `Slider.Root`s slot props and must be passed to the individual `Slider.Thumb` and `Slider.Tick` components

--- a/content/components/slider.md
+++ b/content/components/slider.md
@@ -28,4 +28,58 @@ description: Allows users to select a value from a continuous range by sliding a
 </Slider.Root>
 ```
 
+## Examples
+
+### Multiple Thumbs and Ticks
+
+If the `value` prop has more than one value, the slider will render multiple thumbs. You can also use the `ticks` slot prop to render ticks at specific intervals.
+
+```svelte
+<script lang="ts">
+	import { Slider } from "bits-ui";
+
+	let value = [5, 7];
+</script>
+
+<Slider.Root min={0} max={10} step={1} bind:value let:ticks let:thumbs>
+	<Slider.Range />
+
+	{#each thumbs as thumb}
+		<Slider.Thumb {thumb} />
+	{/each}
+
+	{#each ticks as tick}
+		<Slider.Tick {tick} />
+	{/each}
+</Slider.Root>
+```
+
+### Vertical Orientation
+
+You can use the `orientation` prop to change the orientation of the slider, which defaults to `"horizontal"`.
+
+```svelte
+<Slider.Root let:thumbs orientation="vertical">
+	<Slider.Range />
+
+	{#each thumbs as thumb}
+		<Slider.Thumb {thumb} />
+	{/each}
+</Slider.Root>
+```
+
+### RTL Support
+
+You can use the `dir` prop to change the reading direction of the slider, which defaults to `"ltr"`.
+
+```svelte
+<Slider.Root let:thumbs dir="rtl">
+	<Slider.Range />
+
+	{#each thumbs as thumb}
+		<Slider.Thumb {thumb} />
+	{/each}
+</Slider.Root>
+```
+
 <APISection {schemas} />

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
   "type": "module",
   "dependencies": {
     "@internationalized/date": "^3.5.1",
-    "@melt-ui/svelte": "0.68.0",
+    "@melt-ui/svelte": "0.71.2",
     "nanoid": "^5.0.4"
   },
   "peerDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ dependencies:
     specifier: ^3.5.1
     version: 3.5.1
   '@melt-ui/svelte':
-    specifier: 0.68.0
-    version: 0.68.0(svelte@4.2.8)
+    specifier: 0.71.2
+    version: 0.71.2(svelte@4.2.8)
   nanoid:
     specifier: ^5.0.4
     version: 5.0.4
@@ -24,7 +24,7 @@ devDependencies:
     version: 0.16.5(svelte@4.2.8)
   '@melt-ui/pp':
     specifier: ^0.3.0
-    version: 0.3.0(@melt-ui/svelte@0.68.0)(svelte@4.2.8)
+    version: 0.3.0(@melt-ui/svelte@0.71.2)(svelte@4.2.8)
   '@playwright/test':
     specifier: ^1.28.1
     version: 1.36.2
@@ -1078,21 +1078,21 @@ packages:
       - supports-color
     dev: true
 
-  /@melt-ui/pp@0.3.0(@melt-ui/svelte@0.68.0)(svelte@4.2.8):
+  /@melt-ui/pp@0.3.0(@melt-ui/svelte@0.71.2)(svelte@4.2.8):
     resolution: {integrity: sha512-b07Bdh8l2KcwKVCXOY+SoBw1dk9eWvQfMSi6SoacpRVyVmmfpi0kV4oGt3HYF0tUCB3sEmVicxse50ZzZxEzEA==}
     engines: {pnpm: '>=8.6.3'}
     peerDependencies:
       '@melt-ui/svelte': '>= 0.29.0'
       svelte: ^3.55.0 || ^4.0.0 || ^5.0.0-next.1
     dependencies:
-      '@melt-ui/svelte': 0.68.0(svelte@4.2.8)
+      '@melt-ui/svelte': 0.71.2(svelte@4.2.8)
       estree-walker: 3.0.3
       magic-string: 0.30.5
       svelte: 4.2.8
     dev: true
 
-  /@melt-ui/svelte@0.68.0(svelte@4.2.8):
-    resolution: {integrity: sha512-/QvA98hnYEodZtHJ71+ocum/WWp30hVNt3F8uiZKnNYwZDaiQYjlyR9AaGKYcZLCe6R68op1mfCzc0kTzJilyA==}
+  /@melt-ui/svelte@0.71.2(svelte@4.2.8):
+    resolution: {integrity: sha512-GDUErhAphEoEOLpcBjQ84BgzRR6M3344fQE4QYFffwT7aedWak7CvNsECgeig1Y5xvfDmeEaFnGlOQXIBucJYw==}
     peerDependencies:
       svelte: '>=3 <5'
     dependencies:
@@ -2477,7 +2477,7 @@ packages:
       normalize-path: 3.0.0
       readdirp: 3.6.0
     optionalDependencies:
-      fsevents: 2.3.2
+      fsevents: 2.3.3
     dev: true
 
   /chownr@2.0.0:

--- a/src/components/demos/slider-demo.svelte
+++ b/src/components/demos/slider-demo.svelte
@@ -7,6 +7,7 @@
 <div class="w-full md:max-w-[280px]">
 	<Slider.Root
 		bind:value
+		let:thumbs
 		class="relative flex w-full touch-none select-none items-center"
 	>
 		<span
@@ -14,8 +15,11 @@
 		>
 			<Slider.Range class="absolute h-full bg-foreground" />
 		</span>
-		<Slider.Thumb
-			class="block rounded-full border border-border-input bg-background shadow transition-colors sq-[27px] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-foreground focus-visible:ring-offset-2 active:scale-98 disabled:pointer-events-none disabled:opacity-50"
-		/>
+		{#each thumbs as thumb}
+			<Slider.Thumb
+				{thumb}
+				class="block rounded-full border border-border-input bg-background shadow transition-colors sq-[27px] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-foreground focus-visible:ring-offset-2 active:scale-98 disabled:pointer-events-none disabled:opacity-50"
+			/>
+		{/each}
 	</Slider.Root>
 </div>

--- a/src/content/api-reference/slider.ts
+++ b/src/content/api-reference/slider.ts
@@ -59,11 +59,15 @@ const root: APISchema<Slider.Props> = {
 		...domElProps("HTMLSpanElement")
 	},
 	slotProps: {
-		...builderAndAttrsSlotProps,
 		ticks: {
-			type: C.NUMBER,
-			description: "The number of ticks to display on the slider."
-		}
+			type: "Tick[]",
+			description: "The tick builders to pass to the individual `Slider.Tick` components."
+		},
+		thumbs: {
+			type: "Thumb[]",
+			description: "The thumb builders to pass to the individual `Slider.Thumb` components."
+		},
+		...builderAndAttrsSlotProps
 	},
 	dataAttributes: [
 		{
@@ -82,7 +86,14 @@ const root: APISchema<Slider.Props> = {
 const thumb: APISchema<Slider.ThumbProps> = {
 	title: "Thumb",
 	description: "A thumb on the slider.",
-	props: domElProps("HTMLSpanElement"),
+	props: {
+		thumb: {
+			type: "Thumb",
+			description:
+				"An individual thumb builder from the `thumbs` slot prop provided by the `Slider.Root` component."
+		},
+		...domElProps("HTMLSpanElement")
+	},
 	slotProps: { ...builderAndAttrsSlotProps },
 	dataAttributes: [
 		{
@@ -108,7 +119,14 @@ const range: APISchema<Slider.RangeProps> = {
 const tick: APISchema<Slider.TickProps> = {
 	title: "Tick",
 	description: "A tick mark on the slider.",
-	props: domElProps("HTMLSpanElement"),
+	props: {
+		tick: {
+			type: "Tick",
+			description:
+				"An individual tick builder from the `ticks` slot prop provided by the `Slider.Root` component."
+		},
+		...domElProps("HTMLSpanElement")
+	},
 	slotProps: { ...builderAndAttrsSlotProps },
 	dataAttributes: [
 		{

--- a/src/lib/bits/menu/components/menu-sub-trigger.svelte
+++ b/src/lib/bits/menu/components/menu-sub-trigger.svelte
@@ -17,8 +17,10 @@
 	const {
 		elements: { subTrigger },
 		ids,
-		getAttrs
+		getAttrs,
+		options
 	} = getSubTrigger();
+	const { disabled: disabledStore } = options;
 
 	const dispatch = createDispatcher();
 
@@ -27,7 +29,10 @@
 	}
 
 	$: builder = $subTrigger;
-	$: attrs = { ...getAttrs("sub-trigger"), ...disabledAttrs(disabled) };
+	$: attrs = {
+		...getAttrs("sub-trigger"),
+		...disabledAttrs(disabled || $disabledStore)
+	};
 	$: Object.assign(builder, attrs);
 </script>
 

--- a/src/lib/bits/slider/_types.ts
+++ b/src/lib/bits/slider/_types.ts
@@ -3,8 +3,9 @@
  * to type-check our API documentation, which requires we document each prop,
  * but we don't want to document the HTML attributes.
  */
-import type { CreateSliderProps } from "@melt-ui/svelte";
+import type { CreateSliderProps, Slider } from "@melt-ui/svelte";
 import type { Expand, OmitValue, OnChangeFn, DOMElement } from "$lib/internal/index.js";
+import type { StoresValues } from "svelte/store";
 
 type Props = Expand<
 	OmitValue<CreateSliderProps> & {
@@ -23,8 +24,23 @@ type Props = Expand<
 
 type RangeProps = DOMElement<HTMLSpanElement>;
 
-type ThumbProps = DOMElement<HTMLSpanElement>;
+type ThumbProps = DOMElement<HTMLSpanElement> & {
+	/**
+	 * An individual thumb builder from the `thumbs` slot prop
+	 * provided by the `Slider.Root` component.
+	 */
+	thumb: Thumb;
+};
 
-type TickProps = DOMElement<HTMLSpanElement>;
+type TickProps = DOMElement<HTMLSpanElement> & {
+	/**
+	 * An individual tick builder from the `ticks` slot prop
+	 * provided by the `Slider.Root` component.
+	 */
+	tick: Tick;
+};
 
 export type { Props, RangeProps, ThumbProps, TickProps };
+
+type Tick = StoresValues<Slider["elements"]["ticks"]>[number];
+type Thumb = StoresValues<Slider["elements"]["thumbs"]>[number];

--- a/src/lib/bits/slider/components/slider-thumb.svelte
+++ b/src/lib/bits/slider/components/slider-thumb.svelte
@@ -9,16 +9,14 @@
 
 	export let asChild: $$Props["asChild"] = false;
 	export let el: $$Props["el"] = undefined;
+	export let thumb: $$Props["thumb"];
 
-	const {
-		elements: { thumb },
-		getAttrs
-	} = getCtx();
+	const { getAttrs } = getCtx();
 
 	const dispatch = createDispatcher();
 	const attrs = getAttrs("thumb");
 
-	$: builder = $thumb();
+	$: builder = thumb;
 	$: Object.assign(builder, attrs);
 </script>
 

--- a/src/lib/bits/slider/components/slider-tick.svelte
+++ b/src/lib/bits/slider/components/slider-tick.svelte
@@ -7,15 +7,13 @@
 
 	export let asChild: $$Props["asChild"] = false;
 	export let el: $$Props["el"] = undefined;
+	export let tick: $$Props["tick"];
 
-	const {
-		elements: { tick },
-		getAttrs
-	} = getCtx();
+	const { getAttrs } = getCtx();
 
 	const attrs = getAttrs("tick");
 
-	$: builder = $tick();
+	$: builder = tick;
 	$: Object.assign(builder, attrs);
 </script>
 

--- a/src/lib/bits/slider/components/slider.svelte
+++ b/src/lib/bits/slider/components/slider.svelte
@@ -16,8 +16,8 @@
 	export let el: $$Props["el"] = undefined;
 
 	const {
-		elements: { root },
-		states: { value: localValue, ticks },
+		elements: { root, ticks, thumbs },
+		states: { value: localValue },
 		updateOption,
 		getAttrs
 	} = setCtx({
@@ -50,9 +50,9 @@
 </script>
 
 {#if asChild}
-	<slot {builder} ticks={$ticks} />
+	<slot {builder} ticks={$ticks} thumbs={$thumbs} />
 {:else}
 	<span bind:this={el} use:melt={builder} {...$$restProps}>
-		<slot {builder} ticks={$ticks} />
+		<slot {builder} ticks={$ticks} thumbs={$thumbs} />
 	</span>
 {/if}

--- a/src/tests/slider/SliderRangeTest.svelte
+++ b/src/tests/slider/SliderRangeTest.svelte
@@ -6,22 +6,29 @@
 </script>
 
 <main>
-	<Slider.Root data-testid="root" bind:value {...$$restProps} let:ticks>
+	<Slider.Root
+		data-testid="root"
+		bind:value
+		{...$$restProps}
+		let:ticks
+		let:thumbs
+	>
 		<span
 			class="bg-primary/20 relative h-1.5 w-full grow overflow-hidden rounded-full"
 		>
 			<Slider.Range data-testid="range" class="bg-primary absolute h-full" />
 		</span>
-		{#each value as _, i}
+		{#each thumbs as thumb, i}
 			<Slider.Thumb
+				{thumb}
 				aria-label="Volume"
 				data-testid="thumb-{i}"
 				class="border-primary/50 focus-visible:ring-ring block h-4 w-4 rounded-full border bg-background shadow transition-colors focus-visible:outline-none focus-visible:ring-1 disabled:pointer-events-none disabled:opacity-50"
 			/>
 		{/each}
 
-		{#each { length: ticks } as _}
-			<Slider.Tick data-testid="tick" />
+		{#each ticks as tick}
+			<Slider.Tick data-testid="tick" {tick} />
 		{/each}
 	</Slider.Root>
 </main>

--- a/src/tests/slider/SliderTest.svelte
+++ b/src/tests/slider/SliderTest.svelte
@@ -29,6 +29,7 @@
 		bind:value
 		{...$$restProps}
 		let:ticks
+		let:thumbs
 		{min}
 		{max}
 		{step}
@@ -38,14 +39,17 @@
 		>
 			<Slider.Range data-testid="range" class="bg-primary absolute h-full" />
 		</span>
-		<Slider.Thumb
-			aria-label="age"
-			data-testid="thumb"
-			class="border-primary/50 focus-visible:ring-ring block h-4 w-4 rounded-full border bg-background shadow transition-colors focus-visible:outline-none focus-visible:ring-1 disabled:pointer-events-none disabled:opacity-50"
-		/>
+		{#each thumbs as thumb}
+			<Slider.Thumb
+				{thumb}
+				aria-label="age"
+				data-testid="thumb"
+				class="border-primary/50 focus-visible:ring-ring block h-4 w-4 rounded-full border bg-background shadow transition-colors focus-visible:outline-none focus-visible:ring-1 disabled:pointer-events-none disabled:opacity-50"
+			/>
+		{/each}
 
-		{#each { length: ticks } as _}
-			<Slider.Tick data-testid="tick" />
+		{#each ticks as tick}
+			<Slider.Tick data-testid="tick" {tick} />
 		{/each}
 	</Slider.Root>
 </main>


### PR DESCRIPTION
Closes #307
Closes #304 

This PR also updates Melt UI to the latest version which results in a multitude of small bug fixes regarding dialogs and menu performance. However, these updates introduce a breaking change to the `Slider` components.

The `Slider.Root` now exposes the `thumbs` and `ticks` slot props, each of which is an array of builders that must be passed to the `Slider.Thumb` and `Slider.Tick` components if being used.

```svelte
<Slider.Root let:thumbs let:ticks>
	<!-- ... -->
	{#each thumbs as thumb}
		<Slider.Thumb {thumb} />
	{/each}

	{#each ticks as tick}
		<Slider.Tick {tick} />
	{/each}
	<!-- ... -->
</Slider.Root>
```