### PR TITLE
fix: Forward click events from toolbar buttons and links

### DIFF
--- a/.changeset/funny-balloons-bathe.md
+++ b/.changeset/funny-balloons-bathe.md
@@ -1,5 +1,0 @@
----
-"bits-ui": patch
----
-
-fix: Forward click events from toolbar buttons and links

--- a/.changeset/funny-balloons-bathe.md
+++ b/.changeset/funny-balloons-bathe.md
@@ -1,0 +1,5 @@
+---
+"bits-ui": patch
+---
+
+fix: Forward click events from toolbar buttons and links

--- a/src/lib/bits/toolbar/components/toolbar-button.svelte
+++ b/src/lib/bits/toolbar/components/toolbar-button.svelte
@@ -25,7 +25,7 @@
 {#if asChild}
 	<slot {builder} />
 {:else}
-	<button bind:this={el} use:melt={builder} type="button" {...$$restProps} on:m-keydown={dispatch}>
+	<button bind:this={el} use:melt={builder} type="button" {...$$restProps} on:click on:m-keydown={dispatch}>
 		<slot {builder} />
 	</button>
 {/if}

--- a/src/lib/bits/toolbar/components/toolbar-button.svelte
+++ b/src/lib/bits/toolbar/components/toolbar-button.svelte
@@ -25,7 +25,14 @@
 {#if asChild}
 	<slot {builder} />
 {:else}
-	<button bind:this={el} use:melt={builder} type="button" {...$$restProps} on:click on:m-keydown={dispatch}>
+	<button
+		bind:this={el}
+		use:melt={builder}
+		type="button"
+		{...$$restProps}
+		on:click
+		on:m-keydown={dispatch}
+	>
 		<slot {builder} />
 	</button>
 {/if}

--- a/src/lib/bits/toolbar/components/toolbar-link.svelte
+++ b/src/lib/bits/toolbar/components/toolbar-link.svelte
@@ -25,6 +25,7 @@
 {#if asChild}
 	<slot {builder} />
 {:else}
+	<!-- svelte-ignore a11y-no-static-element-interactions -->
 	<svelte:element
 		this={"a"}
 		bind:this={el}

--- a/src/lib/bits/toolbar/components/toolbar-link.svelte
+++ b/src/lib/bits/toolbar/components/toolbar-link.svelte
@@ -30,6 +30,7 @@
 		bind:this={el}
 		use:melt={builder}
 		{...$$restProps}
+		on:click
 		on:m-keydown={dispatch}
 	>
 		<slot {builder} />

--- a/src/lib/bits/toolbar/types.ts
+++ b/src/lib/bits/toolbar/types.ts
@@ -16,12 +16,18 @@ type GroupItemProps = I.GroupItemProps & HTMLButtonAttributes;
 /**
  * Events
  */
-type ButtonEvents = {
-	keydown: CustomEventHandler<KeyboardEvent, HTMLButtonElement>;
+type HTMLEventHandler<T extends Event = Event, E extends Element = Element> = T & {
+	currentTarget: EventTarget & E;
 };
 
-type LinkEvents = {
-	keydown: CustomEventHandler<KeyboardEvent, HTMLAnchorElement>;
+type ButtonEvents<T extends Element = HTMLButtonElement> = {
+	click: HTMLEventHandler<MouseEvent, T>;
+	keydown: CustomEventHandler<KeyboardEvent, T>;
+};
+
+type LinkEvents<T extends Element = HTMLAnchorElement> = {
+	click: HTMLEventHandler<MouseEvent, T>;
+	keydown: CustomEventHandler<KeyboardEvent, T>;
 };
 
 type GroupItemEvents<T extends Element = HTMLButtonElement> = {

--- a/src/tests/toolbar/Toolbar.spec.ts
+++ b/src/tests/toolbar/Toolbar.spec.ts
@@ -29,6 +29,7 @@ function setup(
 	const button = returned.getByTestId("button");
 	const styleBinding = returned.getByTestId("style-binding");
 	const alignBinding = returned.getByTestId("align-binding");
+	const clickedBinding = returned.getByTestId("clicked-binding");
 	return {
 		user,
 		root,
@@ -44,6 +45,7 @@ function setup(
 		button,
 		styleBinding,
 		alignBinding,
+		clickedBinding,
 		...returned,
 	};
 }
@@ -233,6 +235,26 @@ describe("Toolbar", () => {
 		expect(groupSingleItemCenter).toHaveAttribute("data-state", "on");
 		expect(groupSingleItemCenter).toHaveAttribute("aria-checked", "true");
 	});
+
+	it.each(["link", "button"])("toolbar %s forwards click event", async (kind) => {
+		const { user, clickedBinding, [kind as keyof ReturnType<typeof setup>]: el } = setup();
+
+		expect(clickedBinding).toHaveTextContent("undefined");
+		await user.click(el as Element);
+		expect(clickedBinding).toHaveTextContent(kind);
+	});
+
+	it.each([kbd.ENTER, kbd.SPACE])(
+		"toolbar button forwards click event when the %s key is pressed",
+		async (key) => {
+			const { user, button, clickedBinding } = setup();
+
+			button.focus();
+			expect(clickedBinding).toHaveTextContent("undefined");
+			await user.keyboard(key);
+			expect(clickedBinding).toHaveTextContent("button");
+		}
+	);
 
 	it.todo("`asChild` behavior");
 });

--- a/src/tests/toolbar/ToolbarTest.svelte
+++ b/src/tests/toolbar/ToolbarTest.svelte
@@ -11,6 +11,8 @@
 
 	let style: string[] | undefined = ["bold"];
 	let align: string | undefined;
+
+	let clicked: string | undefined;
 </script>
 
 <main>
@@ -20,6 +22,10 @@
 
 	<button data-testid="align-binding" on:click={() => (align = "center")}>
 		{align}
+	</button>
+
+	<button data-testid="clicked-binding">
+		{clicked}
 	</button>
 
 	<Toolbar.Root data-testid="root" {...$$restProps}>
@@ -60,8 +66,10 @@
 			</Toolbar.GroupItem>
 		</Toolbar.Group>
 
-		<Toolbar.Link data-testid="link">Edited 2 hours ago</Toolbar.Link>
+		<Toolbar.Link data-testid="link" on:click={() => (clicked = "link")}
+			>Edited 2 hours ago</Toolbar.Link
+		>
 
-		<Toolbar.Button data-testid="button">Save</Toolbar.Button>
+		<Toolbar.Button data-testid="button" on:click={() => (clicked = "button")}>Save</Toolbar.Button>
 	</Toolbar.Root>
 </main>


### PR DESCRIPTION
At present click events are not forwarded from toolbar buttons and links, making them pretty much useless except in render delegation mode.