### PR TITLE
fix: Adjusted import aliases to fix the malformed package build

### DIFF
--- a/.changeset/clean-peas-add.md
+++ b/.changeset/clean-peas-add.md
@@ -2,4 +2,4 @@
 "bits-ui": patch
 ---
 
-fix: Adjusted internal aliases to fix `@melt/svelte` imports in the built package
+fix: Adjusted internal import aliases to fix the malformed package build

--- a/.changeset/clean-peas-add.md
+++ b/.changeset/clean-peas-add.md
@@ -1,0 +1,5 @@
+---
+"bits-ui": patch
+---
+
+fix: Adjusted internal aliases to fix `@melt/svelte` imports in the built package

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -13,13 +13,12 @@ const config = {
 	kit: {
 		adapter: adapter(),
 		alias: {
-			$lib: "src/lib",
+			$lib: "src/lib/index.js",
 			"$lib/*": "src/lib/*",
-			$internal: "src/lib/internal",
+			$internal: "src/lib/internal/index.js",
 			"$internal/*": "src/lib/internal/*",
 			"@/*": "src/*",
-			"@": "src",
-			$icons: "src/components/icons",
+			$icons: "src/components/icons/index.js",
 			"$icons/*": "src/components/icons/*",
 			"contentlayer/generated": ".contentlayer/generated",
 		},

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,8 @@
 		"sourceMap": true,
 		"strict": true,
 		"moduleResolution": "NodeNext",
-		"module": "NodeNext"
+		"module": "NodeNext",
+		"verbatimModuleSyntax": true
 	},
 	"include": [
 		"./svelte-kit/ambient.d.ts",


### PR DESCRIPTION
The `@` alias that was added [here](https://github.com/huntabyte/bits-ui/pull/367/files#diff-6317e218ea40a2a9b47af98e100e81c06f9c0abff66737e6ca06ec4b29402242) was replacing all instances of `@` in the import paths, causing the built package to break when it would misfire upon seeing `@melt-ui/svelte`.