### PR TITLE
fix: Wrap CustomEventHandler with CustomEvent

### DIFF
--- a/.changeset/nine-carpets-vanish.md
+++ b/.changeset/nine-carpets-vanish.md
@@ -1,0 +1,5 @@
+---
+"bits-ui": patch
+---
+
+fix: Event type for `CustomEventHandler` (#389)

--- a/src/lib/helpers/event-handlers.ts
+++ b/src/lib/helpers/event-handlers.ts
@@ -1,4 +1,4 @@
-export type CustomEventHandler<T extends Event = Event, M extends Element = Element> = T & {
-	currentTarget: EventTarget & M;
-	originalEvent: T;
-};
+export type CustomEventHandler<T extends Event = Event, M extends Element = Element> = CustomEvent<{
+    currentTarget: EventTarget & M;
+    originalEvent: T;
+}>;

--- a/src/lib/helpers/event-handlers.ts
+++ b/src/lib/helpers/event-handlers.ts
@@ -1,4 +1,4 @@
 export type CustomEventHandler<T extends Event = Event, M extends Element = Element> = CustomEvent<{
-    currentTarget: EventTarget & M;
-    originalEvent: T;
+	currentTarget: EventTarget & M;
+	originalEvent: T;
 }>;


### PR DESCRIPTION
Svelte forwarded events are wrapped in a `CustomEvent` (clearly seen when logging the received event from svelte). This fixes incorrect `.detail` types and issue #389 .

`CustomEventHandler` now matches the logged output from event handlers:
![Screenshot 2024-03-12 at 23 33 11](https://github.com/huntabyte/bits-ui/assets/94024065/4c0bb0df-bd7a-4b78-96af-344245525479)

