### PR TITLE
Change contextmenu event to MouseEvent

### DIFF
--- a/.changeset/loud-icons-bake.md
+++ b/.changeset/loud-icons-bake.md
@@ -1,0 +1,5 @@
+---
+"bits-ui": patch
+---
+
+Change `contextmenu` event type to `MouseEvent`

--- a/src/lib/bits/menu/types.ts
+++ b/src/lib/bits/menu/types.ts
@@ -70,7 +70,7 @@ type SubTriggerEvents = Omit<ItemEvents, "pointerdown">;
 // Trigger events used by the context menu
 type ContextTriggerEvents<T extends Element = HTMLDivElement> = {
 	pointerdown: CustomEventHandler<PointerEvent, T>;
-	contextmenu: CustomEventHandler<Event, T>;
+	contextmenu: CustomEventHandler<MouseEvent, T>;
 };
 
 // Trigger events used by the dropdown


### PR DESCRIPTION
Google Chrome gives PointerEvent by according to [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Element/contextmenu_event) Firefox and Safari still sends MouseEvent. PointerEvent inherits from MouseEvent and thus giving this the type of MouseEvent should be safe.

I don't know if this is Event because of Melt reasons but this seems sane. If this would warrant a changeset I'll add it, but it seems like a very small change