### PR TITLE
chore: expose `open` and `onOpenChange` props to DatePicker component

### DIFF
--- a/.changeset/afraid-otters-give.md
+++ b/.changeset/afraid-otters-give.md
@@ -1,0 +1,5 @@
+---
+"bits-ui": minor
+---
+
+Expose `open` and `onOpenChange` props to `DatePicker.Root` component

--- a/src/lib/bits/date-picker/components/date-picker.svelte
+++ b/src/lib/bits/date-picker/components/date-picker.svelte
@@ -5,6 +5,8 @@
 
 	type $$Props = Props;
 
+	export let open: $$Props["open"] = undefined;
+	export let onOpenChange: $$Props["onOpenChange"] = undefined;
 	export let value: $$Props["value"] = undefined;
 	export let onValueChange: $$Props["onValueChange"] = undefined;
 	export let placeholder: $$Props["placeholder"] = undefined;
@@ -31,10 +33,16 @@
 	export let onOutsideClick: $$Props["onOutsideClick"] = undefined;
 
 	const {
-		states: { value: localValue, placeholder: localPlaceholder, isInvalid: localIsInvalid },
+		states: {
+			open: localOpen,
+			value: localValue,
+			placeholder: localPlaceholder,
+			isInvalid: localIsInvalid,
+		},
 		updateOption,
 		ids,
 	} = setCtx({
+		defaultOpen: open,
 		defaultValue: value,
 		defaultPlaceholder: placeholder,
 		preventDeselect,
@@ -66,6 +74,13 @@
 			if (placeholder !== next) {
 				onPlaceholderChange?.(next);
 				placeholder = next;
+			}
+			return next;
+		},
+		onOpenChange: ({ next }) => {
+			if (open !== next) {
+				onOpenChange?.(next);
+				open = next;
 			}
 			return next;
 		},
@@ -132,6 +147,7 @@
 
 	$: value !== undefined && localValue.set(value);
 	$: placeholder !== undefined && localPlaceholder.set(placeholder);
+	$: open !== undefined && localOpen.set(open);
 
 	$: updateOption("disabled", disabled);
 	$: updateOption("isDateUnavailable", isDateUnavailable);


### PR DESCRIPTION
After this discussion here https://github.com/huntabyte/bits-ui/discussions/388, it turns out that the `open` prop was not being exposed, ergo, couldn't bind to it for programmatic control.

This P.R exposes it and the `onOpenChange` function.

If there's something else you wish added/removed, please let me know.

Closes: #399 