### PR TITLE
feat: Combobox `touchedInput`

### DIFF
--- a/.changeset/rare-actors-shout.md
+++ b/.changeset/rare-actors-shout.md
@@ -1,0 +1,5 @@
+---
+"bits-ui": minor
+---
+
+feat: Combobox `touchedInput`

--- a/src/components/demos/combobox-demo.svelte
+++ b/src/components/demos/combobox-demo.svelte
@@ -12,13 +12,15 @@
 	];
 
 	let inputValue = "";
+	let touchedInput = false;
 
-	$: filteredFruits = inputValue
-		? fruits.filter((fruit) => fruit.value.includes(inputValue.toLowerCase()))
-		: fruits;
+	$: filteredFruits =
+		inputValue && touchedInput
+			? fruits.filter((fruit) => fruit.value.includes(inputValue.toLowerCase()))
+			: fruits;
 </script>
 
-<Combobox.Root items={filteredFruits} bind:inputValue>
+<Combobox.Root items={filteredFruits} bind:inputValue bind:touchedInput>
 	<div class="relative">
 		<OrangeSlice class="absolute start-3 top-1/2 size-6 -translate-y-1/2 text-muted-foreground" />
 		<Combobox.Input

--- a/src/content/api-reference/combobox.ts
+++ b/src/content/api-reference/combobox.ts
@@ -112,6 +112,12 @@ export const root: APISchema<Combobox.Props> = {
 			description: "An array of items to add type-safety to the `onSelectedChange` callback.",
 		},
 		onOutsideClick: onOutsideClickProp,
+		touchedInput: {
+			type: C.BOOLEAN,
+			default: C.FALSE,
+			description:
+				"The touched state of the input. When the menu closes, the state is reset to `false`. Whenever a key is pressed into the input, the state is set to `true`. You can bind to this to handle filtering the items only when the input has been touched.",
+		},
 	},
 	slotProps: { ids: idsSlotProp },
 };

--- a/src/lib/bits/combobox/_types.ts
+++ b/src/lib/bits/combobox/_types.ts
@@ -66,6 +66,14 @@ type Props<T = unknown, Multiple extends boolean = false> = Expand<
 		 * type the `selected` and `onSelectedChange` props.
 		 */
 		items?: Selected<T>[];
+
+		/**
+		 * Whether the input has been touched or not. You can bind to this to
+		 * handle filtering the items only when the input has been touched.
+		 *
+		 * @defaultValue false
+		 */
+		touchedInput?: boolean;
 	}
 >;
 

--- a/src/lib/bits/combobox/components/combobox.svelte
+++ b/src/lib/bits/combobox/components/combobox.svelte
@@ -30,7 +30,12 @@
 	export let inputValue: $$Props["inputValue"] = "";
 
 	const {
-		states: { open: localOpen, selected: localSelected, inputValue: localInputValue, touchedInput },
+		states: {
+			open: localOpen,
+			selected: localSelected,
+			inputValue: localInputValue,
+			touchedInput: localTouchedInput,
+		},
 		updateOption,
 		ids,
 	} = setCtx<T, Multiple>({
@@ -89,7 +94,11 @@
 		})
 	);
 
-	$: if ($touchedInput) inputValue = $localInputValue;
+	export let touchedInput: boolean;
+
+	$: touchedInput = $localTouchedInput;
+
+	$: if ($localTouchedInput) inputValue = $localInputValue;
 	$: inputValue !== undefined && localInputValue.set(inputValue);
 
 	$: open !== undefined && localOpen.set(open);


### PR DESCRIPTION
Closes: #397

This PR introduces a new prop to the `Combobox.Root`, `touchedInput`, which you can bind to and receive updates on whether the input has been touched or not. This enables you to do things like this:

```svelte
<script lang="ts">
	import { Combobox } from "$lib/index.js";
	import { flyAndScale } from "@/utils/index.js";
	import { Check, OrangeSlice, CaretUpDown } from "$icons/index.js";

	const fruits = [
		{ value: "mango", label: "Mango" },
		{ value: "watermelon", label: "Watermelon" },
		{ value: "apple", label: "Apple" },
		{ value: "pineapple", label: "Pineapple" },
		{ value: "orange", label: "Orange" },
	];

	let inputValue = "";
	let touchedInput = false;

	$: filteredFruits =
		inputValue && touchedInput
			? fruits.filter((fruit) => fruit.value.includes(inputValue.toLowerCase()))
			: fruits;
</script>

<Combobox.Root bind:inputValue bind:touchedInput>
	<!-- ... -->
</Combobox.Root>
 ```

Which shows the full list if the menu is first opened until the user has typed something into the input, rather than keeping the list filtered to the currently selected item.