### PR TITLE
next: improvements

### DIFF
--- a/packages/bits-ui/src/lib/bits/accordion/accordion.svelte.ts
+++ b/packages/bits-ui/src/lib/bits/accordion/accordion.svelte.ts
@@ -240,22 +240,13 @@ class AccordionTriggerState {
 		if (!candidateItems.length) return;
 
 		const currentIndex = candidateItems.indexOf(itemEl);
-
-		switch (e.key) {
-			case kbd.ARROW_DOWN:
-				candidateItems[(currentIndex + 1) % candidateItems.length]?.focus();
-				return;
-			case kbd.ARROW_UP:
-				candidateItems[
-					(currentIndex - 1 + candidateItems.length) % candidateItems.length
-				]?.focus();
-				return;
-			case kbd.HOME:
-				candidateItems[0]?.focus();
-				return;
-			case kbd.END:
-				candidateItems[candidateItems.length - 1]?.focus();
-		}
+		const keyToIndex = {
+			[kbd.ARROW_DOWN]: (currentIndex + 1) % candidateItems.length,
+			[kbd.ARROW_UP]: (currentIndex - 1 + candidateItems.length) % candidateItems.length,
+			[kbd.HOME]: 0,
+			[kbd.END]: candidateItems.length - 1,
+		};
+		candidateItems[keyToIndex[e.key]!]?.focus();
 	});
 
 	get props() {

--- a/packages/bits-ui/src/lib/bits/accordion/accordion.svelte.ts
+++ b/packages/bits-ui/src/lib/bits/accordion/accordion.svelte.ts
@@ -28,8 +28,8 @@ type AccordionBaseStateProps = ReadonlyBoxedValues<{
 
 class AccordionBaseState {
 	id = undefined as unknown as ReadonlyBox<string>;
-	disabled = undefined as unknown as ReadonlyBox<boolean>;
-	forceVisible = undefined as unknown as ReadonlyBox<boolean>;
+	disabled: ReadonlyBox<boolean>;
+	forceVisible: ReadonlyBox<boolean>;
 	#attrs = $derived({
 		id: this.id.value,
 		"data-accordion-root": "",

--- a/packages/bits-ui/src/lib/bits/accordion/accordion.svelte.ts
+++ b/packages/bits-ui/src/lib/bits/accordion/accordion.svelte.ts
@@ -60,12 +60,12 @@ export class AccordionSingleState extends AccordionBaseState {
 		this.#value = props.value;
 	}
 
-	get value() {
-		return this.#value.value;
+	includesItem(item: string) {
+		return this.#value.value === item;
 	}
 
-	set value(v: string) {
-		this.#value.value = v;
+	toggleItem(item: string) {
+		this.#value.value = this.includesItem(item) ? "" : item;
 	}
 }
 
@@ -85,12 +85,16 @@ export class AccordionMultiState extends AccordionBaseState {
 		this.#value = props.value;
 	}
 
-	get value() {
-		return this.#value.value;
+	includesItem(item: string) {
+		return this.#value.value.includes(item);
 	}
 
-	set value(v: string[]) {
-		this.#value.value = v;
+	toggleItem(item: string) {
+		if (this.includesItem(item)) {
+			this.#value.value = this.#value.value.filter((v) => v !== item);
+		} else {
+			this.#value.value = [...this.#value.value, item];
+		}
 	}
 }
 
@@ -113,9 +117,7 @@ export class AccordionItemState {
 		"data-accordion-item": "",
 	} as const;
 	isDisabled = $derived(this.disabled.value || this.root.disabled.value);
-	isSelected = $derived(
-		this.root.isMulti ? this.root.value.includes(this.value) : this.root.value === this.value
-	);
+	isSelected = $derived(this.root.includesItem(this.value));
 
 	constructor(props: AccordionItemStateProps) {
 		this.#value = props.value;
@@ -128,19 +130,7 @@ export class AccordionItemState {
 	}
 
 	updateValue() {
-		if (this.root.isMulti) {
-			if (this.root.value.includes(this.value)) {
-				this.root.value = this.root.value.filter((v) => v !== this.value);
-			} else {
-				this.root.value = [...this.root.value, this.value];
-			}
-		} else {
-			if (this.root.value === this.value) {
-				this.root.value = "";
-			} else {
-				this.root.value = this.value;
-			}
-		}
+		this.root.toggleItem(this.value);
 	}
 
 	get props() {

--- a/packages/bits-ui/src/lib/bits/accordion/accordion.svelte.ts
+++ b/packages/bits-ui/src/lib/bits/accordion/accordion.svelte.ts
@@ -26,19 +26,14 @@ type AccordionBaseStateProps = ReadonlyBoxedValues<{
 	forceVisible: boolean;
 }>;
 
-interface AccordionRootAttrs {
-	id: string;
-	"data-accordion-root": string;
-}
-
 class AccordionBaseState {
 	id: ReadonlyBox<string> = undefined as unknown as ReadonlyBox<string>;
 	disabled: ReadonlyBox<boolean> = undefined as unknown as ReadonlyBox<boolean>;
 	forceVisible: ReadonlyBox<boolean> = undefined as unknown as ReadonlyBox<boolean>;
-	attrs: AccordionRootAttrs = $derived({
+	attrs = $derived({
 		id: this.id.value,
 		"data-accordion-root": "",
-	});
+	} as const);
 
 	constructor(props: AccordionBaseStateProps) {
 		this.id = props.id;
@@ -110,17 +105,13 @@ type AccordionItemStateProps = ReadonlyBoxedValues<{
 	rootState: AccordionState;
 };
 
-interface AccordionItemAttrs {
-	"data-accordion-item": string;
-}
-
 export class AccordionItemState {
 	#value: ReadonlyBox<string>;
 	disabled: ReadonlyBox<boolean> = undefined as unknown as ReadonlyBox<boolean>;
 	root: AccordionState = undefined as unknown as AccordionState;
-	attrs: AccordionItemAttrs = {
+	attrs = {
 		"data-accordion-item": "",
-	};
+	} as const;
 	isDisabled = $derived(this.disabled.value || this.root.disabled.value);
 	isSelected = $derived(
 		this.root.isMulti ? this.root.value.includes(this.value) : this.root.value === this.value
@@ -190,7 +181,7 @@ class AccordionTriggerState {
 	isDisabled = $derived(
 		this.disabled.value || this.itemState.disabled.value || this.root.disabled.value
 	);
-	attrs: Record<string, unknown> = $derived({
+	attrs = $derived({
 		id: this.id.value,
 		disabled: this.isDisabled,
 		"aria-expanded": getAriaExpanded(this.itemState.isSelected),
@@ -199,7 +190,7 @@ class AccordionTriggerState {
 		"data-value": this.itemState.value,
 		"data-state": openClosedAttrs(this.itemState.isSelected),
 		"data-accordion-trigger": "",
-	});
+	} as const);
 
 	constructor(props: AccordionTriggerStateProps, itemState: AccordionItemState) {
 		this.disabled = props.disabled;
@@ -264,12 +255,12 @@ class AccordionTriggerState {
 
 class AccordionContentState {
 	item = undefined as unknown as AccordionItemState;
-	attrs: Record<string, unknown> = $derived({
+	attrs = $derived({
 		"data-state": openClosedAttrs(this.item.isSelected),
 		"data-disabled": dataDisabledAttrs(this.item.isDisabled),
 		"data-value": this.item.value,
 		"data-accordion-content": "",
-	});
+	} as const);
 
 	constructor(item: AccordionItemState) {
 		this.item = item;

--- a/packages/bits-ui/src/lib/bits/accordion/accordion.svelte.ts
+++ b/packages/bits-ui/src/lib/bits/accordion/accordion.svelte.ts
@@ -30,7 +30,7 @@ class AccordionBaseState {
 	id: ReadonlyBox<string> = undefined as unknown as ReadonlyBox<string>;
 	disabled: ReadonlyBox<boolean> = undefined as unknown as ReadonlyBox<boolean>;
 	forceVisible: ReadonlyBox<boolean> = undefined as unknown as ReadonlyBox<boolean>;
-	attrs = $derived({
+	#attrs = $derived({
 		id: this.id.value,
 		"data-accordion-root": "",
 	} as const);
@@ -42,7 +42,7 @@ class AccordionBaseState {
 	}
 
 	get props() {
-		return this.attrs;
+		return this.#attrs;
 	}
 }
 
@@ -113,7 +113,7 @@ export class AccordionItemState {
 	#value: ReadonlyBox<string>;
 	disabled: ReadonlyBox<boolean> = undefined as unknown as ReadonlyBox<boolean>;
 	root: AccordionState = undefined as unknown as AccordionState;
-	attrs = {
+	#attrs = {
 		"data-accordion-item": "",
 	} as const;
 	isDisabled = $derived(this.disabled.value || this.root.disabled.value);
@@ -134,7 +134,7 @@ export class AccordionItemState {
 	}
 
 	get props() {
-		return this.attrs;
+		return this.#attrs;
 	}
 
 	createTrigger(props: AccordionTriggerStateProps) {
@@ -171,7 +171,7 @@ class AccordionTriggerState {
 	isDisabled = $derived(
 		this.disabled.value || this.itemState.disabled.value || this.root.disabled.value
 	);
-	attrs = $derived({
+	#attrs = $derived({
 		id: this.id.value,
 		disabled: this.isDisabled,
 		"aria-expanded": getAriaExpanded(this.itemState.isSelected),
@@ -232,7 +232,7 @@ class AccordionTriggerState {
 
 	get props() {
 		return {
-			...this.attrs,
+			...this.#attrs,
 			onclick: this.onclick,
 			onkeydown: this.onkeydown,
 		};
@@ -245,7 +245,7 @@ class AccordionTriggerState {
 
 class AccordionContentState {
 	item = undefined as unknown as AccordionItemState;
-	attrs = $derived({
+	#attrs = $derived({
 		"data-state": openClosedAttrs(this.item.isSelected),
 		"data-disabled": dataDisabledAttrs(this.item.isDisabled),
 		"data-value": this.item.value,
@@ -257,7 +257,7 @@ class AccordionContentState {
 	}
 
 	get props() {
-		return this.attrs;
+		return this.#attrs;
 	}
 }
 

--- a/packages/bits-ui/src/lib/bits/accordion/accordion.svelte.ts
+++ b/packages/bits-ui/src/lib/bits/accordion/accordion.svelte.ts
@@ -113,11 +113,13 @@ export class AccordionItemState {
 	#value: ReadonlyBox<string>;
 	disabled = undefined as unknown as ReadonlyBox<boolean>;
 	root = undefined as unknown as AccordionState;
-	#attrs = {
-		"data-accordion-item": "",
-	} as const;
 	isDisabled = $derived(this.disabled.value || this.root.disabled.value);
 	isSelected = $derived(this.root.includesItem(this.value));
+	#attrs = $derived({
+		"data-accordion-item": "",
+		"data-state": this.isSelected ? "open" : "closed",
+		"data-disabled": this.isDisabled ? "" : undefined,
+	} as const);
 
 	constructor(props: AccordionItemStateProps) {
 		this.#value = props.value;

--- a/packages/bits-ui/src/lib/bits/accordion/accordion.svelte.ts
+++ b/packages/bits-ui/src/lib/bits/accordion/accordion.svelte.ts
@@ -27,9 +27,9 @@ type AccordionBaseStateProps = ReadonlyBoxedValues<{
 }>;
 
 class AccordionBaseState {
-	id: ReadonlyBox<string> = undefined as unknown as ReadonlyBox<string>;
-	disabled: ReadonlyBox<boolean> = undefined as unknown as ReadonlyBox<boolean>;
-	forceVisible: ReadonlyBox<boolean> = undefined as unknown as ReadonlyBox<boolean>;
+	id = undefined as unknown as ReadonlyBox<string>;
+	disabled = undefined as unknown as ReadonlyBox<boolean>;
+	forceVisible = undefined as unknown as ReadonlyBox<boolean>;
 	#attrs = $derived({
 		id: this.id.value,
 		"data-accordion-root": "",
@@ -111,8 +111,8 @@ type AccordionItemStateProps = ReadonlyBoxedValues<{
 
 export class AccordionItemState {
 	#value: ReadonlyBox<string>;
-	disabled: ReadonlyBox<boolean> = undefined as unknown as ReadonlyBox<boolean>;
-	root: AccordionState = undefined as unknown as AccordionState;
+	disabled = undefined as unknown as ReadonlyBox<boolean>;
+	root = undefined as unknown as AccordionState;
 	#attrs = {
 		"data-accordion-item": "",
 	} as const;
@@ -158,10 +158,10 @@ type AccordionTriggerStateProps = ReadonlyBoxedValues<{
 }>;
 
 class AccordionTriggerState {
-	disabled: ReadonlyBox<boolean> = undefined as unknown as ReadonlyBox<boolean>;
-	id: ReadonlyBox<string> = undefined as unknown as ReadonlyBox<string>;
-	root: AccordionState = undefined as unknown as AccordionState;
-	itemState: AccordionItemState = undefined as unknown as AccordionItemState;
+	disabled = undefined as unknown as ReadonlyBox<boolean>;
+	id = undefined as unknown as ReadonlyBox<string>;
+	root = undefined as unknown as AccordionState;
+	itemState = undefined as unknown as AccordionItemState;
 	onclickProp = boxWithState<AccordionTriggerStateProps["onclick"]>(readonlyBox(() => () => {}));
 	onkeydownProp = boxWithState<AccordionTriggerStateProps["onkeydown"]>(
 		readonlyBox(() => () => {})

--- a/packages/bits-ui/src/lib/bits/accordion/components/accordion-item.svelte
+++ b/packages/bits-ui/src/lib/bits/accordion/components/accordion-item.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import type { AccordionItemProps } from "../types.js";
 	import { setAccordionItemState } from "../accordion.svelte.js";
-	import { box } from "$lib/internal/box.svelte.js";
+	import { readonlyBox } from "$lib/internal/box.svelte.js";
 	let {
 		asChild,
 		disabled: disabledProp = false,
@@ -12,8 +12,8 @@
 		...restProps
 	}: AccordionItemProps = $props();
 
-	const disabled = box(() => disabledProp);
-	const value = box(() => valueProp);
+	const disabled = readonlyBox(() => disabledProp);
+	const value = readonlyBox(() => valueProp);
 
 	const item = setAccordionItemState({ value, disabled });
 

--- a/packages/bits-ui/src/lib/bits/accordion/components/accordion-item.svelte
+++ b/packages/bits-ui/src/lib/bits/accordion/components/accordion-item.svelte
@@ -17,13 +17,9 @@
 
 	const item = setAccordionItemState({ value, disabled });
 
-	const isDisabled = $derived(disabled || item.root.disabled);
-
 	const mergedProps = $derived({
 		...restProps,
 		...item.props,
-		"data-state": item.isSelected ? "open" : "closed",
-		"data-disabled": isDisabled ? "" : undefined,
 	});
 </script>
 

--- a/packages/bits-ui/src/lib/bits/accordion/components/accordion-trigger.svelte
+++ b/packages/bits-ui/src/lib/bits/accordion/components/accordion-trigger.svelte
@@ -2,7 +2,7 @@
 	import type { AccordionTriggerProps } from "../types.js";
 	import { getAccordionTriggerState } from "../accordion.svelte.js";
 	import { generateId } from "$lib/internal/id.js";
-	import { box } from "$lib/internal/box.svelte.js";
+	import { readonlyBox } from "$lib/internal/box.svelte.js";
 
 	let {
 		disabled: disabledProp = false,
@@ -16,10 +16,10 @@
 		...restProps
 	}: AccordionTriggerProps = $props();
 
-	const disabled = box(() => disabledProp);
-	const id = box(() => idProp);
-	const onkeydown = box(() => onkeydownProp);
-	const onclick = box(() => onclickProp);
+	const disabled = readonlyBox(() => disabledProp);
+	const id = readonlyBox(() => idProp);
+	const onkeydown = readonlyBox(() => onkeydownProp);
+	const onclick = readonlyBox(() => onclickProp);
 
 	const trigger = getAccordionTriggerState({
 		disabled,

--- a/packages/bits-ui/src/lib/bits/accordion/components/accordion.svelte
+++ b/packages/bits-ui/src/lib/bits/accordion/components/accordion.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { setAccordionRootState } from "../accordion.svelte.js";
 	import type { AccordionRootProps } from "../types.js";
-	import { box } from "$lib/internal/box.svelte.js";
+	import { box, readonlyBox } from "$lib/internal/box.svelte.js";
 	import { generateId } from "$lib/internal/id.js";
 
 	let {
@@ -40,9 +40,9 @@
 	}
 
 	const value = createValueState();
-	const id = box(() => idProp);
-	const disabled = box(() => disabledProp);
-	const forceVisible = box(() => forceVisibleProp);
+	const id = readonlyBox(() => idProp);
+	const disabled = readonlyBox(() => disabledProp);
+	const forceVisible = readonlyBox(() => forceVisibleProp);
 
 	const rootState = setAccordionRootState({ type, value, id, disabled, forceVisible });
 

--- a/packages/bits-ui/src/lib/bits/accordion/components/accordion.svelte
+++ b/packages/bits-ui/src/lib/bits/accordion/components/accordion.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { setAccordionRootState } from "../accordion.svelte.js";
 	import type { AccordionRootProps } from "../types.js";
-	import { box, readonlyBox } from "$lib/internal/box.svelte.js";
+	import { type Box, box, readonlyBox } from "$lib/internal/box.svelte.js";
 	import { generateId } from "$lib/internal/id.js";
 
 	let {
@@ -18,28 +18,15 @@
 		...restProps
 	}: AccordionRootProps = $props();
 
-	function createValueState() {
-		if (type === "single") {
-			valueProp === undefined && (valueProp = "");
-			return box(
-				() => valueProp as string,
-				(v) => {
-					valueProp = v;
-					onValueChange?.(v as string[] & string);
-				}
-			);
-		}
-		valueProp === undefined && (valueProp = []);
-		return box(
-			() => valueProp as string[],
-			(v) => {
-				valueProp = v;
-				onValueChange?.(v as string[] & string);
-			}
-		);
-	}
+	valueProp === undefined && (type === "single" ? (valueProp = "") : (valueProp = []));
 
-	const value = createValueState();
+	const value = box(
+		() => valueProp!,
+		(v) => {
+			valueProp = v;
+			onValueChange?.(v as any);
+		}
+	) as Box<string> | Box<string[]>;
 	const id = readonlyBox(() => idProp);
 	const disabled = readonlyBox(() => disabledProp);
 	const forceVisible = readonlyBox(() => forceVisibleProp);

--- a/packages/bits-ui/src/lib/bits/avatar/avatar.svelte.ts
+++ b/packages/bits-ui/src/lib/bits/avatar/avatar.svelte.ts
@@ -28,7 +28,7 @@ class AvatarRootState {
 		"data-status": this.loadingStatus.value,
 	});
 
-	#imageTimerId: number = 0;
+	#imageTimerId: NodeJS.Timeout | undefined = undefined;
 
 	constructor(props: AvatarRootStateProps) {
 		this.delayMs = props.delayMs ?? this.delayMs;
@@ -42,18 +42,13 @@ class AvatarRootState {
 
 	#loadImage(src: string) {
 		// clear any existing timers before creating a new one
-		window.clearTimeout(this.#imageTimerId);
+		clearTimeout(this.#imageTimerId);
 		const image = new Image();
 		image.src = src;
 		image.onload = () => {
-			// if its 0 then we don't need to add a delay
-			if (this.delayMs.value !== 0) {
-				this.#imageTimerId = window.setTimeout(() => {
-					this.loadingStatus.value = "loaded";
-				}, this.delayMs.value);
-			} else {
+			this.#imageTimerId = setTimeout(() => {
 				this.loadingStatus.value = "loaded";
-			}
+			}, this.delayMs.value);
 		};
 		image.onerror = () => {
 			this.loadingStatus.value = "error";

--- a/packages/bits-ui/src/lib/bits/avatar/avatar.svelte.ts
+++ b/packages/bits-ui/src/lib/bits/avatar/avatar.svelte.ts
@@ -1,7 +1,6 @@
 import { getContext, setContext } from "svelte";
 import type { ImageLoadingStatus } from "@melt-ui/svelte";
 import type { AvatarImageLoadingStatus } from "./types.js";
-import type { OnChangeFn } from "$lib/internal/types.js";
 import { styleToString } from "$lib/internal/style.js";
 import { type Box, type BoxedValues, box } from "$lib/internal/box.svelte.js";
 

--- a/packages/bits-ui/src/lib/bits/avatar/avatar.svelte.ts
+++ b/packages/bits-ui/src/lib/bits/avatar/avatar.svelte.ts
@@ -2,15 +2,15 @@ import { getContext, setContext } from "svelte";
 import type { ImageLoadingStatus } from "@melt-ui/svelte";
 import type { AvatarImageLoadingStatus } from "./types.js";
 import { styleToString } from "$lib/internal/style.js";
-import { type Box, type BoxedValues, box } from "$lib/internal/box.svelte.js";
+import { type Box, type ReadonlyBox, readonlyBox } from "$lib/internal/box.svelte.js";
 
 /**
  * ROOT
  */
-type AvatarRootStateProps = BoxedValues<{
-	delayMs: number;
-	loadingStatus: AvatarImageLoadingStatus;
-}>;
+type AvatarRootStateProps = {
+	delayMs: ReadonlyBox<number>;
+	loadingStatus: Box<AvatarImageLoadingStatus>;
+};
 
 interface AvatarRootAttrs {
 	"data-avatar-root": string;
@@ -20,9 +20,9 @@ interface AvatarRootAttrs {
 type AvatarImageSrc = string | null | undefined;
 
 class AvatarRootState {
-	src = box<AvatarImageSrc>(() => null);
-	delayMs = box(() => 0);
-	loadingStatus = box<ImageLoadingStatus>(() => "loading");
+	src = readonlyBox<AvatarImageSrc>(() => null);
+	delayMs: ReadonlyBox<number>;
+	loadingStatus: Box<ImageLoadingStatus> = undefined as unknown as Box<ImageLoadingStatus>;
 	#attrs: AvatarRootAttrs = $derived({
 		"data-avatar-root": "",
 		"data-status": this.loadingStatus.value,
@@ -31,7 +31,7 @@ class AvatarRootState {
 	#imageTimerId: NodeJS.Timeout | undefined = undefined;
 
 	constructor(props: AvatarRootStateProps) {
-		this.delayMs = props.delayMs ?? this.delayMs;
+		this.delayMs = props.delayMs;
 		this.loadingStatus = props.loadingStatus;
 
 		$effect.pre(() => {
@@ -55,7 +55,7 @@ class AvatarRootState {
 		};
 	}
 
-	createImage(src: Box<AvatarImageSrc>) {
+	createImage(src: ReadonlyBox<AvatarImageSrc>) {
 		return new AvatarImageState(src, this);
 	}
 
@@ -88,7 +88,7 @@ class AvatarImageState {
 		src: this.root.src.value,
 	});
 
-	constructor(src: Box<AvatarImageSrc>, root: AvatarRootState) {
+	constructor(src: ReadonlyBox<AvatarImageSrc>, root: AvatarRootState) {
 		this.root = root;
 		root.src = src;
 	}
@@ -139,7 +139,7 @@ export function getAvatarRootState(): AvatarRootState {
 	return getContext(AVATAR_ROOT_KEY);
 }
 
-export function getAvatarImageState(src: Box<AvatarImageSrc>) {
+export function getAvatarImageState(src: ReadonlyBox<AvatarImageSrc>) {
 	return getAvatarRootState().createImage(src);
 }
 

--- a/packages/bits-ui/src/lib/bits/avatar/avatar.svelte.ts
+++ b/packages/bits-ui/src/lib/bits/avatar/avatar.svelte.ts
@@ -12,21 +12,16 @@ type AvatarRootStateProps = {
 	loadingStatus: Box<AvatarImageLoadingStatus>;
 };
 
-interface AvatarRootAttrs {
-	"data-avatar-root": string;
-	"data-status": ImageLoadingStatus;
-}
-
 type AvatarImageSrc = string | null | undefined;
 
 class AvatarRootState {
 	src = readonlyBox<AvatarImageSrc>(() => null);
 	delayMs: ReadonlyBox<number>;
 	loadingStatus: Box<ImageLoadingStatus> = undefined as unknown as Box<ImageLoadingStatus>;
-	#attrs: AvatarRootAttrs = $derived({
+	#attrs = $derived({
 		"data-avatar-root": "",
 		"data-status": this.loadingStatus.value,
-	});
+	} as const);
 
 	#imageTimerId: NodeJS.Timeout | undefined = undefined;
 
@@ -72,21 +67,15 @@ class AvatarRootState {
  * IMAGE
  */
 
-interface AvatarImageAttrs {
-	style: string;
-	src: AvatarImageSrc;
-	"data-avatar-image": string;
-}
-
 class AvatarImageState {
 	root: AvatarRootState = undefined as unknown as AvatarRootState;
-	#attrs: AvatarImageAttrs = $derived({
+	#attrs = $derived({
 		style: styleToString({
 			display: this.root.loadingStatus.value === "loaded" ? "block" : "none",
 		}),
 		"data-avatar-image": "",
 		src: this.root.src.value,
-	});
+	} as const);
 
 	constructor(src: ReadonlyBox<AvatarImageSrc>, root: AvatarRootState) {
 		this.root = root;
@@ -102,19 +91,14 @@ class AvatarImageState {
  * FALLBACK
  */
 
-interface AvatarFallbackAttrs {
-	style: string;
-	"data-avatar-fallback": string;
-}
-
 class AvatarFallbackState {
 	root: AvatarRootState = undefined as unknown as AvatarRootState;
-	#attrs: AvatarFallbackAttrs = $derived({
+	#attrs = $derived({
 		style: styleToString({
 			display: this.root.loadingStatus.value === "loaded" ? "none" : "block",
 		}),
 		"data-avatar-fallback": "",
-	});
+	} as const);
 
 	constructor(root: AvatarRootState) {
 		this.root = root;

--- a/packages/bits-ui/src/lib/bits/avatar/avatar.svelte.ts
+++ b/packages/bits-ui/src/lib/bits/avatar/avatar.svelte.ts
@@ -17,7 +17,7 @@ type AvatarImageSrc = string | null | undefined;
 class AvatarRootState {
 	src = readonlyBox<AvatarImageSrc>(() => null);
 	delayMs: ReadonlyBox<number>;
-	loadingStatus: Box<ImageLoadingStatus> = undefined as unknown as Box<ImageLoadingStatus>;
+	loadingStatus = undefined as unknown as Box<ImageLoadingStatus>;
 	#attrs = $derived({
 		"data-avatar-root": "",
 		"data-status": this.loadingStatus.value,
@@ -68,7 +68,7 @@ class AvatarRootState {
  */
 
 class AvatarImageState {
-	root: AvatarRootState = undefined as unknown as AvatarRootState;
+	root = undefined as unknown as AvatarRootState;
 	#attrs = $derived({
 		style: styleToString({
 			display: this.root.loadingStatus.value === "loaded" ? "block" : "none",
@@ -92,7 +92,7 @@ class AvatarImageState {
  */
 
 class AvatarFallbackState {
-	root: AvatarRootState = undefined as unknown as AvatarRootState;
+	root = undefined as unknown as AvatarRootState;
 	#attrs = $derived({
 		style: styleToString({
 			display: this.root.loadingStatus.value === "loaded" ? "none" : "block",

--- a/packages/bits-ui/src/lib/bits/avatar/components/avatar-image.svelte
+++ b/packages/bits-ui/src/lib/bits/avatar/components/avatar-image.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
 	import type { ImageProps } from "../index.js";
 	import { getAvatarImageState } from "../avatar.svelte.js";
-	import { box } from "$lib/internal/box.svelte.js";
+	import { readonlyBox } from "$lib/internal/box.svelte.js";
 
 	let { src: srcProp, asChild, child, el = $bindable(), ...restProps }: ImageProps = $props();
 
-	const src = box(() => srcProp);
+	const src = readonlyBox(() => srcProp);
 
 	const imageState = getAvatarImageState(src);
 

--- a/packages/bits-ui/src/lib/bits/avatar/components/avatar.svelte
+++ b/packages/bits-ui/src/lib/bits/avatar/components/avatar.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import type { RootProps } from "../index.js";
 	import { setAvatarRootState } from "../avatar.svelte.js";
-	import { box } from "$lib/internal/box.svelte.js";
+	import { box, readonlyBox } from "$lib/internal/box.svelte.js";
 
 	let {
 		delayMs: delayMsProp = 0,
@@ -22,7 +22,7 @@
 		}
 	);
 
-	const delayMs = box(() => delayMsProp);
+	const delayMs = readonlyBox(() => delayMsProp);
 
 	const rootState = setAvatarRootState({
 		delayMs,

--- a/packages/bits-ui/src/lib/bits/checkbox/checkbox.svelte.ts
+++ b/packages/bits-ui/src/lib/bits/checkbox/checkbox.svelte.ts
@@ -29,8 +29,8 @@ class CheckboxRootState {
 	checked = undefined as unknown as Box<boolean | "indeterminate">;
 	disabled = undefined as unknown as ReadonlyBox<boolean>;
 	required = undefined as unknown as ReadonlyBox<boolean>;
-	name = undefined as unknown as ReadonlyBox<string | undefined>;
-	value = undefined as unknown as ReadonlyBox<string | undefined>;
+	name: ReadonlyBox<string | undefined>;
+	value: ReadonlyBox<string | undefined>;
 	onclickProp = boxWithState<CheckboxRootStateProps["onclick"]>(readonlyBox(() => () => {}));
 	onkeydownProp = boxWithState<CheckboxRootStateProps["onkeydown"]>(readonlyBox(() => () => {}));
 	#attrs = $derived({

--- a/packages/bits-ui/src/lib/bits/checkbox/checkbox.svelte.ts
+++ b/packages/bits-ui/src/lib/bits/checkbox/checkbox.svelte.ts
@@ -26,15 +26,11 @@ function getCheckboxDataState(checked: boolean | "indeterminate") {
 }
 
 class CheckboxRootState {
-	checked: Box<boolean | "indeterminate"> = undefined as unknown as Box<
-		boolean | "indeterminate"
-	>;
-	disabled: ReadonlyBox<boolean> = undefined as unknown as ReadonlyBox<boolean>;
-	required: ReadonlyBox<boolean> = undefined as unknown as ReadonlyBox<boolean>;
-	name: ReadonlyBox<string | undefined> = undefined as unknown as ReadonlyBox<string | undefined>;
-	value: ReadonlyBox<string | undefined> = undefined as unknown as ReadonlyBox<
-		string | undefined
-	>;
+	checked = undefined as unknown as Box<boolean | "indeterminate">;
+	disabled = undefined as unknown as ReadonlyBox<boolean>;
+	required = undefined as unknown as ReadonlyBox<boolean>;
+	name = undefined as unknown as ReadonlyBox<string | undefined>;
+	value = undefined as unknown as ReadonlyBox<string | undefined>;
 	onclickProp = boxWithState<CheckboxRootStateProps["onclick"]>(readonlyBox(() => () => {}));
 	onkeydownProp = boxWithState<CheckboxRootStateProps["onkeydown"]>(readonlyBox(() => () => {}));
 	#attrs = $derived({

--- a/packages/bits-ui/src/lib/bits/checkbox/checkbox.svelte.ts
+++ b/packages/bits-ui/src/lib/bits/checkbox/checkbox.svelte.ts
@@ -4,19 +4,19 @@
 
 import { getContext, setContext } from "svelte";
 import { getAriaChecked, getAriaRequired, getDataDisabled } from "$lib/internal/attrs.js";
-import { type Box, type BoxedValues, box } from "$lib/internal/box.svelte.js";
+import { type Box, type ReadonlyBox, boxWithState, readonlyBox } from "$lib/internal/box.svelte.js";
 import { type EventCallback, composeHandlers } from "$lib/internal/events.js";
 import { kbd } from "$lib/internal/kbd.js";
 
-type CheckboxRootStateProps = BoxedValues<{
-	checked: boolean | "indeterminate";
-	disabled: boolean;
-	required: boolean;
-	name: string | undefined;
-	value: string | undefined;
-	onclick?: EventCallback<MouseEvent>;
-	onkeydown?: EventCallback<KeyboardEvent>;
-}>;
+type CheckboxRootStateProps = {
+	checked: Box<boolean | "indeterminate">;
+	disabled: ReadonlyBox<boolean>;
+	required: ReadonlyBox<boolean>;
+	name: ReadonlyBox<string | undefined>;
+	value: ReadonlyBox<string | undefined>;
+	onclick: ReadonlyBox<EventCallback<MouseEvent>>;
+	onkeydown: ReadonlyBox<EventCallback<KeyboardEvent>>;
+};
 
 function getCheckboxDataState(checked: boolean | "indeterminate") {
 	if (checked === "indeterminate") {
@@ -26,13 +26,17 @@ function getCheckboxDataState(checked: boolean | "indeterminate") {
 }
 
 class CheckboxRootState {
-	checked = box<boolean | "indeterminate">(() => false);
-	disabled = box(() => false);
-	required = box(() => false);
-	name = box<string | undefined>(() => undefined);
-	value = box<string | undefined>(() => undefined);
-	onclickProp = box(() => {}) as unknown as Box<EventCallback<MouseEvent> | undefined>;
-	onkeydownProp = box(() => {}) as unknown as Box<EventCallback<KeyboardEvent> | undefined>;
+	checked: Box<boolean | "indeterminate"> = undefined as unknown as Box<
+		boolean | "indeterminate"
+	>;
+	disabled: ReadonlyBox<boolean> = undefined as unknown as ReadonlyBox<boolean>;
+	required: ReadonlyBox<boolean> = undefined as unknown as ReadonlyBox<boolean>;
+	name: ReadonlyBox<string | undefined> = undefined as unknown as ReadonlyBox<string | undefined>;
+	value: ReadonlyBox<string | undefined> = undefined as unknown as ReadonlyBox<
+		string | undefined
+	>;
+	onclickProp = boxWithState<CheckboxRootStateProps["onclick"]>(readonlyBox(() => () => {}));
+	onkeydownProp = boxWithState<CheckboxRootStateProps["onkeydown"]>(readonlyBox(() => () => {}));
 	#attrs = $derived({
 		"data-disabled": getDataDisabled(this.disabled.value),
 		"data-state": getCheckboxDataState(this.checked.value),
@@ -50,15 +54,15 @@ class CheckboxRootState {
 		this.required = props.required;
 		this.name = props.name;
 		this.value = props.value;
-		this.onclickProp = props.onclick ?? this.onclickProp;
-		this.onkeydownProp = props.onkeydown ?? this.onkeydownProp;
+		this.onclickProp.value = props.onclick;
+		this.onkeydownProp.value = props.onkeydown;
 	}
 
-	onkeydown = composeHandlers(this.onkeydownProp.value, (e) => {
+	onkeydown = composeHandlers(this.onkeydownProp, (e) => {
 		if (e.key === kbd.ENTER) e.preventDefault();
 	});
 
-	onclick = composeHandlers(this.onclickProp.value, () => {
+	onclick = composeHandlers(this.onclickProp, () => {
 		if (this.disabled.value) return;
 		if (this.checked.value === "indeterminate") {
 			this.checked.value = true;

--- a/packages/bits-ui/src/lib/bits/checkbox/components/checkbox.svelte
+++ b/packages/bits-ui/src/lib/bits/checkbox/components/checkbox.svelte
@@ -2,18 +2,18 @@
 	import type { RootProps } from "../index.js";
 	import { setCheckboxRootState } from "../checkbox.svelte.js";
 	import CheckboxInput from "./checkbox-input.svelte";
-	import { box } from "$lib/internal/box.svelte.js";
+	import { box, readonlyBox } from "$lib/internal/box.svelte.js";
 
 	let {
 		checked: checkedProp = $bindable(false),
 		onCheckedChange,
 		disabled: disabledProp = false,
 		required: requiredProp = false,
-		name: nameProp = undefined,
-		value: valueProp = undefined,
+		name: nameProp,
+		value: valueProp,
 		el = $bindable(),
-		onclick: onclickProp,
-		onkeydown: onkeydownProp,
+		onclick: onclickProp = () => {},
+		onkeydown: onkeydownProp = () => {},
 		asChild,
 		child,
 		indicator,
@@ -27,12 +27,12 @@
 			onCheckedChange?.(v);
 		}
 	);
-	const disabled = box(() => disabledProp);
-	const required = box(() => requiredProp);
-	const name = box(() => nameProp);
-	const value = box(() => valueProp);
-	const onclick = box(() => onclickProp);
-	const onkeydown = box(() => onkeydownProp);
+	const disabled = readonlyBox(() => disabledProp);
+	const required = readonlyBox(() => requiredProp);
+	const name = readonlyBox(() => nameProp);
+	const value = readonlyBox(() => valueProp);
+	const onclick = readonlyBox(() => onclickProp);
+	const onkeydown = readonlyBox(() => onkeydownProp);
 
 	const checkboxState = setCheckboxRootState({
 		checked,

--- a/packages/bits-ui/src/lib/internal/box.svelte.ts
+++ b/packages/bits-ui/src/lib/internal/box.svelte.ts
@@ -1,13 +1,25 @@
 export type Setter<T> = (value: T) => void;
 export type Getter<T> = () => T;
 
-export class Box<T> {
-	#set: Setter<T> = $state() as Setter<T>;
+export class ReadonlyBox<T> {
 	#get: Getter<T> = $state() as Getter<T>;
 
-	constructor(get: Getter<T>, set: Setter<T>) {
-		this.#set = set;
+	constructor(get: Getter<T>) {
 		this.#get = get;
+	}
+
+	get value() {
+		return this.#get();
+	}
+}
+
+export class Box<T> {
+	#get: Getter<T> = $state() as Getter<T>;
+	#set: Setter<T> = $state() as Setter<T>;
+
+	constructor(get: Getter<T>, set: Setter<T>) {
+		this.#get = get;
+		this.#set = set;
 	}
 
 	get value() {
@@ -19,10 +31,26 @@ export class Box<T> {
 	}
 }
 
-export function box<T>(get: Getter<T>, set: Setter<T> = () => {}) {
+export function box<T>(get: Getter<T>, set: Setter<T>) {
 	return new Box(get, set);
+}
+
+export function readonlyBox<T>(get: Getter<T>) {
+	return new ReadonlyBox(get);
+}
+
+export function boxWithState<T>(initialVal: T) {
+	let state = $state(initialVal);
+	return box(
+		() => state,
+		(newValue) => (state = newValue)
+	);
 }
 
 export type BoxedValues<T> = {
 	[K in keyof T]: Box<T[K]>;
+};
+
+export type ReadonlyBoxedValues<T> = {
+	[K in keyof T]: ReadonlyBox<T[K]>;
 };

--- a/packages/bits-ui/src/lib/internal/events.ts
+++ b/packages/bits-ui/src/lib/internal/events.ts
@@ -1,4 +1,5 @@
 import { createEventDispatcher } from "svelte";
+import type { Box, ReadonlyBox } from "./box.svelte.js";
 
 type MeltEvent<T extends Event = Event> = {
 	detail: {
@@ -40,12 +41,15 @@ export type EventCallback<E extends Event = Event, T extends Element = Element> 
 ) => void;
 
 export function composeHandlers<E extends Event = Event, T extends Element = Element>(
-	...handlers: Array<EventCallback<E, T> | undefined>
+	...handlers: Array<EventCallback<E, T> | Box<ReadonlyBox<EventCallback<E, T>>> | undefined>
 ): (e: E & { currentTarget: EventTarget & T }) => void {
-	return (e: E & { currentTarget: EventTarget & T }) => {
+	return function (this: T, e: E & { currentTarget: EventTarget & T }) {
 		for (const handler of handlers) {
-			if (handler && !e.defaultPrevented) {
-				handler(e);
+			if (!handler || e.defaultPrevented) return;
+			if (typeof handler === "function") {
+				handler.call(this, e);
+			} else {
+				handler.value.value.call(this, e);
 			}
 		}
 	};


### PR DESCRIPTION
The following PR fixes/changes the following:
- Currently, event-listener props don't get executed because of loss of reactivity. This PR correctly handles the reactivity of event-listener props
- added readonlyBox to explicitly not allow us to update the state, which for most props is the desired behavior.
- Removed unnecessary checks like `props.id ?? this.id` since `props.id` will always be of type `Box<number>`
- inferring attrs as const
- In accordion, currently the accordion item is responsible for updating the root's value and contains logic to handle different types (single | multiple). I moved this logic to the root for better code clarity.
- accordion item `isSelected` should be a derived state instead of updated in an effect
- marked the attrs property as private `#attrs` in accordion
- avoid unnecessarily creating a box state for a property on the prototype. Instead set it to undefined on the prototype and in the constructor, we will update the property based on the props. (it's totally ok to set a property to undefined on the prototype even if we access it in a derived state because the derived state runs the code inside only after the constructor, at which point we will have set properties based on the props)
- fixed `this` not being `e.currentTarget` in event listeners by binding `this` correctly inside `composeHandlers`. This doesn't affect the `this` in the event listener methods on the class since we use arrow functions.