### PR TITLE
next: more improvements

### DIFF
--- a/packages/bits-ui/src/lib/bits/accordion/accordion.svelte.ts
+++ b/packages/bits-ui/src/lib/bits/accordion/accordion.svelte.ts
@@ -70,9 +70,8 @@ export class AccordionSingleState extends AccordionBaseState {
 /**
  * MULTIPLE
  */
-interface AccordionMultiStateProps extends AccordionBaseStateProps {
-	value: Box<string[]>;
-}
+
+type AccordionMultiStateProps = AccordionBaseStateProps & BoxedValues<{ value: string[] }>;
 
 export class AccordionMultiState extends AccordionBaseState {
 	#value: Box<string[]>;
@@ -110,7 +109,7 @@ type AccordionItemStateProps = ReadonlyBoxedValues<{
 export class AccordionItemState {
 	#value: ReadonlyBox<string>;
 	disabled = undefined as unknown as ReadonlyBox<boolean>;
-	root: AccordionState = undefined as unknown as AccordionState;
+	root = undefined as unknown as AccordionState;
 	isSelected = $derived(this.root.includesItem(this.value));
 	isDisabled = $derived(this.disabled.value || this.root.disabled.value);
 	#attrs = $derived({
@@ -260,7 +259,7 @@ class AccordionContentState {
 	isMountAnimationPrevented = $state(false);
 	width = boxedState(0);
 	height = boxedState(0);
-	presentEl: Box<HTMLElement | undefined> = boxedState<HTMLElement | undefined>(undefined);
+	presentEl = boxedState<HTMLElement | undefined>(undefined);
 	forceMount = undefined as unknown as ReadonlyBox<boolean>;
 	present = $derived(this.item.isSelected);
 	#attrs = $derived({
@@ -359,8 +358,8 @@ export function setAccordionRootState(props: InitAccordionProps) {
 	}
 }
 
-export function getAccordionRootState(): AccordionState {
-	return getContext(ACCORDION_ROOT_KEY);
+export function getAccordionRootState() {
+	return getContext<AccordionState>(ACCORDION_ROOT_KEY);
 }
 
 export function setAccordionItemState(props: Omit<AccordionItemStateProps, "rootState">) {
@@ -371,8 +370,8 @@ export function setAccordionItemState(props: Omit<AccordionItemStateProps, "root
 	return itemState;
 }
 
-export function getAccordionItemState(): AccordionItemState {
-	return getContext(ACCORDION_ITEM_KEY);
+export function getAccordionItemState() {
+	return getContext<AccordionItemState>(ACCORDION_ITEM_KEY);
 }
 
 export function getAccordionTriggerState(props: AccordionTriggerStateProps): AccordionTriggerState {

--- a/packages/bits-ui/src/lib/bits/accordion/accordion.svelte.ts
+++ b/packages/bits-ui/src/lib/bits/accordion/accordion.svelte.ts
@@ -253,10 +253,8 @@ type AccordionContentStateProps = BoxedValues<{
 
 class AccordionContentState {
 	item = undefined as unknown as AccordionItemState;
-	originalStyles = $state<{ transitionDuration: string; animationName: string } | undefined>(
-		undefined
-	);
-	isMountAnimationPrevented = $state(false);
+	originalStyles: { transitionDuration: string; animationName: string } | undefined = undefined;
+	isMountAnimationPrevented = false;
 	width = boxedState(0);
 	height = boxedState(0);
 	presentEl = boxedState<HTMLElement | undefined>(undefined);
@@ -312,7 +310,7 @@ class AccordionContentState {
 				this.width.value = rect.width;
 
 				// unblock any animations/transitions that were originally set if not the initial render
-				if (!untrack(() => this.isMountAnimationPrevented)) {
+				if (!this.isMountAnimationPrevented) {
 					const { animationName, transitionDuration } = this.originalStyles;
 					node.style.transitionDuration = transitionDuration;
 					node.style.animationName = animationName;

--- a/packages/bits-ui/src/lib/bits/accordion/accordion.svelte.ts
+++ b/packages/bits-ui/src/lib/bits/accordion/accordion.svelte.ts
@@ -253,7 +253,7 @@ type AccordionContentStateProps = BoxedValues<{
 
 class AccordionContentState {
 	item = undefined as unknown as AccordionItemState;
-	originalStyles = boxedState<{ transitionDuration: string; animationName: string } | undefined>(
+	originalStyles = $state<{ transitionDuration: string; animationName: string } | undefined>(
 		undefined
 	);
 	isMountAnimationPrevented = $state(false);
@@ -298,7 +298,7 @@ class AccordionContentState {
 
 			tick().then(() => {
 				// get the dimensions of the element
-				this.originalStyles.value = this.originalStyles.value || {
+				this.originalStyles = this.originalStyles || {
 					transitionDuration: node.style.transitionDuration,
 					animationName: node.style.animationName,
 				};
@@ -313,7 +313,7 @@ class AccordionContentState {
 
 				// unblock any animations/transitions that were originally set if not the initial render
 				if (!untrack(() => this.isMountAnimationPrevented)) {
-					const { animationName, transitionDuration } = this.originalStyles.value;
+					const { animationName, transitionDuration } = this.originalStyles;
 					node.style.transitionDuration = transitionDuration;
 					node.style.animationName = animationName;
 				}

--- a/packages/bits-ui/src/lib/bits/accordion/accordion.svelte.ts
+++ b/packages/bits-ui/src/lib/bits/accordion/accordion.svelte.ts
@@ -25,15 +25,10 @@ type AccordionBaseStateProps = ReadonlyBoxedValues<{
 	disabled: boolean;
 }>;
 
-interface AccordionRootAttrs {
-	id: string;
-	"data-accordion-root": string;
-}
-
 class AccordionBaseState {
 	id = undefined as unknown as ReadonlyBox<string>;
 	disabled: ReadonlyBox<boolean>;
-	#attrs: AccordionRootAttrs = $derived({
+	#attrs = $derived({
 		id: this.id.value,
 		"data-accordion-root": "",
 	} as const);
@@ -176,7 +171,7 @@ class AccordionTriggerState {
 	isDisabled = $derived(
 		this.disabled.value || this.itemState.disabled.value || this.root.disabled.value
 	);
-	#attrs: Record<string, unknown> = $derived({
+	#attrs = $derived({
 		id: this.id.value,
 		disabled: this.isDisabled,
 		"aria-expanded": getAriaExpanded(this.itemState.isSelected),
@@ -268,7 +263,7 @@ class AccordionContentState {
 	presentEl: Box<HTMLElement | undefined> = boxedState<HTMLElement | undefined>(undefined);
 	forceMount = undefined as unknown as ReadonlyBox<boolean>;
 	present = $derived(this.item.isSelected);
-	#attrs: Record<string, unknown> = $derived({
+	#attrs = $derived({
 		"data-state": getDataOpenClosed(this.item.isSelected),
 		"data-disabled": getDataDisabled(this.item.isDisabled),
 		"data-value": this.item.value,

--- a/packages/bits-ui/src/lib/bits/accordion/accordion.svelte.ts
+++ b/packages/bits-ui/src/lib/bits/accordion/accordion.svelte.ts
@@ -1,4 +1,4 @@
-import { getContext, onMount, setContext, tick, untrack } from "svelte";
+import { getContext, setContext, tick, untrack } from "svelte";
 import {
 	type Box,
 	type BoxedValues,
@@ -13,7 +13,6 @@ import {
 	getDataOpenClosed,
 	kbd,
 	readonlyBox,
-	styleToString,
 	verifyContextDeps,
 } from "$lib/internal/index.js";
 import type { StyleProperties } from "$lib/shared/index.js";

--- a/packages/bits-ui/src/lib/bits/accordion/accordion.svelte.ts
+++ b/packages/bits-ui/src/lib/bits/accordion/accordion.svelte.ts
@@ -158,60 +158,60 @@ type AccordionTriggerStateProps = ReadonlyBoxedValues<{
 }>;
 
 class AccordionTriggerState {
-	disabled = undefined as unknown as ReadonlyBox<boolean>;
-	id = undefined as unknown as ReadonlyBox<string>;
-	root = undefined as unknown as AccordionState;
-	itemState = undefined as unknown as AccordionItemState;
-	onclickProp = boxedState<AccordionTriggerStateProps["onclick"]>(readonlyBox(() => () => {}));
-	onkeydownProp = boxedState<AccordionTriggerStateProps["onkeydown"]>(
+	#disabled = undefined as unknown as ReadonlyBox<boolean>;
+	#id = undefined as unknown as ReadonlyBox<string>;
+	#root = undefined as unknown as AccordionState;
+	#itemState = undefined as unknown as AccordionItemState;
+	#onclickProp = boxedState<AccordionTriggerStateProps["onclick"]>(readonlyBox(() => () => {}));
+	#onkeydownProp = boxedState<AccordionTriggerStateProps["onkeydown"]>(
 		readonlyBox(() => () => {})
 	);
 
 	// Disabled if the trigger itself, the item it belongs to, or the root is disabled
-	isDisabled = $derived(
-		this.disabled.value || this.itemState.disabled.value || this.root.disabled.value
+	#isDisabled = $derived(
+		this.#disabled.value || this.#itemState.disabled.value || this.#root.disabled.value
 	);
 	#attrs = $derived({
-		id: this.id.value,
-		disabled: this.isDisabled,
-		"aria-expanded": getAriaExpanded(this.itemState.isSelected),
-		"aria-disabled": getAriaDisabled(this.isDisabled),
-		"data-disabled": getDataDisabled(this.isDisabled),
-		"data-value": this.itemState.value,
-		"data-state": getDataOpenClosed(this.itemState.isSelected),
+		id: this.#id.value,
+		disabled: this.#isDisabled,
+		"aria-expanded": getAriaExpanded(this.#itemState.isSelected),
+		"aria-disabled": getAriaDisabled(this.#isDisabled),
+		"data-disabled": getDataDisabled(this.#isDisabled),
+		"data-value": this.#itemState.value,
+		"data-state": getDataOpenClosed(this.#itemState.isSelected),
 		"data-accordion-trigger": "",
 	} as const);
 
 	constructor(props: AccordionTriggerStateProps, itemState: AccordionItemState) {
-		this.disabled = props.disabled;
-		this.itemState = itemState;
-		this.root = itemState.root;
-		this.onclickProp.value = props.onclick;
-		this.onkeydownProp.value = props.onkeydown;
-		this.id = props.id;
+		this.#disabled = props.disabled;
+		this.#itemState = itemState;
+		this.#root = itemState.root;
+		this.#onclickProp.value = props.onclick;
+		this.#onkeydownProp.value = props.onkeydown;
+		this.#id = props.id;
 	}
 
-	onclick = composeHandlers(this.onclickProp, () => {
-		if (this.isDisabled) return;
-		this.itemState.updateValue();
+	#onclick = composeHandlers(this.#onclickProp, () => {
+		if (this.#isDisabled) return;
+		this.#itemState.updateValue();
 	});
 
-	onkeydown = composeHandlers(this.onkeydownProp, (e: KeyboardEvent) => {
+	#onkeydown = composeHandlers(this.#onkeydownProp, (e: KeyboardEvent) => {
 		const handledKeys = [kbd.ARROW_DOWN, kbd.ARROW_UP, kbd.HOME, kbd.END, kbd.SPACE, kbd.ENTER];
-		if (this.isDisabled || !handledKeys.includes(e.key)) return;
+		if (this.#isDisabled || !handledKeys.includes(e.key)) return;
 
 		e.preventDefault();
 
 		if (e.key === kbd.SPACE || e.key === kbd.ENTER) {
-			this.itemState.updateValue();
+			this.#itemState.updateValue();
 			return;
 		}
 
-		if (!this.root.id.value || !this.id.value) return;
+		if (!this.#root.id.value || !this.#id.value) return;
 
-		const rootEl = document.getElementById(this.root.id.value);
+		const rootEl = document.getElementById(this.#root.id.value);
 		if (!rootEl) return;
-		const itemEl = document.getElementById(this.id.value);
+		const itemEl = document.getElementById(this.#id.value);
 		if (!itemEl) return;
 
 		const items = Array.from(rootEl.querySelectorAll<HTMLElement>("[data-accordion-trigger]"));
@@ -235,8 +235,8 @@ class AccordionTriggerState {
 	get props() {
 		return {
 			...this.#attrs,
-			onclick: this.onclick,
-			onkeydown: this.onkeydown,
+			onclick: this.#onclick,
+			onkeydown: this.#onkeydown,
 		};
 	}
 }

--- a/packages/bits-ui/src/lib/bits/accordion/accordion.svelte.ts
+++ b/packages/bits-ui/src/lib/bits/accordion/accordion.svelte.ts
@@ -330,8 +330,8 @@ class AccordionContentState {
  * CONTEXT METHODS
  */
 
-export const ACCORDION_ROOT_KEY = "Accordion.Root";
-export const ACCORDION_ITEM_KEY = "Accordion.Item";
+export const ACCORDION_ROOT_KEY = Symbol("Accordion.Root");
+export const ACCORDION_ITEM_KEY = Symbol("Accordion.Item");
 
 type AccordionState = AccordionSingleState | AccordionMultiState;
 

--- a/packages/bits-ui/src/lib/bits/accordion/accordion.svelte.ts
+++ b/packages/bits-ui/src/lib/bits/accordion/accordion.svelte.ts
@@ -343,19 +343,12 @@ type InitAccordionProps = {
 };
 
 export function setAccordionRootState(props: InitAccordionProps) {
-	if (props.type === "single") {
-		const { value, type, ...rest } = props;
-		return setContext(
-			ACCORDION_ROOT_KEY,
-			new AccordionSingleState({ ...rest, value: value as Box<string> })
-		);
-	} else {
-		const { value, type, ...rest } = props;
-		return setContext(
-			ACCORDION_ROOT_KEY,
-			new AccordionMultiState({ ...rest, value: value as Box<string[]> })
-		);
-	}
+	const { type, ...rest } = props;
+	const rootState =
+		type === "single"
+			? new AccordionSingleState(rest as AccordionSingleStateProps)
+			: new AccordionMultiState(rest as AccordionMultiStateProps);
+	return setContext(ACCORDION_ROOT_KEY, rootState);
 }
 
 export function getAccordionRootState() {

--- a/packages/bits-ui/src/lib/bits/avatar/avatar.svelte.ts
+++ b/packages/bits-ui/src/lib/bits/avatar/avatar.svelte.ts
@@ -50,14 +50,9 @@ class AvatarRootState {
 		const image = new Image();
 		image.src = src;
 		image.onload = () => {
-			// if its 0 then we don't need to add a delay
-			if (this.delayMs.value !== 0) {
-				this.#imageTimerId = setTimeout(() => {
-					this.loadingStatus.value = "loaded";
-				}, this.delayMs.value);
-			} else {
+			this.#imageTimerId = setTimeout(() => {
 				this.loadingStatus.value = "loaded";
-			}
+			}, this.delayMs.value);
 		};
 		image.onerror = () => {
 			this.loadingStatus.value = "error";

--- a/packages/bits-ui/src/lib/bits/avatar/avatar.svelte.ts
+++ b/packages/bits-ui/src/lib/bits/avatar/avatar.svelte.ts
@@ -19,11 +19,6 @@ type AvatarRootStateProps = {
 	style: ReadonlyBox<StyleProperties>;
 };
 
-interface AvatarRootAttrs {
-	"data-avatar-root": string;
-	"data-status": ImageLoadingStatus;
-}
-
 type AvatarImageSrc = string | null | undefined;
 
 class AvatarRootState {
@@ -31,11 +26,11 @@ class AvatarRootState {
 	delayMs: ReadonlyBox<number>;
 	loadingStatus = undefined as unknown as Box<ImageLoadingStatus>;
 	styleProp = undefined as unknown as ReadonlyBox<StyleProperties>;
-	#attrs: AvatarRootAttrs = $derived({
+	#attrs = $derived({
 		"data-avatar-root": "",
 		"data-status": this.loadingStatus.value,
 		style: styleToString(this.styleProp.value),
-	});
+	} as const);
 
 	#imageTimerId: NodeJS.Timeout | undefined = undefined;
 
@@ -86,12 +81,6 @@ class AvatarRootState {
  * IMAGE
  */
 
-interface AvatarImageAttrs {
-	style: string;
-	src: AvatarImageSrc;
-	"data-avatar-image": string;
-}
-
 type AvatarImageStateProps = ReadonlyBoxedValues<{
 	src: AvatarImageSrc;
 	style: StyleProperties;
@@ -100,7 +89,7 @@ type AvatarImageStateProps = ReadonlyBoxedValues<{
 class AvatarImageState {
 	root = undefined as unknown as AvatarRootState;
 	styleProp = undefined as unknown as ReadonlyBox<StyleProperties>;
-	#attrs: AvatarImageAttrs = $derived({
+	#attrs = $derived({
 		style: styleToString({
 			...this.styleProp.value,
 			display: this.root.loadingStatus.value === "loaded" ? "block" : "none",
@@ -124,11 +113,6 @@ class AvatarImageState {
  * FALLBACK
  */
 
-interface AvatarFallbackAttrs {
-	style: string;
-	"data-avatar-fallback": string;
-}
-
 type AvatarFallbackStateProps = ReadonlyBoxedValues<{
 	style: StyleProperties;
 }>;
@@ -136,7 +120,7 @@ type AvatarFallbackStateProps = ReadonlyBoxedValues<{
 class AvatarFallbackState {
 	root = undefined as unknown as AvatarRootState;
 	styleProp = undefined as unknown as ReadonlyBox<StyleProperties>;
-	#attrs: AvatarFallbackAttrs = $derived({
+	#attrs = $derived({
 		style: styleToString({
 			...this.styleProp.value,
 			display: this.root.loadingStatus.value === "loaded" ? "none" : "block",

--- a/packages/bits-ui/src/lib/bits/avatar/avatar.svelte.ts
+++ b/packages/bits-ui/src/lib/bits/avatar/avatar.svelte.ts
@@ -32,31 +32,29 @@ class AvatarRootState {
 		style: styleToString(this.styleProp.value),
 	} as const);
 
-	#imageTimerId: NodeJS.Timeout | undefined = undefined;
-
 	constructor(props: AvatarRootStateProps) {
 		this.delayMs = props.delayMs;
 		this.loadingStatus = props.loadingStatus;
 
 		$effect.pre(() => {
 			if (!this.src.value) return;
-			this.#loadImage(this.src.value);
+			return this.#loadImage(this.src.value);
 		});
 	}
 
 	#loadImage(src: string) {
-		// clear any existing timers before creating a new one
-		clearTimeout(this.#imageTimerId);
+		let imageTimerId: NodeJS.Timeout;
 		const image = new Image();
 		image.src = src;
 		image.onload = () => {
-			this.#imageTimerId = setTimeout(() => {
+			imageTimerId = setTimeout(() => {
 				this.loadingStatus.value = "loaded";
 			}, this.delayMs.value);
 		};
 		image.onerror = () => {
 			this.loadingStatus.value = "error";
 		};
+		return () => clearTimeout(imageTimerId);
 	}
 
 	createImage(props: AvatarImageStateProps) {

--- a/packages/bits-ui/src/lib/bits/avatar/avatar.svelte.ts
+++ b/packages/bits-ui/src/lib/bits/avatar/avatar.svelte.ts
@@ -46,6 +46,7 @@ class AvatarRootState {
 		let imageTimerId: NodeJS.Timeout;
 		const image = new Image();
 		image.src = src;
+		this.loadingStatus.value = "loading";
 		image.onload = () => {
 			imageTimerId = setTimeout(() => {
 				this.loadingStatus.value = "loaded";

--- a/packages/bits-ui/src/lib/bits/checkbox/checkbox.svelte.ts
+++ b/packages/bits-ui/src/lib/bits/checkbox/checkbox.svelte.ts
@@ -41,8 +41,8 @@ class CheckboxRootState {
 	required = undefined as unknown as ReadonlyBox<boolean>;
 	name: ReadonlyBox<string | undefined>;
 	value: ReadonlyBox<string | undefined>;
-	onclickProp = boxedState<CheckboxRootStateProps["onclick"]>(readonlyBox(() => () => {}));
-	onkeydownProp = boxedState<CheckboxRootStateProps["onkeydown"]>(readonlyBox(() => () => {}));
+	#onclickProp = boxedState<CheckboxRootStateProps["onclick"]>(readonlyBox(() => () => {}));
+	#onkeydownProp = boxedState<CheckboxRootStateProps["onkeydown"]>(readonlyBox(() => () => {}));
 	#attrs = $derived({
 		"data-disabled": getDataDisabled(this.disabled.value),
 		"data-state": getCheckboxDataState(this.checked.value),
@@ -60,15 +60,15 @@ class CheckboxRootState {
 		this.required = props.required;
 		this.name = props.name;
 		this.value = props.value;
-		this.onclickProp.value = props.onclick;
-		this.onkeydownProp.value = props.onkeydown;
+		this.#onclickProp.value = props.onclick;
+		this.#onkeydownProp.value = props.onkeydown;
 	}
 
-	onkeydown = composeHandlers(this.onkeydownProp, (e) => {
+	#onkeydown = composeHandlers(this.#onkeydownProp, (e) => {
 		if (e.key === kbd.ENTER) e.preventDefault();
 	});
 
-	onclick = composeHandlers(this.onclickProp, () => {
+	#onclick = composeHandlers(this.#onclickProp, () => {
 		if (this.disabled.value) return;
 		if (this.checked.value === "indeterminate") {
 			this.checked.value = true;
@@ -88,8 +88,8 @@ class CheckboxRootState {
 	get props() {
 		return {
 			...this.#attrs,
-			onclick: this.onclick,
-			onkeydown: this.onkeydown,
+			onclick: this.#onclick,
+			onkeydown: this.#onkeydown,
 		};
 	}
 }

--- a/packages/bits-ui/src/lib/bits/checkbox/checkbox.svelte.ts
+++ b/packages/bits-ui/src/lib/bits/checkbox/checkbox.svelte.ts
@@ -144,7 +144,7 @@ class CheckboxInputState {
  * CONTEXT METHODS
  */
 
-export const CHECKBOX_ROOT_KEY = "Checkbox.Root";
+export const CHECKBOX_ROOT_KEY = Symbol("Checkbox.Root");
 
 export function setCheckboxRootState(props: CheckboxRootStateProps) {
 	return setContext(CHECKBOX_ROOT_KEY, new CheckboxRootState(props));

--- a/packages/bits-ui/src/lib/bits/checkbox/checkbox.svelte.ts
+++ b/packages/bits-ui/src/lib/bits/checkbox/checkbox.svelte.ts
@@ -14,7 +14,6 @@ import {
 } from "$lib/internal/box.svelte.js";
 import { type EventCallback, composeHandlers } from "$lib/internal/events.js";
 import { kbd } from "$lib/internal/kbd.js";
-import type { StyleProperties } from "$lib/shared/index.js";
 
 type CheckboxRootStateProps = ReadonlyBoxedValues<{
 	disabled: boolean;

--- a/packages/bits-ui/src/lib/bits/collapsible/collapsible.svelte.ts
+++ b/packages/bits-ui/src/lib/bits/collapsible/collapsible.svelte.ts
@@ -170,7 +170,7 @@ class CollapsibleTriggerState {
 	}
 }
 
-export const COLLAPSIBLE_ROOT_KEY = "Collapsible.Root";
+export const COLLAPSIBLE_ROOT_KEY = Symbol("Collapsible.Root");
 
 export function setCollapsibleRootState(props: CollapsibleRootStateProps) {
 	return setContext(COLLAPSIBLE_ROOT_KEY, new CollapsibleRootState(props));

--- a/packages/bits-ui/src/lib/bits/collapsible/collapsible.svelte.ts
+++ b/packages/bits-ui/src/lib/bits/collapsible/collapsible.svelte.ts
@@ -63,14 +63,12 @@ type CollapsibleContentStateProps = BoxedValues<{
 
 class CollapsibleContentState {
 	root = undefined as unknown as CollapsibleRootState;
-	currentStyle = boxedState<{ transitionDuration: string; animationName: string } | undefined>(
-		undefined
-	);
+	currentStyle = $state<{ transitionDuration: string; animationName: string }>();
 	styleProp = undefined as unknown as ReadonlyBox<StyleProperties>;
 	#isMountAnimationPrevented = $state(false);
-	#width = boxedState(0);
-	#height = boxedState(0);
-	#presentEl = boxedState<HTMLElement | undefined>(undefined);
+	#width = $state(0);
+	#height = $state(0);
+	#presentEl: Box<HTMLElement | undefined>;
 	present = $derived(this.root.open);
 	#attrs = $derived({
 		id: this.root.contentId.value,
@@ -79,12 +77,8 @@ class CollapsibleContentState {
 		"data-collapsible-content": "",
 		style: styleToString({
 			...this.styleProp.value,
-			"--bits-collapsible-content-height": this.#height.value
-				? `${this.#height.value}px`
-				: undefined,
-			"--bits-collapsible-content-width": this.#width.value
-				? `${this.#width.value}px`
-				: undefined,
+			"--bits-collapsible-content-height": this.#height ? `${this.#height}px` : undefined,
+			"--bits-collapsible-content-width": this.#width ? `${this.#width}px` : undefined,
 		}),
 	} as const);
 
@@ -107,7 +101,7 @@ class CollapsibleContentState {
 			const node = this.#presentEl.value;
 			if (!node) return;
 
-			this.currentStyle.value = this.currentStyle.value || {
+			this.currentStyle = this.currentStyle || {
 				transitionDuration: node.style.transitionDuration,
 				animationName: node.style.animationName,
 			};
@@ -118,12 +112,12 @@ class CollapsibleContentState {
 
 			// get the dimensions of the element
 			const rect = node.getBoundingClientRect();
-			this.#height.value = rect.height;
-			this.#width.value = rect.width;
+			this.#height = rect.height;
+			this.#width = rect.width;
 
 			// unblock any animations/transitions that were originally set if not the initial render
 			if (!this.#isMountAnimationPrevented) {
-				const { animationName, transitionDuration } = this.currentStyle.value;
+				const { animationName, transitionDuration } = this.currentStyle;
 				node.style.transitionDuration = transitionDuration;
 				node.style.animationName = animationName;
 			}

--- a/packages/bits-ui/src/lib/bits/collapsible/collapsible.svelte.ts
+++ b/packages/bits-ui/src/lib/bits/collapsible/collapsible.svelte.ts
@@ -70,7 +70,7 @@ class CollapsibleContentState {
 	#isMountAnimationPrevented = $state(false);
 	#width = boxedState(0);
 	#height = boxedState(0);
-	#presentEl: Box<HTMLElement | undefined> = boxedState<HTMLElement | undefined>(undefined);
+	#presentEl = boxedState<HTMLElement | undefined>(undefined);
 	present = $derived(this.root.open);
 	#attrs = $derived({
 		id: this.root.contentId.value,

--- a/packages/bits-ui/src/lib/bits/collapsible/collapsible.svelte.ts
+++ b/packages/bits-ui/src/lib/bits/collapsible/collapsible.svelte.ts
@@ -176,8 +176,8 @@ export function setCollapsibleRootState(props: CollapsibleRootStateProps) {
 	return setContext(COLLAPSIBLE_ROOT_KEY, new CollapsibleRootState(props));
 }
 
-export function getCollapsibleRootState(): CollapsibleRootState {
-	return getContext(COLLAPSIBLE_ROOT_KEY);
+export function getCollapsibleRootState() {
+	return getContext<CollapsibleRootState>(COLLAPSIBLE_ROOT_KEY);
 }
 
 export function getCollapsibleTriggerState(

--- a/packages/bits-ui/src/lib/bits/collapsible/collapsible.svelte.ts
+++ b/packages/bits-ui/src/lib/bits/collapsible/collapsible.svelte.ts
@@ -67,10 +67,10 @@ class CollapsibleContentState {
 		undefined
 	);
 	styleProp = undefined as unknown as ReadonlyBox<StyleProperties>;
-	isMountAnimationPrevented = $state(false);
-	width = boxedState(0);
-	height = boxedState(0);
-	presentEl: Box<HTMLElement | undefined> = boxedState<HTMLElement | undefined>(undefined);
+	#isMountAnimationPrevented = $state(false);
+	#width = boxedState(0);
+	#height = boxedState(0);
+	#presentEl: Box<HTMLElement | undefined> = boxedState<HTMLElement | undefined>(undefined);
 	present = $derived(this.root.open);
 	#attrs = $derived({
 		id: this.root.contentId.value,
@@ -79,32 +79,32 @@ class CollapsibleContentState {
 		"data-collapsible-content": "",
 		style: styleToString({
 			...this.styleProp.value,
-			"--bits-collapsible-content-height": this.height.value
-				? `${this.height.value}px`
+			"--bits-collapsible-content-height": this.#height.value
+				? `${this.#height.value}px`
 				: undefined,
-			"--bits-collapsible-content-width": this.width.value
-				? `${this.width.value}px`
+			"--bits-collapsible-content-width": this.#width.value
+				? `${this.#width.value}px`
 				: undefined,
 		}),
 	} as const);
 
 	constructor(props: CollapsibleContentStateProps, root: CollapsibleRootState) {
 		this.root = root;
-		this.isMountAnimationPrevented = root.open.value;
-		this.presentEl = props.presentEl;
+		this.#isMountAnimationPrevented = root.open.value;
+		this.#presentEl = props.presentEl;
 		this.root.contentId = props.id;
 		this.styleProp = props.style;
 
 		onMount(() => {
 			requestAnimationFrame(() => {
-				this.isMountAnimationPrevented = false;
+				this.#isMountAnimationPrevented = false;
 			});
 		});
 
 		$effect.pre(() => {
 			// eslint-disable-next-line no-unused-expressions
 			this.root.open.value;
-			const node = this.presentEl.value;
+			const node = this.#presentEl.value;
 			if (!node) return;
 
 			this.currentStyle.value = this.currentStyle.value || {
@@ -118,11 +118,11 @@ class CollapsibleContentState {
 
 			// get the dimensions of the element
 			const rect = node.getBoundingClientRect();
-			this.height.value = rect.height;
-			this.width.value = rect.width;
+			this.#height.value = rect.height;
+			this.#width.value = rect.width;
 
 			// unblock any animations/transitions that were originally set if not the initial render
-			if (!this.isMountAnimationPrevented) {
+			if (!this.#isMountAnimationPrevented) {
 				const { animationName, transitionDuration } = this.currentStyle.value;
 				node.style.transitionDuration = transitionDuration;
 				node.style.animationName = animationName;
@@ -140,32 +140,32 @@ type CollapsibleTriggerStateProps = ReadonlyBoxedValues<{
 }>;
 
 class CollapsibleTriggerState {
-	root = undefined as unknown as CollapsibleRootState;
-	onclickProp = boxedState<CollapsibleTriggerStateProps["onclick"]>(readonlyBox(() => () => {}));
+	#root = undefined as unknown as CollapsibleRootState;
+	#onclickProp = boxedState<CollapsibleTriggerStateProps["onclick"]>(readonlyBox(() => () => {}));
 
 	#attrs = $derived({
 		type: "button",
-		"aria-controls": this.root.contentId.value,
-		"aria-expanded": getAriaExpanded(this.root.open.value),
-		"data-state": getDataOpenClosed(this.root.open.value),
-		"data-disabled": getDataDisabled(this.root.disabled.value),
-		disabled: this.root.disabled.value,
+		"aria-controls": this.#root.contentId.value,
+		"aria-expanded": getAriaExpanded(this.#root.open.value),
+		"data-state": getDataOpenClosed(this.#root.open.value),
+		"data-disabled": getDataDisabled(this.#root.disabled.value),
+		disabled: this.#root.disabled.value,
 		"data-collapsible-trigger": "",
 	} as const);
 
 	constructor(props: CollapsibleTriggerStateProps, root: CollapsibleRootState) {
-		this.root = root;
-		this.onclickProp.value = props.onclick;
+		this.#root = root;
+		this.#onclickProp.value = props.onclick;
 	}
 
-	onclick = composeHandlers(this.onclickProp, () => {
-		this.root.toggleOpen();
+	#onclick = composeHandlers(this.#onclickProp, () => {
+		this.#root.toggleOpen();
 	});
 
 	get props() {
 		return {
 			...this.#attrs,
-			onclick: this.onclick,
+			onclick: this.#onclick,
 		};
 	}
 }

--- a/packages/bits-ui/src/lib/internal/context.ts
+++ b/packages/bits-ui/src/lib/internal/context.ts
@@ -1,12 +1,15 @@
-import { getAllContexts } from "svelte";
+import { hasContext } from "svelte";
 import { DEV } from "esm-env";
 
-export function verifyContextDeps(...deps: string[]) {
+export function verifyContextDeps(...deps: Array<string | symbol>) {
 	if (DEV) {
-		const ctx = getAllContexts();
-		const missing = deps.filter((dep) => !ctx.has(dep));
-		if (missing.length > 0) {
-			// TODO: symbols break our ability to show the name of the missing context. :/
+		const missing: string[] = [];
+		for (const dep of deps) {
+			if (hasContext(dep)) continue;
+			const depLabel = typeof dep === "symbol" ? dep.description : dep;
+			missing.push(depLabel!);
+		}
+		if (missing.length) {
 			throw new Error(`Missing context dependencies: ${missing.join(", ")}`);
 		}
 	}


### PR DESCRIPTION
- enable using symbols as context keys
- infer attrs as const
- use private properties where possible
- use state instead of box where possible
- improve performance of `verifyContextDeps` by not calling `getAllContexts` when `verifyContextDeps` is mostly used for 1/2 contexts. use `hasContext` instead
- simplify some logic...