### PR TITLE
Improve compatibility with `exactOptionalPropertyTypes`

### DIFF
--- a/packages/bits-ui/src/lib/bits/floating/_types.ts
+++ b/packages/bits-ui/src/lib/bits/floating/_types.ts
@@ -42,7 +42,7 @@ export type FloatingProps = {
 	 * The distance in pixels from the anchor to the floating element.
 	 * @see https://floating-ui.com/docs/offset#options
 	 */
-	sideOffset?: number;
+	sideOffset?: number | undefined;
 
 	/**
 	 * Whether the content should be the same width as the trigger.

--- a/packages/bits-ui/src/lib/bits/menu/types.ts
+++ b/packages/bits-ui/src/lib/bits/menu/types.ts
@@ -63,7 +63,7 @@ export type MenuCheckboxItemPropsWithoutHTML = Expand<
 		 *
 		 * @defaultValue false
 		 */
-		checked?: boolean | "indeterminate";
+		checked?: boolean | "indeterminate" | undefined;
 
 		/**
 		 * A callback function called when the checked state changes.

--- a/packages/bits-ui/src/lib/bits/menu/types.ts
+++ b/packages/bits-ui/src/lib/bits/menu/types.ts
@@ -79,7 +79,7 @@ export type MenuRadioGroupPropsWithoutHTML = Expand<
 		 *
 		 * @defaultValue undefined
 		 */
-		value?: MeltContextMenuRadioGroupProps["defaultValue"] & {};
+		value?: (MeltContextMenuRadioGroupProps["defaultValue"] & {}) | undefined;
 
 		/**
 		 * A callback function called when the value changes.

--- a/packages/bits-ui/src/lib/internal/types.ts
+++ b/packages/bits-ui/src/lib/internal/types.ts
@@ -80,7 +80,7 @@ export type TransitionProps<
 	/**
 	 * A transition function to use during both the in and out transitions.
 	 */
-	transition?: T;
+	transition?: T | undefined;
 
 	/**
 	 * The configuration to pass to the `transition` function.


### PR DESCRIPTION
This PR fixes the issues described in #516 that I've encountered so far when using shadcn-svelte.

If ok with you, I can create PRs like this as I run into new issues, gradually improving compatibility with `exactOptionalPropertyTypes`.