### PR TITLE
chore: Replaced all self-closing non-void elements

### DIFF
--- a/.changeset/rotten-spoons-carry.md
+++ b/.changeset/rotten-spoons-carry.md
@@ -1,0 +1,5 @@
+---
+"bits-ui": patch
+---
+
+chore: Replaced all self-closing non-void elements

--- a/packages/bits-ui/src/lib/bits/alert-dialog/components/alert-dialog-overlay.svelte
+++ b/packages/bits-ui/src/lib/bits/alert-dialog/components/alert-dialog-overlay.svelte
@@ -39,7 +39,7 @@
 		transition:transition={transitionConfig}
 		use:melt={builder}
 		{...$$restProps}
-	/>
+	></div>
 {:else if inTransition && outTransition && $open}
 	<div
 		bind:this={el}
@@ -47,16 +47,21 @@
 		out:outTransition={outTransitionConfig}
 		use:melt={builder}
 		{...$$restProps}
-	/>
+	></div>
 {:else if inTransition && $open}
-	<div bind:this={el} in:inTransition={inTransitionConfig} use:melt={builder} {...$$restProps} />
+	<div
+		bind:this={el}
+		in:inTransition={inTransitionConfig}
+		use:melt={builder}
+		{...$$restProps}
+	></div>
 {:else if outTransition && $open}
 	<div
 		bind:this={el}
 		out:outTransition={outTransitionConfig}
 		use:melt={builder}
 		{...$$restProps}
-	/>
+	></div>
 {:else if $open}
-	<div bind:this={el} use:melt={builder} {...$$restProps} />
+	<div bind:this={el} use:melt={builder} {...$$restProps}></div>
 {/if}

--- a/packages/bits-ui/src/lib/bits/combobox/components/combobox-arrow.svelte
+++ b/packages/bits-ui/src/lib/bits/combobox/components/combobox-arrow.svelte
@@ -23,5 +23,5 @@
 {#if asChild}
 	<slot {builder} />
 {:else}
-	<div bind:this={el} use:melt={builder} {...$$restProps} />
+	<div bind:this={el} use:melt={builder} {...$$restProps}></div>
 {/if}

--- a/packages/bits-ui/src/lib/bits/date-picker/components/date-picker-arrow.svelte
+++ b/packages/bits-ui/src/lib/bits/date-picker/components/date-picker-arrow.svelte
@@ -26,5 +26,5 @@
 {#if asChild}
 	<slot {builder} />
 {:else}
-	<div bind:this={el} use:melt={builder} {...$$restProps} />
+	<div bind:this={el} use:melt={builder} {...$$restProps}></div>
 {/if}

--- a/packages/bits-ui/src/lib/bits/date-range-picker/components/date-range-picker-arrow.svelte
+++ b/packages/bits-ui/src/lib/bits/date-range-picker/components/date-range-picker-arrow.svelte
@@ -26,5 +26,5 @@
 {#if asChild}
 	<slot {builder} />
 {:else}
-	<div bind:this={el} use:melt={builder} {...$$restProps} />
+	<div bind:this={el} use:melt={builder} {...$$restProps}></div>
 {/if}

--- a/packages/bits-ui/src/lib/bits/dialog/components/dialog-overlay.svelte
+++ b/packages/bits-ui/src/lib/bits/dialog/components/dialog-overlay.svelte
@@ -41,7 +41,7 @@
 		transition:transition={transitionConfig}
 		use:melt={builder}
 		{...$$restProps}
-	/>
+	></div>
 {:else if inTransition && outTransition && $open}
 	<!-- svelte-ignore a11y-no-static-element-interactions -->
 	<div
@@ -51,7 +51,7 @@
 		use:melt={builder}
 		on:mouseup
 		{...$$restProps}
-	/>
+	></div>
 {:else if inTransition && $open}
 	<!-- svelte-ignore a11y-no-static-element-interactions -->
 	<div
@@ -60,7 +60,7 @@
 		use:melt={builder}
 		on:mouseup
 		{...$$restProps}
-	/>
+	></div>
 {:else if outTransition && $open}
 	<!-- svelte-ignore a11y-no-static-element-interactions -->
 	<div
@@ -69,8 +69,8 @@
 		use:melt={builder}
 		on:mouseup
 		{...$$restProps}
-	/>
+	></div>
 {:else if $open}
 	<!-- svelte-ignore a11y-no-static-element-interactions -->
-	<div bind:this={el} use:melt={builder} on:mouseup {...$$restProps} />
+	<div bind:this={el} use:melt={builder} on:mouseup {...$$restProps}></div>
 {/if}

--- a/packages/bits-ui/src/lib/bits/link-preview/components/link-preview-arrow.svelte
+++ b/packages/bits-ui/src/lib/bits/link-preview/components/link-preview-arrow.svelte
@@ -22,5 +22,5 @@
 {#if asChild}
 	<slot {builder} />
 {:else}
-	<div bind:this={el} use:melt={builder} {...$$restProps} />
+	<div bind:this={el} use:melt={builder} {...$$restProps}></div>
 {/if}

--- a/packages/bits-ui/src/lib/bits/menu/components/menu-arrow.svelte
+++ b/packages/bits-ui/src/lib/bits/menu/components/menu-arrow.svelte
@@ -23,5 +23,5 @@
 {#if asChild}
 	<slot {builder} />
 {:else}
-	<div bind:this={el} use:melt={builder} {...$$restProps} />
+	<div bind:this={el} use:melt={builder} {...$$restProps}></div>
 {/if}

--- a/packages/bits-ui/src/lib/bits/menu/components/menu-separator.svelte
+++ b/packages/bits-ui/src/lib/bits/menu/components/menu-separator.svelte
@@ -22,5 +22,5 @@
 {#if asChild}
 	<slot {builder} />
 {:else}
-	<div bind:this={el} use:melt={$separator} {...$$restProps} />
+	<div bind:this={el} use:melt={$separator} {...$$restProps}></div>
 {/if}

--- a/packages/bits-ui/src/lib/bits/popover/components/popover-arrow.svelte
+++ b/packages/bits-ui/src/lib/bits/popover/components/popover-arrow.svelte
@@ -23,5 +23,5 @@
 {#if asChild}
 	<slot {builder} />
 {:else}
-	<div bind:this={el} use:melt={builder} {...$$restProps} />
+	<div bind:this={el} use:melt={builder} {...$$restProps}></div>
 {/if}

--- a/packages/bits-ui/src/lib/bits/select/components/select-arrow.svelte
+++ b/packages/bits-ui/src/lib/bits/select/components/select-arrow.svelte
@@ -23,5 +23,5 @@
 {#if asChild}
 	<slot {builder} />
 {:else}
-	<div bind:this={el} use:melt={builder} {...$$restProps} />
+	<div bind:this={el} use:melt={builder} {...$$restProps}></div>
 {/if}

--- a/packages/bits-ui/src/lib/bits/separator/components/separator.svelte
+++ b/packages/bits-ui/src/lib/bits/separator/components/separator.svelte
@@ -28,5 +28,5 @@
 {#if asChild}
 	<slot {builder} />
 {:else}
-	<div bind:this={el} use:melt={builder} {...$$restProps} />
+	<div bind:this={el} use:melt={builder} {...$$restProps}></div>
 {/if}

--- a/packages/bits-ui/src/lib/bits/slider/components/slider-range.svelte
+++ b/packages/bits-ui/src/lib/bits/slider/components/slider-range.svelte
@@ -22,5 +22,5 @@
 {#if asChild}
 	<slot {builder} />
 {:else}
-	<span bind:this={el} use:melt={builder} {...$$restProps} />
+	<span bind:this={el} use:melt={builder} {...$$restProps}></span>
 {/if}

--- a/packages/bits-ui/src/lib/bits/slider/components/slider-thumb.svelte
+++ b/packages/bits-ui/src/lib/bits/slider/components/slider-thumb.svelte
@@ -23,5 +23,5 @@
 {#if asChild}
 	<slot {builder} />
 {:else}
-	<span bind:this={el} use:melt={builder} {...$$restProps} on:m-keydown={dispatch} />
+	<span bind:this={el} use:melt={builder} {...$$restProps} on:m-keydown={dispatch}></span>
 {/if}

--- a/packages/bits-ui/src/lib/bits/slider/components/slider-tick.svelte
+++ b/packages/bits-ui/src/lib/bits/slider/components/slider-tick.svelte
@@ -20,5 +20,5 @@
 {#if asChild}
 	<slot {builder} />
 {:else}
-	<span bind:this={el} use:melt={builder} {...$$restProps} />
+	<span bind:this={el} use:melt={builder} {...$$restProps}></span>
 {/if}

--- a/packages/bits-ui/src/lib/bits/switch/components/switch-thumb.svelte
+++ b/packages/bits-ui/src/lib/bits/switch/components/switch-thumb.svelte
@@ -22,5 +22,5 @@
 {#if asChild}
 	<slot {attrs} checked={$checked} />
 {:else}
-	<span bind:this={el} {...$$restProps} {...attrs} />
+	<span bind:this={el} {...$$restProps} {...attrs}></span>
 {/if}

--- a/packages/bits-ui/src/lib/bits/tooltip/components/tooltip-arrow.svelte
+++ b/packages/bits-ui/src/lib/bits/tooltip/components/tooltip-arrow.svelte
@@ -23,5 +23,5 @@
 {#if asChild}
 	<slot {builder} />
 {:else}
-	<div bind:this={el} use:melt={builder} {...$$restProps} />
+	<div bind:this={el} use:melt={builder} {...$$restProps}></div>
 {/if}

--- a/packages/bits-ui/src/tests/combobox/ComboboxTest.svelte
+++ b/packages/bits-ui/src/tests/combobox/ComboboxTest.svelte
@@ -57,4 +57,4 @@
 		{/if}
 	</button>
 </main>
-<div data-testid="portal-target" id="portal-target" />
+<div data-testid="portal-target" id="portal-target"></div>

--- a/packages/bits-ui/src/tests/link-preview/LinkPreviewTest.svelte
+++ b/packages/bits-ui/src/tests/link-preview/LinkPreviewTest.svelte
@@ -22,4 +22,4 @@
 	<button data-testid="binding" on:click={() => (open = !open)}>{open}</button>
 	<div data-testid="outside">outside</div>
 </main>
-<div data-testid="portal-target" id="portal-target" />
+<div data-testid="portal-target" id="portal-target"></div>

--- a/packages/bits-ui/src/tests/popover/PopoverTest.svelte
+++ b/packages/bits-ui/src/tests/popover/PopoverTest.svelte
@@ -19,4 +19,4 @@
 	<button data-testid="binding" on:click={() => (open = !open)}>{open}</button>
 	<div data-testid="outside">outside</div>
 </main>
-<div data-testid="portal-target" id="portal-target" />
+<div data-testid="portal-target" id="portal-target"></div>

--- a/packages/bits-ui/src/tests/select/SelectTest.svelte
+++ b/packages/bits-ui/src/tests/select/SelectTest.svelte
@@ -50,4 +50,4 @@
 		{/if}
 	</button>
 </main>
-<div data-testid="portal-target" id="portal-target" />
+<div data-testid="portal-target" id="portal-target"></div>

--- a/packages/bits-ui/src/tests/tooltip/TooltipTest.svelte
+++ b/packages/bits-ui/src/tests/tooltip/TooltipTest.svelte
@@ -14,4 +14,4 @@
 	<button data-testid="binding" on:click={() => (open = !open)}>{open}</button>
 	<div data-testid="outside">outside</div>
 </main>
-<div data-testid="portal-target" id="portal-target" />
+<div data-testid="portal-target" id="portal-target"></div>


### PR DESCRIPTION
Was doing some dep cleanup for Runed and Bits was causing warnings for this in the newer versions of Svelte 5