### PR TITLE
Added slot to overlay and globalized transitions to support nested modals using flex for centering

### DIFF
--- a/packages/bits-ui/src/lib/bits/dialog/components/dialog-content.svelte
+++ b/packages/bits-ui/src/lib/bits/dialog/components/dialog-content.svelte
@@ -42,7 +42,7 @@
 {:else if transition && $open}
 	<div
 		bind:this={el}
-		transition:transition={transitionConfig}
+		transition:transition|global={transitionConfig}
 		use:melt={builder}
 		{...$$restProps}
 		on:pointerdown
@@ -58,8 +58,8 @@
 {:else if inTransition && outTransition && $open}
 	<div
 		bind:this={el}
-		in:inTransition={inTransitionConfig}
-		out:outTransition={outTransitionConfig}
+		in:inTransition|global={inTransitionConfig}
+		out:outTransition|global={outTransitionConfig}
 		use:melt={builder}
 		on:pointerdown
 		on:pointermove
@@ -75,7 +75,7 @@
 {:else if inTransition && $open}
 	<div
 		bind:this={el}
-		in:inTransition={inTransitionConfig}
+		in:inTransition|global={inTransitionConfig}
 		use:melt={builder}
 		on:pointerdown
 		on:pointermove
@@ -91,7 +91,7 @@
 {:else if outTransition && $open}
 	<div
 		bind:this={el}
-		out:outTransition={outTransitionConfig}
+		out:outTransition|global={outTransitionConfig}
 		use:melt={builder}
 		on:pointerdown
 		on:pointermove

--- a/packages/bits-ui/src/lib/bits/dialog/components/dialog-overlay.svelte
+++ b/packages/bits-ui/src/lib/bits/dialog/components/dialog-overlay.svelte
@@ -41,7 +41,9 @@
 		transition:transition={transitionConfig}
 		use:melt={builder}
 		{...$$restProps}
-	></div>
+	>
+		<slot />
+	</div>
 {:else if inTransition && outTransition && $open}
 	<!-- svelte-ignore a11y-no-static-element-interactions a11y_no_static_element_interactions -->
 	<div
@@ -51,7 +53,9 @@
 		use:melt={builder}
 		on:mouseup
 		{...$$restProps}
-	></div>
+	>
+		<slot />
+	</div>
 {:else if inTransition && $open}
 	<!-- svelte-ignore a11y-no-static-element-interactions a11y_no_static_element_interactions -->
 	<div
@@ -60,7 +64,9 @@
 		use:melt={builder}
 		on:mouseup
 		{...$$restProps}
-	></div>
+	>
+		<slot />
+	</div>
 {:else if outTransition && $open}
 	<!-- svelte-ignore a11y-no-static-element-interactions a11y_no_static_element_interactions -->
 	<div
@@ -69,8 +75,10 @@
 		use:melt={builder}
 		on:mouseup
 		{...$$restProps}
-	></div>
+	>
+		<slot />
+	</div>
 {:else if $open}
 	<!-- svelte-ignore a11y-no-static-element-interactions a11y_no_static_element_interactions -->
-	<div bind:this={el} use:melt={builder} on:mouseup {...$$restProps}></div>
+	<div bind:this={el} use:melt={builder} on:mouseup {...$$restProps}><slot /></div>
 {/if}


### PR DESCRIPTION
This pull request is based on https://github.com/huntabyte/shadcn-svelte/issues/534. PR necessary to be able to use flex for centering the dialogs.
Once this gets merged, everyone can decide if they want to use flex in their projects and make the necessary changes in their local shadcn code themselves.