### PR TITLE
fix: Updated ComboboxLabelProps to use HTMLLabelAttributes

### DIFF
--- a/.changeset/fresh-islands-cover.md
+++ b/.changeset/fresh-islands-cover.md
@@ -1,0 +1,5 @@
+---
+"bits-ui": patch
+---
+
+fix: Updated `ComboboxLabelProps` to use `HTMLLabelAttributes`

--- a/packages/bits-ui/src/lib/bits/combobox/types.ts
+++ b/packages/bits-ui/src/lib/bits/combobox/types.ts
@@ -1,4 +1,4 @@
-import type { EventHandler, HTMLInputAttributes } from "svelte/elements";
+import type { EventHandler, HTMLInputAttributes, HTMLLabelAttributes } from "svelte/elements";
 import type {
 	ComboboxOptionProps as MeltComboboxOptionProps,
 	CreateComboboxProps as MeltComboboxProps,
@@ -113,7 +113,7 @@ export type ComboboxContentProps<
 > = ComboboxContentPropsWithoutHTML<T, In, Out> & HTMLDivAttributes;
 
 export type ComboboxInputProps = ComboboxInputPropsWithoutHTML & HTMLInputAttributes;
-export type ComboboxLabelProps = ComboboxLabelPropsWithoutHTML & HTMLDivAttributes;
+export type ComboboxLabelProps = ComboboxLabelPropsWithoutHTML & HTMLLabelAttributes;
 
 export type ComboboxGroupProps = ComboboxGroupPropsWithoutHTML & HTMLDivAttributes;
 export type ComboboxGroupLabelProps = ComboboxGroupLabelPropsWithoutHTML & HTMLDivAttributes;


### PR DESCRIPTION
Changed types since the attributes are applied to a `<label>` element and not a `<div>` element.