### PR TITLE
fix: ContentProps type

### DIFF
--- a/.changeset/thick-turkeys-grab.md
+++ b/.changeset/thick-turkeys-grab.md
@@ -1,0 +1,5 @@
+---
+"bits-ui": patch
+---
+
+fix: ContentProps type

--- a/packages/bits-ui/src/lib/bits/floating/_types.ts
+++ b/packages/bits-ui/src/lib/bits/floating/_types.ts
@@ -1,4 +1,4 @@
-import type { DOMElement, Transition, TransitionProps } from "$lib/internal/index.js";
+import type { DOMElement, Expand, Transition, TransitionProps } from "$lib/internal/index.js";
 
 export type ArrowProps = Expand<
 	{


### PR DESCRIPTION
The ContentProps type is used by the `Select` and `DropdownMenu`. I just exported the `Expand` type from `$lib/internal/index.js`

This closes #543, closes #512.