### PR TITLE
fix: date pickers clear

### DIFF
--- a/packages/bits-ui/src/lib/bits/date-picker/components/date-picker.svelte
+++ b/packages/bits-ui/src/lib/bits/date-picker/components/date-picker.svelte
@@ -145,7 +145,7 @@
 		ids.dateField.description.set(descriptionId);
 	}
 
-	$: value !== undefined && localValue.set(value);
+	$: value !== $localValue && localValue.set(value);
 	$: placeholder !== undefined && localPlaceholder.set(placeholder);
 	$: open !== undefined && localOpen.set(open);
 

--- a/packages/bits-ui/src/lib/bits/date-range-picker/components/date-range-picker.svelte
+++ b/packages/bits-ui/src/lib/bits/date-range-picker/components/date-range-picker.svelte
@@ -37,7 +37,7 @@
 			placeholder: localPlaceholder,
 			isInvalid: localIsInvalid,
 			startValue: localStartValue,
-			endValue,
+			endValue: localEndValue,
 		},
 		updateOption,
 		ids,
@@ -188,7 +188,14 @@
 	}
 
 	$: startValue = $localStartValue;
-	$: value !== undefined && localValue.set(value);
+
+	$: if (value !== $localValue) {
+		const nextValue = { start: value?.start, end: value?.end };
+
+		if (nextValue.start !== $localStartValue) localStartValue.set(nextValue.start);
+		if (nextValue.end !== $localEndValue) localEndValue.set(nextValue.end);
+		localValue.set(nextValue);
+	}
 	$: placeholder !== undefined && localPlaceholder.set(placeholder);
 
 	$: updateOption("disabled", disabled);
@@ -215,5 +222,5 @@
 	ids={$idValues}
 	isInvalid={$localIsInvalid}
 	startValue={$localStartValue}
-	endValue={$endValue}
+	endValue={$localEndValue}
 />


### PR DESCRIPTION
this PR solves two issues:

- clearing value for date range field https://github.com/huntabyte/bits-ui/issues/391
- clearing value for date picker when value is set to undefined (not reported. Currently clearing value works only when is set to null, but this will cause TS error)

I still have issue with date range field which will not clear segments even when value, startValue and endValue clears (for date field it works fine). I'm not sure how segments get updates after value changes - I need some help here. Maybe it must be done on melt-ui.