### PR TITLE
feat: forward additional events from `<Button>`

### DIFF
--- a/.changeset/clever-rockets-accept.md
+++ b/.changeset/clever-rockets-accept.md
@@ -1,0 +1,5 @@
+---
+"bits-ui": patch
+---
+
+feat: forward additional events from `<Button>`

--- a/packages/bits-ui/src/lib/bits/button/components/button.svelte
+++ b/packages/bits-ui/src/lib/bits/button/components/button.svelte
@@ -26,6 +26,10 @@
 		on:keyup
 		on:mouseenter
 		on:mouseleave
+		on:mousedown
+		on:pointerdown
+		on:mouseup
+		on:pointerup
 		tabindex="0"
 		use:builderActions={{ builders }}
 		{...getAttrs(builders)}
@@ -47,6 +51,10 @@
 		on:keyup
 		on:mouseenter
 		on:mouseleave
+		on:mousedown
+		on:pointerdown
+		on:mouseup
+		on:pointerup
 		tabindex="0"
 		{...$$restProps}
 		{...attrs}

--- a/packages/bits-ui/src/lib/bits/button/types.ts
+++ b/packages/bits-ui/src/lib/bits/button/types.ts
@@ -34,4 +34,8 @@ export type ButtonEvents = {
 	keyup: ButtonEventHandler<KeyboardEvent>;
 	mouseenter: ButtonEventHandler<MouseEvent>;
 	mouseleave: ButtonEventHandler<MouseEvent>;
+	mousedown: ButtonEventHandler<MouseEvent>;
+	mouseup: ButtonEventHandler<MouseEvent>;
+	pointerdown: ButtonEventHandler<PointerEvent>;
+	pointerup: ButtonEventHandler<PointerEvent>;
 };


### PR DESCRIPTION
Forward `pointerdown`, `pointerup`, `mousedown`, and `mouseup` events from the `<Button>` component