### PR TITLE
chore: make v5 compatibility more flexible

### DIFF
--- a/packages/bits-ui/package.json
+++ b/packages/bits-ui/package.json
@@ -58,6 +58,6 @@
 		"nanoid": "^5.0.5"
 	},
 	"peerDependencies": {
-		"svelte": "^4.0.0 || ^5.0.0-next.118"
+		"svelte": ">=4 <=5"
 	}
 }


### PR DESCRIPTION
since svelte v5 is backwards compatible, updating peerDep range to `<=5` means we don't have to update this when there's a new rc version.

This will make it similar to how melt-ui is currently: https://github.com/melt-ui/melt-ui/blob/develop/package.json#L61