### PR TITLE
docs: Update descriptions and structure for Toggle/Group

### DIFF
--- a/sites/docs/content/components/toggle-group.md
+++ b/sites/docs/content/components/toggle-group.md
@@ -1,6 +1,6 @@
 ---
 title: Toggle Group
-description: A control element that switches between two states, providing a binary choice.
+description: Groups multiple toggle controls, allowing users to enable one or multiple options.
 ---
 
 <script>

--- a/sites/docs/content/components/toggle.md
+++ b/sites/docs/content/components/toggle.md
@@ -1,6 +1,6 @@
 ---
 title: Toggle
-description: Groups multiple toggle controls, allowing users to enable one or multiple options.
+description: A control element that switches between two states, providing a binary choice.
 ---
 
 <script>
@@ -21,10 +21,7 @@ description: Groups multiple toggle controls, allowing users to enable one or mu
 	import { Toggle } from "bits-ui";
 </script>
 
-<Toggle.Root>
-	<Toggle.Thumb />
-	<Toggle.Input />
-</Toggle.Root>
+<Toggle.Root/>
 ```
 
 <APISection {schemas} />


### PR DESCRIPTION
### Currently, the descriptions for `Toggle` and `Toggle Group` are reversed! 

<img width="483" alt="image" src="https://github.com/huntabyte/bits-ui/assets/682323/7255ff41-7a75-4316-b850-bee5e97e56f4">
<img width="468" alt="image" src="https://github.com/huntabyte/bits-ui/assets/682323/db578d87-bf46-4de5-9d33-7a4696639623">

---

### Also, the structure for `Toggle` includes `Toggle.Thumb` and `Toggle.Input` components which do not exist:

``` ts
<script lang="ts">
  import { Toggle } from "bits-ui";
</script>
 
<Toggle.Root>
  <Toggle.Thumb />
  <Toggle.Input />
</Toggle.Root>
```

---

### This PR switches the descriptions and removes the extraneous components from the structure:

``` ts
<script lang="ts">
  import { Toggle } from "bits-ui";
</script>
 
<Toggle.Root/>
```
