### PR TITLE
fix: `nonpassive` modifier to `touchmove` and `touchstart` events

### DIFF
--- a/.changeset/eight-guests-lay.md
+++ b/.changeset/eight-guests-lay.md
@@ -1,0 +1,5 @@
+---
+"bits-ui": patch
+---
+
+Add `nonpassive` modifier to `touchmove` and `touchstart` events

--- a/packages/bits-ui/src/lib/bits/alert-dialog/components/alert-dialog-content.svelte
+++ b/packages/bits-ui/src/lib/bits/alert-dialog/components/alert-dialog-content.svelte
@@ -46,10 +46,10 @@
 		on:pointerdown
 		on:pointermove
 		on:pointerup
-		on:touchend
-		on:touchstart
 		on:touchcancel
-		on:touchmove
+		on:touchend
+		on:touchmove|nonpassive
+		on:touchstart|nonpassive
 		{...$$restProps}
 	>
 		<slot {builder} />
@@ -63,10 +63,10 @@
 		on:pointerdown
 		on:pointermove
 		on:pointerup
-		on:touchend
-		on:touchstart
 		on:touchcancel
-		on:touchmove
+		on:touchend
+		on:touchmove|nonpassive
+		on:touchstart|nonpassive
 		{...$$restProps}
 	>
 		<slot {builder} />
@@ -79,10 +79,10 @@
 		on:pointerdown
 		on:pointermove
 		on:pointerup
-		on:touchend
-		on:touchstart
 		on:touchcancel
-		on:touchmove
+		on:touchend
+		on:touchmove|nonpassive
+		on:touchstart|nonpassive
 		{...$$restProps}
 	>
 		<slot {builder} />
@@ -95,10 +95,10 @@
 		on:pointerdown
 		on:pointermove
 		on:pointerup
-		on:touchend
-		on:touchstart
 		on:touchcancel
-		on:touchmove
+		on:touchend
+		on:touchmove|nonpassive
+		on:touchstart|nonpassive
 		{...$$restProps}
 	>
 		<slot {builder} />
@@ -110,10 +110,10 @@
 		on:pointerdown
 		on:pointermove
 		on:pointerup
-		on:touchend
-		on:touchstart
 		on:touchcancel
-		on:touchmove
+		on:touchend
+		on:touchmove|nonpassive
+		on:touchstart|nonpassive
 		{...$$restProps}
 	>
 		<slot {builder} />

--- a/packages/bits-ui/src/lib/bits/dialog/components/dialog-content.svelte
+++ b/packages/bits-ui/src/lib/bits/dialog/components/dialog-content.svelte
@@ -48,10 +48,10 @@
 		on:pointerdown
 		on:pointermove
 		on:pointerup
-		on:touchend
-		on:touchstart
 		on:touchcancel
-		on:touchmove
+		on:touchend
+		on:touchmove|nonpassive
+		on:touchstart|nonpassive
 	>
 		<slot {builder} />
 	</div>
@@ -64,10 +64,10 @@
 		on:pointerdown
 		on:pointermove
 		on:pointerup
-		on:touchend
-		on:touchstart
 		on:touchcancel
-		on:touchmove
+		on:touchend
+		on:touchmove|nonpassive
+		on:touchstart|nonpassive
 		{...$$restProps}
 	>
 		<slot {builder} />
@@ -80,10 +80,10 @@
 		on:pointerdown
 		on:pointermove
 		on:pointerup
-		on:touchend
-		on:touchstart
 		on:touchcancel
-		on:touchmove
+		on:touchend
+		on:touchmove|nonpassive
+		on:touchstart|nonpassive
 		{...$$restProps}
 	>
 		<slot {builder} />
@@ -96,10 +96,10 @@
 		on:pointerdown
 		on:pointermove
 		on:pointerup
-		on:touchend
-		on:touchstart
 		on:touchcancel
-		on:touchmove
+		on:touchend
+		on:touchmove|nonpassive
+		on:touchstart|nonpassive
 		{...$$restProps}
 	>
 		<slot {builder} />
@@ -111,10 +111,10 @@
 		on:pointerdown
 		on:pointermove
 		on:pointerup
-		on:touchend
-		on:touchstart
 		on:touchcancel
-		on:touchmove
+		on:touchend
+		on:touchmove|nonpassive
+		on:touchstart|nonpassive
 		{...$$restProps}
 	>
 		<slot {builder} />

--- a/sites/docs/content/components/toggle.md
+++ b/sites/docs/content/components/toggle.md
@@ -21,7 +21,7 @@ description: A control element that switches between two states, providing a bin
 	import { Toggle } from "bits-ui";
 </script>
 
-<Toggle.Root/>
+<Toggle.Root />
 ```
 
 <APISection {schemas} />


### PR DESCRIPTION
### Problem

Chrome complains of non-passive event listener violations if certain listeners are not *explicitly* marked as non-passive.

<img width="614" alt="image" src="https://github.com/huntabyte/bits-ui/assets/682323/d8fb6d0c-1ebe-4aae-bb9e-3f3f719faa74">


### Solution

Svelte has created [a convenient way](https://github.com/sveltejs/svelte/issues/2068) to add a `nonpassive` event modifer like so:

``` ts
  on:touchmove|nonpassive
  on:touchstart|nonpassive
```

This PR applies the modifier to events in `Alert Dialog Content` and `Dialog Content`