### PR TITLE
feat: compatibility with `exactOptionalPropertyTypes`

### DIFF
--- a/.changeset/weak-dingos-help.md
+++ b/.changeset/weak-dingos-help.md
@@ -2,4 +2,4 @@
 "bits-ui": patch
 ---
 
-feat: compatibility with `exactOptionalPropertyTypes`
+fix: compatibility with `exactOptionalPropertyTypes`

--- a/.changeset/weak-dingos-help.md
+++ b/.changeset/weak-dingos-help.md
@@ -1,0 +1,5 @@
+---
+"bits-ui": patch
+---
+
+feat: compatibility with `exactOptionalPropertyTypes`

--- a/packages/bits-ui/src/lib/bits/accordion/types.ts
+++ b/packages/bits-ui/src/lib/bits/accordion/types.ts
@@ -23,12 +23,12 @@ export type AccordionPropsWithoutHTML<Multiple extends boolean> = Expand<
 		 * The value of the accordion.
 		 * You can bind this to a value to programmatically control the open state.
 		 */
-		value?: MeltAccordionProps<Multiple>["defaultValue"];
+		value?: MeltAccordionProps<Multiple>["defaultValue"] | undefined;
 
 		/**
 		 * A callback function called when the value changes.
 		 */
-		onValueChange?: OnChangeFn<MeltAccordionProps<Multiple>["defaultValue"]>;
+		onValueChange?: OnChangeFn<MeltAccordionProps<Multiple>["defaultValue"]> | undefined;
 	} & DOMElement
 >;
 
@@ -41,7 +41,7 @@ export type AccordionHeaderPropsWithoutHTML = Expand<
 		/**
 		 * The heading level of the accordion header.
 		 */
-		level?: ObjectVariation<MeltAccordionHeadingProps>["level"];
+		level?: ObjectVariation<MeltAccordionHeadingProps>["level"] | undefined;
 	} & DOMElement
 >;
 

--- a/packages/bits-ui/src/lib/bits/alert-dialog/types.ts
+++ b/packages/bits-ui/src/lib/bits/alert-dialog/types.ts
@@ -21,12 +21,12 @@ export type AlertDialogPropsWithoutHTML = Expand<
 		 *
 		 * @defaultValue false
 		 */
-		open?: boolean;
+		open?: boolean | undefined;
 
 		/**
 		 * A callback function called when the open state changes.
 		 */
-		onOpenChange?: OnChangeFn<boolean>;
+		onOpenChange?: OnChangeFn<boolean> | undefined;
 	}
 >;
 
@@ -54,7 +54,7 @@ export type AlertDialogPortalPropsWithoutHTML = DOMElement;
 
 export type AlertDialogTitlePropsWithoutHTML = Expand<
 	{
-		level?: "h1" | "h2" | "h3" | "h4" | "h5" | "h6";
+		level?: "h1" | "h2" | "h3" | "h4" | "h5" | "h6" | undefined;
 	} & DOMElement<HTMLHeadingElement>
 >;
 

--- a/packages/bits-ui/src/lib/bits/aspect-ratio/types.ts
+++ b/packages/bits-ui/src/lib/bits/aspect-ratio/types.ts
@@ -1,4 +1,4 @@
-import type { DOMEl, HTMLDivAttributes } from "$lib/internal/index.js";
+import type { DOMEl, Expand, HTMLDivAttributes } from "$lib/internal/index.js";
 
 export type AspectRatioPropsWithoutHTML = Expand<
 	{

--- a/packages/bits-ui/src/lib/bits/aspect-ratio/types.ts
+++ b/packages/bits-ui/src/lib/bits/aspect-ratio/types.ts
@@ -2,7 +2,7 @@ import type { DOMEl, HTMLDivAttributes } from "$lib/internal/index.js";
 
 export type AspectRatioPropsWithoutHTML = Expand<
 	{
-		ratio?: number;
+		ratio?: number | undefined;
 	} & DOMEl
 >;
 

--- a/packages/bits-ui/src/lib/bits/avatar/types.ts
+++ b/packages/bits-ui/src/lib/bits/avatar/types.ts
@@ -14,12 +14,12 @@ export type AvatarPropsWithoutHTML = Expand<
 		 * The loading state of the image.
 		 * You can bind this to a boolean value to programmatically control the loading state.
 		 */
-		loadingStatus?: "loading" | "loaded" | "error";
+		loadingStatus?: "loading" | "loaded" | "error" | undefined;
 
 		/**
 		 * A callback function called when the loading state changes.
 		 */
-		onLoadingStatusChange?: OnChangeFn<"loading" | "loaded" | "error">;
+		onLoadingStatusChange?: OnChangeFn<"loading" | "loaded" | "error"> | undefined;
 	} & DOMElement
 >;
 

--- a/packages/bits-ui/src/lib/bits/button/types.ts
+++ b/packages/bits-ui/src/lib/bits/button/types.ts
@@ -6,19 +6,19 @@ export type ButtonPropsWithoutHTML = {
 	/**
 	 * Melt UI builders to apply to the button component.
 	 */
-	builders?: Builder[];
+	builders?: Builder[] | undefined;
 };
 
 type AnchorElement = ButtonPropsWithoutHTML &
 	HTMLAnchorAttributes & {
-		href?: HTMLAnchorAttributes["href"];
-		type?: never;
+		href?: HTMLAnchorAttributes["href"] | undefined;
+		type?: never | undefined;
 	} & DOMEl<HTMLAnchorElement>;
 
 type ButtonElement = ButtonPropsWithoutHTML &
 	HTMLButtonAttributes & {
-		type?: HTMLButtonAttributes["type"];
-		href?: never;
+		type?: HTMLButtonAttributes["type"] | undefined;
+		href?: never | undefined;
 	} & DOMEl<HTMLButtonElement>;
 
 export type ButtonProps = AnchorElement | ButtonElement;

--- a/packages/bits-ui/src/lib/bits/calendar/types.ts
+++ b/packages/bits-ui/src/lib/bits/calendar/types.ts
@@ -30,12 +30,12 @@ export type CalendarPropsWithoutHTML<Multiple extends boolean = false> = Expand<
 		 * You can bind this to a value to programmatically control the
 		 * value state.
 		 */
-		value?: MeltCalendarProps<Multiple>["defaultValue"];
+		value?: MeltCalendarProps<Multiple>["defaultValue"] | undefined;
 
 		/**
 		 * A callback function called when the value changes.
 		 */
-		onValueChange?: OnChangeFn<MeltCalendarProps<Multiple>["defaultValue"]>;
+		onValueChange?: OnChangeFn<MeltCalendarProps<Multiple>["defaultValue"]> | undefined;
 
 		/**
 		 * The placeholder date, used to display the calendar when no
@@ -45,12 +45,12 @@ export type CalendarPropsWithoutHTML<Multiple extends boolean = false> = Expand<
 		 * You can bind this to a value to programmatically control the
 		 * placeholder state.
 		 */
-		placeholder?: DateValue;
+		placeholder?: DateValue | undefined;
 
 		/**
 		 * A callback function called when the placeholder changes.
 		 */
-		onPlaceholderChange?: OnChangeFn<DateValue>;
+		onPlaceholderChange?: OnChangeFn<DateValue> | undefined;
 
 		/**
 		 * If `true`, the calendar will focus the selected day,
@@ -59,7 +59,7 @@ export type CalendarPropsWithoutHTML<Multiple extends boolean = false> = Expand<
 		 *
 		 * @default false
 		 */
-		initialFocus?: boolean;
+		initialFocus?: boolean | undefined;
 	} & DOMElement
 >;
 

--- a/packages/bits-ui/src/lib/bits/calendar/types.ts
+++ b/packages/bits-ui/src/lib/bits/calendar/types.ts
@@ -7,7 +7,7 @@ import type {
 } from "svelte/elements";
 import type { DateValue } from "@internationalized/date";
 import type { CreateCalendarProps as MeltCalendarProps } from "@melt-ui/svelte";
-import type { DOMElement, HTMLDivAttributes, OnChangeFn } from "$lib/internal/index.js";
+import type { DOMElement, Expand, HTMLDivAttributes, OnChangeFn } from "$lib/internal/index.js";
 import type { CustomEventHandler } from "$lib/index.js";
 
 type OmitCalendarProps<T> = Omit<

--- a/packages/bits-ui/src/lib/bits/checkbox/types.ts
+++ b/packages/bits-ui/src/lib/bits/checkbox/types.ts
@@ -18,12 +18,12 @@ export type CheckboxPropsWithoutHTML = Expand<
 		 *
 		 * @defaultValue false
 		 */
-		checked?: boolean | "indeterminate";
+		checked?: boolean | "indeterminate" | undefined;
 
 		/**
 		 * A callback function called when the checked state changes.
 		 */
-		onCheckedChange?: OnChangeFn<boolean | "indeterminate">;
+		onCheckedChange?: OnChangeFn<boolean | "indeterminate"> | undefined;
 	} & DOMElement<HTMLButtonElement>
 >;
 

--- a/packages/bits-ui/src/lib/bits/collapsible/types.ts
+++ b/packages/bits-ui/src/lib/bits/collapsible/types.ts
@@ -20,12 +20,12 @@ export type CollapsiblePropsWithoutHTML = Expand<
 		 *
 		 * @defaultValue false
 		 */
-		open?: boolean;
+		open?: boolean | undefined;
 
 		/**
 		 * A callback function called when the open state changes.
 		 */
-		onOpenChange?: OnChangeFn<boolean>;
+		onOpenChange?: OnChangeFn<boolean> | undefined;
 	} & DOMElement
 >;
 

--- a/packages/bits-ui/src/lib/bits/combobox/ctx.ts
+++ b/packages/bits-ui/src/lib/bits/combobox/ctx.ts
@@ -46,11 +46,11 @@ export function getCtx() {
 
 type Items<T> = {
 	value: T;
-	label?: string;
+	label?: string | undefined;
 };
 
 type Props<T = unknown, M extends boolean = false> = CreateComboboxProps<T, M> & {
-	items?: Items<T>[];
+	items?: Items<T>[] | undefined;
 };
 
 export function setCtx<T = unknown, M extends boolean = false>(props: Props<T, M>) {

--- a/packages/bits-ui/src/lib/bits/combobox/types.ts
+++ b/packages/bits-ui/src/lib/bits/combobox/types.ts
@@ -43,7 +43,7 @@ export type ComboboxPropsWithoutHTML<T = unknown, Multiple extends boolean = fal
 		/**
 		 * A callback function called when the selected value changes.
 		 */
-		onSelectedChange?: OnChangeFn<SelectValue<Selected<T>, Multiple>>;
+		onSelectedChange?: OnChangeFn<SelectValue<Selected<T>, Multiple>> | undefined;
 
 		/**
 		 * The open state of the combobox menu.
@@ -51,17 +51,17 @@ export type ComboboxPropsWithoutHTML<T = unknown, Multiple extends boolean = fal
 		 *
 		 * @defaultValue false
 		 */
-		open?: boolean;
+		open?: boolean | undefined;
 
 		/**
 		 * A callback function called when the open state changes.
 		 */
-		onOpenChange?: OnChangeFn<boolean>;
+		onOpenChange?: OnChangeFn<boolean> | undefined;
 
 		/**
 		 * Whether or not multiple values can be selected.
 		 */
-		multiple?: Multiple;
+		multiple?: Multiple | undefined;
 
 		/**
 		 * The value of the input.
@@ -69,13 +69,13 @@ export type ComboboxPropsWithoutHTML<T = unknown, Multiple extends boolean = fal
 		 *
 		 * @defaultValue ""
 		 */
-		inputValue?: string;
+		inputValue?: string | undefined;
 
 		/**
 		 * Optionally provide an array of `Selected<T>` objects to
 		 * type the `selected` and `onSelectedChange` props.
 		 */
-		items?: Selected<T>[];
+		items?: Selected<T>[] | undefined;
 
 		/**
 		 * Whether the input has been touched or not. You can bind to this to
@@ -83,7 +83,7 @@ export type ComboboxPropsWithoutHTML<T = unknown, Multiple extends boolean = fal
 		 *
 		 * @defaultValue false
 		 */
-		touchedInput?: boolean;
+		touchedInput?: boolean | undefined;
 	}
 >;
 

--- a/packages/bits-ui/src/lib/bits/date-field/types.ts
+++ b/packages/bits-ui/src/lib/bits/date-field/types.ts
@@ -17,34 +17,34 @@ export type DateFieldPropsWithoutHTML = Expand<
 		 * The value of the date field.
 		 * You can bind this to a `DateValue` object to programmatically control the value.
 		 */
-		value?: DateValue;
+		value?: DateValue | undefined;
 
 		/**
 		 * A callback function called when the value changes.
 		 */
-		onValueChange?: OnChangeFn<DateValue | undefined>;
+		onValueChange?: OnChangeFn<DateValue | undefined> | undefined;
 
 		/**
 		 * The placeholder date used to start the field.
 		 */
-		placeholder?: DateValue;
+		placeholder?: DateValue | undefined;
 
 		/**
 		 * A callback function called when the placeholder changes.
 		 */
-		onPlaceholderChange?: OnChangeFn<DateValue>;
+		onPlaceholderChange?: OnChangeFn<DateValue> | undefined;
 
 		/**
 		 * The id of the validation message element which is used to apply the
 		 * appropriate `aria-describedby` attribute to the input.
 		 */
-		validationId?: string;
+		validationId?: string | undefined;
 
 		/**
 		 * The id of the description element which is used to describe the input.
 		 * This is used to apply the appropriate `aria-describedby` attribute to the input.
 		 */
-		descriptionId?: string;
+		descriptionId?: string | undefined;
 	}
 >;
 

--- a/packages/bits-ui/src/lib/bits/date-picker/types.ts
+++ b/packages/bits-ui/src/lib/bits/date-picker/types.ts
@@ -51,45 +51,45 @@ export type DatePickerPropsWithoutHTML = Expand<
 		 *
 		 * @default false
 		 */
-		open?: boolean;
+		open?: boolean | undefined;
 
 		/**
 		 * A callback function called when the open state changes.
 		 */
-		onOpenChange?: OnChangeFn<boolean>;
+		onOpenChange?: OnChangeFn<boolean> | undefined;
 
 		/**
 		 * The value of the date field.
 		 * You can bind this to a `DateValue` object to programmatically control the value.
 		 */
-		value?: DateValue;
+		value?: DateValue | undefined;
 
 		/**
 		 * A callback function called when the value changes.
 		 */
-		onValueChange?: OnChangeFn<DateValue | undefined>;
+		onValueChange?: OnChangeFn<DateValue | undefined> | undefined;
 
 		/**
 		 * The placeholder date used to start the field.
 		 */
-		placeholder?: DateValue;
+		placeholder?: DateValue | undefined;
 
 		/**
 		 * A callback function called when the placeholder changes.
 		 */
-		onPlaceholderChange?: OnChangeFn<DateValue>;
+		onPlaceholderChange?: OnChangeFn<DateValue> | undefined;
 
 		/**
 		 * The id of the validation message element which is used to apply the
 		 * appropriate `aria-describedby` attribute to the input.
 		 */
-		validationId?: string;
+		validationId?: string | undefined;
 
 		/**
 		 * The id of the description element which is used to describe the input.
 		 * This is used to apply the appropriate `aria-describedby` attribute to the input.
 		 */
-		descriptionId?: string;
+		descriptionId?: string | undefined;
 	}
 >;
 

--- a/packages/bits-ui/src/lib/bits/date-range-field/types.ts
+++ b/packages/bits-ui/src/lib/bits/date-range-field/types.ts
@@ -27,34 +27,34 @@ export type DateRangeFieldPropsWithoutHTML = Expand<
 		 * The value of the date field.
 		 * You can bind this to a `DateValue` object to programmatically control the value.
 		 */
-		value?: DateRange;
+		value?: DateRange | undefined;
 
 		/**
 		 * A callback function called when the value changes.
 		 */
-		onValueChange?: OnChangeFn<DateRange | undefined>;
+		onValueChange?: OnChangeFn<DateRange | undefined> | undefined;
 
 		/**
 		 * The placeholder date used to start the field.
 		 */
-		placeholder?: DateValue;
+		placeholder?: DateValue | undefined;
 
 		/**
 		 * A callback function called when the placeholder changes.
 		 */
-		onPlaceholderChange?: OnChangeFn<DateValue>;
+		onPlaceholderChange?: OnChangeFn<DateValue> | undefined;
 
 		/**
 		 * The id of the validation message element which is used to apply the
 		 * appropriate `aria-describedby` attribute to the input.
 		 */
-		validationId?: string;
+		validationId?: string | undefined;
 
 		/**
 		 * The id of the description element which is used to describe the input.
 		 * This is used to apply the appropriate `aria-describedby` attribute to the input.
 		 */
-		descriptionId?: string;
+		descriptionId?: string | undefined;
 	}
 >;
 

--- a/packages/bits-ui/src/lib/bits/date-range-picker/types.ts
+++ b/packages/bits-ui/src/lib/bits/date-range-picker/types.ts
@@ -57,45 +57,45 @@ export type DateRangePickerPropsWithoutHTML = Expand<
 		 *
 		 * @default false
 		 */
-		open?: boolean;
+		open?: boolean | undefined;
 
 		/**
 		 * A callback function called when the open state changes.
 		 */
-		onOpenChange?: OnChangeFn<boolean>;
+		onOpenChange?: OnChangeFn<boolean> | undefined;
 
 		/**
 		 * The value of the date field.
 		 * You can bind this to a `DateValue` object to programmatically control the value.
 		 */
-		value?: DateRange;
+		value?: DateRange | undefined;
 
 		/**
 		 * A callback function called when the value changes.
 		 */
-		onValueChange?: OnChangeFn<DateRange | undefined>;
+		onValueChange?: OnChangeFn<DateRange | undefined> | undefined;
 
 		/**
 		 * The placeholder date used to start the field.
 		 */
-		placeholder?: DateValue;
+		placeholder?: DateValue | undefined;
 
 		/**
 		 * A callback function called when the placeholder changes.
 		 */
-		onPlaceholderChange?: OnChangeFn<DateValue>;
+		onPlaceholderChange?: OnChangeFn<DateValue> | undefined;
 
 		/**
 		 * The id of the validation message element which is used to apply the
 		 * appropriate `aria-describedby` attribute to the input.
 		 */
-		validationId?: string;
+		validationId?: string | undefined;
 
 		/**
 		 * The id of the description element which is used to describe the input.
 		 * This is used to apply the appropriate `aria-describedby` attribute to the input.
 		 */
-		descriptionId?: string;
+		descriptionId?: string | undefined;
 
 		/**
 		 * The `start` value of the date range, which can exist prior

--- a/packages/bits-ui/src/lib/bits/dialog/types.ts
+++ b/packages/bits-ui/src/lib/bits/dialog/types.ts
@@ -25,22 +25,22 @@ export type DialogPropsWithoutHTML = Expand<
 		 *
 		 * @defaultValue false
 		 */
-		open?: MeltDialogProps["defaultOpen"] & {};
+		open?: (MeltDialogProps["defaultOpen"] & {}) | undefined;
 
 		/**
 		 * A callback function called when the open state changes.
 		 */
-		onOpenChange?: OnChangeFn<boolean>;
+		onOpenChange?: OnChangeFn<boolean> | undefined;
 
 		/**
 		 * Override the default autofocus behavior of the dialog when it opens
 		 */
-		openFocus?: FocusProp;
+		openFocus?: FocusProp | undefined;
 
 		/**
 		 * Override the default autofocus behavior of the dialog after close
 		 */
-		closeFocus?: FocusProp;
+		closeFocus?: FocusProp | undefined;
 	}
 >;
 
@@ -66,7 +66,7 @@ export type DialogPortalPropsWithoutHTML = DOMElement;
 
 export type DialogTitlePropsWithoutHTML = Expand<
 	{
-		level?: "h1" | "h2" | "h3" | "h4" | "h5" | "h6";
+		level?: "h1" | "h2" | "h3" | "h4" | "h5" | "h6" | undefined;
 	} & DOMElement<HTMLHeadingElement>
 >;
 

--- a/packages/bits-ui/src/lib/bits/floating/_types.ts
+++ b/packages/bits-ui/src/lib/bits/floating/_types.ts
@@ -2,7 +2,7 @@ import type { DOMElement, Expand, Transition, TransitionProps } from "$lib/inter
 
 export type ArrowProps = Expand<
 	{
-		size?: number;
+		size?: number | undefined;
 	} & DOMElement
 >;
 
@@ -22,7 +22,7 @@ export type FloatingProps = {
 	 *
 	 * @see https://floating-ui.com/docs/computePosition#placement
 	 */
-	side?: "top" | "right" | "bottom" | "left";
+	side?: "top" | "right" | "bottom" | "left" | undefined;
 
 	/**
 	 * The preferred alignment of the anchor to render against when open.
@@ -30,26 +30,26 @@ export type FloatingProps = {
 	 *
 	 * @see https://floating-ui.com/docs/computePosition#placement
 	 */
-	align?: "start" | "center" | "end";
+	align?: "start" | "center" | "end" | undefined;
 
 	/**
 	 * An offset in pixels from the "start" or "end" alignment options.
 	 * @see https://floating-ui.com/docs/offset#options
 	 */
-	alignOffset?: number;
+	alignOffset?: number | undefined;
 
 	/**
 	 * The distance in pixels from the anchor to the floating element.
 	 * @see https://floating-ui.com/docs/offset#options
 	 */
-	sideOffset?: number;
+	sideOffset?: number | undefined;
 
 	/**
 	 * Whether the content should be the same width as the trigger.
 	 *
 	 * @see https://floating-ui.com/docs/size
 	 */
-	sameWidth?: boolean;
+	sameWidth?: boolean | undefined;
 
 	/**
 	 * When `true`, overrides the `side` and `align` options to prevent collisions
@@ -58,7 +58,7 @@ export type FloatingProps = {
 	 * @default true
 	 * @see https://floating-ui.com/docs/flip
 	 */
-	avoidCollisions?: boolean;
+	avoidCollisions?: boolean | undefined;
 
 	/**
 	 * The amount in pixels of virtual padding around the viewport edges to check
@@ -67,14 +67,14 @@ export type FloatingProps = {
 	 * @default 8
 	 * @see https://floating-ui.com/docs/detectOverflow#padding
 	 */
-	collisionPadding?: number;
+	collisionPadding?: number | undefined;
 
 	/**
 	 * A boundary element or array of elements to check for collisions against.
 	 *
 	 * @see https://floating-ui.com/docs/detectoverflow#boundary
 	 */
-	collisionBoundary?: Boundary;
+	collisionBoundary?: Boundary | undefined;
 
 	/**
 	 * Whether the floating element should be constrained to the viewport.
@@ -82,13 +82,13 @@ export type FloatingProps = {
 	 * @default false
 	 * @see https://floating-ui.com/docs/size
 	 */
-	fitViewport?: boolean;
+	fitViewport?: boolean | undefined;
 
 	/**
 	 * The positioning strategy to use for the floating element.
 	 * @see https://floating-ui.com/docs/computeposition#strategy
 	 */
-	strategy?: "absolute" | "fixed";
+	strategy?: "absolute" | "fixed" | undefined;
 
 	/**
 	 * Whether the floating element can overlap the reference element.
@@ -96,7 +96,7 @@ export type FloatingProps = {
 	 *
 	 * @see https://floating-ui.com/docs/shift#options
 	 */
-	overlap?: boolean;
+	overlap?: boolean | undefined;
 };
 
 export type ContentProps<

--- a/packages/bits-ui/src/lib/bits/floating/floating-config.ts
+++ b/packages/bits-ui/src/lib/bits/floating/floating-config.ts
@@ -25,14 +25,14 @@ export type FloatingConfig = {
 	 *
 	 * @see https://floating-ui.com/docs/computePosition#placement
 	 */
-	strategy?: "absolute" | "fixed";
+	strategy?: "absolute" | "fixed" | undefined;
 
 	/**
 	 * The offset of the floating element.
 	 *
 	 * @see https://floating-ui.com/docs/offset#options
 	 */
-	offset?: { mainAxis?: number; crossAxis?: number };
+	offset?: { mainAxis?: number; crossAxis?: number } | undefined;
 
 	/**
 	 * The main axis offset or gap between the reference and floating elements.
@@ -40,7 +40,7 @@ export type FloatingConfig = {
 	 *
 	 * @see https://floating-ui.com/docs/offset#options
 	 */
-	gutter?: number;
+	gutter?: number | undefined;
 
 	/**
 	 * The virtual padding around the viewport edges to check for overflow.
@@ -48,7 +48,7 @@ export type FloatingConfig = {
 	 *
 	 * @see https://floating-ui.com/docs/detectOverflow#padding
 	 */
-	overflowPadding?: number;
+	overflowPadding?: number | undefined;
 
 	/**
 	 * Whether to flip the placement.
@@ -56,7 +56,7 @@ export type FloatingConfig = {
 	 *
 	 * @see https://floating-ui.com/docs/flip
 	 */
-	flip?: boolean;
+	flip?: boolean | undefined;
 
 	/**
 	 * Whether the floating element can overlap the reference element.
@@ -64,7 +64,7 @@ export type FloatingConfig = {
 	 *
 	 * @see https://floating-ui.com/docs/shift#options
 	 */
-	overlap?: boolean;
+	overlap?: boolean | undefined;
 
 	/**
 	 * Whether to make the floating element same width as the reference element.
@@ -72,7 +72,7 @@ export type FloatingConfig = {
 	 *
 	 * @see https://floating-ui.com/docs/size
 	 */
-	sameWidth?: boolean;
+	sameWidth?: boolean | undefined;
 
 	/**
 	 * Whether the floating element should fit the viewport.
@@ -80,14 +80,14 @@ export type FloatingConfig = {
 	 *
 	 * @see https://floating-ui.com/docs/size
 	 */
-	fitViewport?: boolean;
+	fitViewport?: boolean | undefined;
 
 	/**
 	 * The overflow boundary of the reference element.
 	 *
 	 * @see https://floating-ui.com/docs/detectoverflow#boundary
 	 */
-	boundary?: Boundary;
+	boundary?: Boundary | undefined;
 };
 
 type Boundary = "clippingAncestors" | Element | Array<Element> | Rect;

--- a/packages/bits-ui/src/lib/bits/link-preview/types.ts
+++ b/packages/bits-ui/src/lib/bits/link-preview/types.ts
@@ -22,12 +22,12 @@ export type LinkPreviewPropsWithoutHTML = Expand<
 		 *
 		 * @defaultValue false
 		 */
-		open?: boolean;
+		open?: boolean | undefined;
 
 		/**
 		 * A callback function called when the open state changes.
 		 */
-		onOpenChange?: OnChangeFn<boolean>;
+		onOpenChange?: OnChangeFn<boolean> | undefined;
 	}
 >;
 

--- a/packages/bits-ui/src/lib/bits/menu/types.ts
+++ b/packages/bits-ui/src/lib/bits/menu/types.ts
@@ -14,6 +14,7 @@ import type {
 import type {
 	DOMEl,
 	DOMElement,
+	Expand,
 	HTMLDivAttributes,
 	OmitChecked,
 	OmitFloating,

--- a/packages/bits-ui/src/lib/bits/menu/types.ts
+++ b/packages/bits-ui/src/lib/bits/menu/types.ts
@@ -35,12 +35,12 @@ export type MenuPropsWithoutHTML = Expand<
 		 *
 		 * @defaultValue false
 		 */
-		open?: boolean;
+		open?: boolean | undefined;
 
 		/**
 		 * A callback function called when the open state changes.
 		 */
-		onOpenChange?: OnChangeFn<boolean>;
+		onOpenChange?: OnChangeFn<boolean> | undefined;
 	}
 >;
 
@@ -51,7 +51,7 @@ export type MenuSubTriggerPropsWithoutHTML = Expand<
 		 *
 		 * @defaultValue false;
 		 */
-		disabled?: boolean;
+		disabled?: boolean | undefined;
 	} & DOMElement
 >;
 
@@ -63,12 +63,12 @@ export type MenuCheckboxItemPropsWithoutHTML = Expand<
 		 *
 		 * @defaultValue false
 		 */
-		checked?: boolean | "indeterminate";
+		checked?: boolean | "indeterminate" | undefined;
 
 		/**
 		 * A callback function called when the checked state changes.
 		 */
-		onCheckedChange?: OnChangeFn<boolean | "indeterminate">;
+		onCheckedChange?: OnChangeFn<boolean | "indeterminate"> | undefined;
 	} & DOMElement
 >;
 
@@ -79,12 +79,12 @@ export type MenuRadioGroupPropsWithoutHTML = Expand<
 		 *
 		 * @defaultValue undefined
 		 */
-		value?: MeltContextMenuRadioGroupProps["defaultValue"] & {};
+		value?: (MeltContextMenuRadioGroupProps["defaultValue"] & {}) | undefined;
 
 		/**
 		 * A callback function called when the value changes.
 		 */
-		onValueChange?: OnChangeFn<MeltContextMenuRadioGroupProps["defaultValue"]>;
+		onValueChange?: OnChangeFn<MeltContextMenuRadioGroupProps["defaultValue"]> | undefined;
 	} & DOMElement
 >;
 
@@ -98,12 +98,12 @@ export type MenuSubPropsWithoutHTML = Expand<
 		 *
 		 * @defaultValue false
 		 */
-		open?: boolean;
+		open?: boolean | undefined;
 
 		/**
 		 * A callback function called when the open state changes.
 		 */
-		onOpenChange?: OnChangeFn<boolean>;
+		onOpenChange?: OnChangeFn<boolean> | undefined;
 	}
 >;
 
@@ -114,7 +114,7 @@ export type MenuItemPropsWithoutHTML = Expand<
 		 *
 		 * @defaultValue false
 		 */
-		disabled?: boolean;
+		disabled?: boolean | undefined;
 	} & DOMElement
 >;
 
@@ -144,11 +144,11 @@ export type MenuRadioItemProps = MenuRadioItemPropsWithoutHTML & HTMLDivAttribut
 export type MenuGroupProps = MenuGroupPropsWithoutHTML & HTMLDivAttributes;
 
 type MenuAnchorElement = HTMLAnchorAttributes & {
-	href?: HTMLAnchorAttributes["href"];
+	href?: HTMLAnchorAttributes["href"] | undefined;
 } & DOMEl<HTMLAnchorElement>;
 
 type MenuDivElement = HTMLDivAttributes & {
-	href?: never;
+	href?: never | undefined;
 } & DOMEl;
 
 export type MenuItemProps = Omit<MenuItemPropsWithoutHTML, "el"> &

--- a/packages/bits-ui/src/lib/bits/pagination/types.ts
+++ b/packages/bits-ui/src/lib/bits/pagination/types.ts
@@ -13,12 +13,12 @@ export type PaginationPropsWithoutHTML = Expand<
 		 *
 		 * You can bind this to a value to programmatically control the value state.
 		 */
-		page?: number;
+		page?: number | undefined;
 
 		/**
 		 * A callback function called when the page changes.
 		 */
-		onPageChange?: OnChangeFn<number>;
+		onPageChange?: OnChangeFn<number> | undefined;
 	} & DOMElement
 >;
 

--- a/packages/bits-ui/src/lib/bits/pin-input/types.ts
+++ b/packages/bits-ui/src/lib/bits/pin-input/types.ts
@@ -18,12 +18,12 @@ export type PinInputPropsWithoutHTML = Expand<
 			 *
 			 * You can bind to this to programmatically control the value.
 			 */
-			value?: MeltPinInputProps["defaultValue"];
+			value?: MeltPinInputProps["defaultValue"] | undefined;
 
 			/**
 			 * A callback function called when the value changes.
 			 */
-			onValueChange?: OnChangeFn<MeltPinInputProps["defaultValue"]>;
+			onValueChange?: OnChangeFn<MeltPinInputProps["defaultValue"]> | undefined;
 		} & DOMElement
 	>
 >;

--- a/packages/bits-ui/src/lib/bits/popover/types.ts
+++ b/packages/bits-ui/src/lib/bits/popover/types.ts
@@ -26,12 +26,12 @@ export type PopoverPropsWithoutHTML = Expand<
 		 *
 		 * @defaultValue false
 		 */
-		open?: boolean;
+		open?: boolean | undefined;
 
 		/**
 		 * A callback function called when the open state changes.
 		 */
-		onOpenChange?: OnChangeFn<boolean>;
+		onOpenChange?: OnChangeFn<boolean> | undefined;
 	}
 >;
 

--- a/packages/bits-ui/src/lib/bits/progress/types.ts
+++ b/packages/bits-ui/src/lib/bits/progress/types.ts
@@ -13,12 +13,12 @@ export type ProgressPropsWithoutHTML = Expand<
 		 * The value of the progress bar.
 		 * You can bind this to a number value to programmatically control the value.
 		 */
-		value?: MeltProgressProps["defaultValue"];
+		value?: MeltProgressProps["defaultValue"] | undefined;
 
 		/**
 		 * A callback function called when the value changes.
 		 */
-		onValueChange?: OnChangeFn<number | null>;
+		onValueChange?: OnChangeFn<number | null> | undefined;
 	} & DOMElement
 >;
 //

--- a/packages/bits-ui/src/lib/bits/radio-group/types.ts
+++ b/packages/bits-ui/src/lib/bits/radio-group/types.ts
@@ -22,13 +22,13 @@ export type RadioGroupPropsWithoutHTML = Expand<
 		 * @defaultValue undefined
 		 */
 
-		value?: MeltRadioGroupProps["defaultValue"] & {};
+		value?: (MeltRadioGroupProps["defaultValue"] & {}) | undefined;
 
 		/**
 		 * A callback function called when the value changes.
 		 */
 
-		onValueChange?: OnChangeFn<MeltRadioGroupProps["defaultValue"] & {}>;
+		onValueChange?: OnChangeFn<MeltRadioGroupProps["defaultValue"] & {}> | undefined;
 	} & DOMElement
 >;
 

--- a/packages/bits-ui/src/lib/bits/range-calendar/types.ts
+++ b/packages/bits-ui/src/lib/bits/range-calendar/types.ts
@@ -30,12 +30,12 @@ export type RangeCalendarPropsWithoutHTML = Expand<
 		 * You can bind this to a value to programmatically control the
 		 * value state.
 		 */
-		value?: DateRange;
+		value?: DateRange | undefined;
 
 		/**
 		 * A callback function called when the value changes.
 		 */
-		onValueChange?: OnChangeFn<DateRange>;
+		onValueChange?: OnChangeFn<DateRange> | undefined;
 
 		/**
 		 * The placeholder date, used to display the calendar when no
@@ -45,12 +45,12 @@ export type RangeCalendarPropsWithoutHTML = Expand<
 		 * You can bind this to a value to programmatically control the
 		 * placeholder state.
 		 */
-		placeholder?: DateValue;
+		placeholder?: DateValue | undefined;
 
 		/**
 		 * A callback function called when the placeholder changes.
 		 */
-		onPlaceholderChange?: OnChangeFn<DateValue>;
+		onPlaceholderChange?: OnChangeFn<DateValue> | undefined;
 
 		/**
 		 * If `true`, the calendar will focus the selected day,
@@ -59,7 +59,7 @@ export type RangeCalendarPropsWithoutHTML = Expand<
 		 *
 		 * @default false
 		 */
-		initialFocus?: boolean;
+		initialFocus?: boolean | undefined;
 
 		/**
 		 * The `start` value of the date range, which can exist prior

--- a/packages/bits-ui/src/lib/bits/range-calendar/types.ts
+++ b/packages/bits-ui/src/lib/bits/range-calendar/types.ts
@@ -7,7 +7,7 @@ import type {
 } from "svelte/elements";
 import type { DateValue } from "@internationalized/date";
 import type { CreateRangeCalendarProps as MeltRangeCalendarProps } from "@melt-ui/svelte";
-import type { DOMElement, HTMLDivAttributes, OnChangeFn } from "$lib/internal/index.js";
+import type { DOMElement, Expand, HTMLDivAttributes, OnChangeFn } from "$lib/internal/index.js";
 import type { CustomEventHandler } from "$lib/index.js";
 
 import type { DateRange } from "$lib/shared/index.js";

--- a/packages/bits-ui/src/lib/bits/select/ctx.ts
+++ b/packages/bits-ui/src/lib/bits/select/ctx.ts
@@ -45,11 +45,11 @@ export function getCtx() {
 
 type Items<T> = {
 	value: T;
-	label?: string;
+	label?: string | undefined;
 };
 
 type Props<T = unknown, M extends boolean = false> = CreateSelectProps<T, M> & {
-	items?: Items<T>[];
+	items?: Items<T>[] | undefined;
 };
 
 export function setCtx<T = unknown, M extends boolean = false>(props: Props<T, M>) {

--- a/packages/bits-ui/src/lib/bits/select/types.ts
+++ b/packages/bits-ui/src/lib/bits/select/types.ts
@@ -49,7 +49,7 @@ export type SelectPropsWithoutHTML<T = unknown, Multiple extends boolean = false
 		/**
 		 * A callback function called when the selected value changes.
 		 */
-		onSelectedChange?: OnChangeFn<SelectValue<Selected<T>, Multiple>>;
+		onSelectedChange?: OnChangeFn<SelectValue<Selected<T>, Multiple>> | undefined;
 
 		/**
 		 * The open state of the select menu.
@@ -57,23 +57,23 @@ export type SelectPropsWithoutHTML<T = unknown, Multiple extends boolean = false
 		 *
 		 * @defaultValue false
 		 */
-		open?: boolean;
+		open?: boolean | undefined;
 
 		/**
 		 * A callback function called when the open state changes.
 		 */
-		onOpenChange?: OnChangeFn<boolean>;
+		onOpenChange?: OnChangeFn<boolean> | undefined;
 
 		/**
 		 * Whether or not multiple values can be selected.
 		 */
-		multiple?: Multiple;
+		multiple?: Multiple | undefined;
 
 		/**
 		 * Optionally provide an array of `Selected<T>` objects to
 		 * type the `selected` and `onSelectedChange` props.
 		 */
-		items?: Selected<T>[];
+		items?: Selected<T>[] | undefined;
 	}
 >;
 
@@ -94,7 +94,7 @@ export type SelectValuePropsWithoutHTML = Expand<
 		 *
 		 * @defaultValue ""
 		 */
-		placeholder?: string;
+		placeholder?: string | undefined;
 	} & DOMElement<HTMLSpanElement>
 >;
 

--- a/packages/bits-ui/src/lib/bits/slider/types.ts
+++ b/packages/bits-ui/src/lib/bits/slider/types.ts
@@ -17,12 +17,12 @@ export type SliderPropsWithoutHTML = Expand<
 		 * The value of the slider.
 		 * You can bind this to a number value to programmatically control the value.
 		 */
-		value?: number[];
+		value?: number[] | undefined;
 
 		/**
 		 * A callback function called when the value changes.
 		 */
-		onValueChange?: OnChangeFn<number[]>;
+		onValueChange?: OnChangeFn<number[]> | undefined;
 	} & DOMElement<HTMLSpanElement>
 >;
 

--- a/packages/bits-ui/src/lib/bits/switch/types.ts
+++ b/packages/bits-ui/src/lib/bits/switch/types.ts
@@ -18,24 +18,26 @@ export type SwitchPropsWithoutHTML = Expand<
 		 *
 		 * @defaultValue false
 		 */
-		checked?: boolean;
+		checked?: boolean | undefined;
 
 		/**
 		 * A callback function called when the checked state changes.
 		 */
-		onCheckedChange?: OnChangeFn<boolean>;
+		onCheckedChange?: OnChangeFn<boolean> | undefined;
 
 		/**
 		 * Whether to include the hidden input element in the DOM.
 		 */
-		includeInput?: boolean;
+		includeInput?: boolean | undefined;
 
 		/**
 		 * Additional input attributes to pass to the hidden input element.
 		 * Note, the value, name, type, and checked attributes are derived from the
 		 * Switch props and cannot be overridden.
 		 */
-		inputAttrs?: Partial<Omit<HTMLInputAttributes, "value" | "name" | "type" | "checked">>;
+		inputAttrs?:
+			| Partial<Omit<HTMLInputAttributes, "value" | "name" | "type" | "checked">>
+			| undefined;
 	} & DOMElement<HTMLButtonElement>
 >;
 

--- a/packages/bits-ui/src/lib/bits/tabs/types.ts
+++ b/packages/bits-ui/src/lib/bits/tabs/types.ts
@@ -19,19 +19,19 @@ export type TabsPropsWithoutHTML = Expand<
 		 * The value of the currently active tab.
 		 * You can bind this to a string value to programmatically control the active tab.
 		 */
-		value?: MeltTabsProps["defaultValue"] & {};
+		value?: (MeltTabsProps["defaultValue"] & {}) | undefined;
 
 		/**
 		 * A callback function called when the value changes.
 		 */
-		onValueChange?: OnChangeFn<MeltTabsProps["defaultValue"]>;
+		onValueChange?: OnChangeFn<MeltTabsProps["defaultValue"]> | undefined;
 
 		/**
 		 * The orientation of the tabs, which determines how keyboard navigation works.
 		 *
 		 * @defaultValue "horizontal"
 		 */
-		orientation?: MeltTabsProps["orientation"] & {};
+		orientation?: (MeltTabsProps["orientation"] & {}) | undefined;
 	} & DOMElement
 >;
 

--- a/packages/bits-ui/src/lib/bits/toggle-group/types.ts
+++ b/packages/bits-ui/src/lib/bits/toggle-group/types.ts
@@ -17,12 +17,12 @@ export type ToggleGroupPropsWithoutHTML<T extends "single" | "multiple"> = Expan
 		 *
 		 * You can bind to this to programmatically control the value.
 		 */
-		value?: MeltToggleGroupProps<T>["defaultValue"];
+		value?: MeltToggleGroupProps<T>["defaultValue"] | undefined;
 
 		/**
 		 * A callback function called when the value changes.
 		 */
-		onValueChange?: OnChangeFn<MeltToggleGroupProps<T>["defaultValue"]>;
+		onValueChange?: OnChangeFn<MeltToggleGroupProps<T>["defaultValue"]> | undefined;
 
 		/**
 		 * The type of the toggle group.
@@ -31,7 +31,7 @@ export type ToggleGroupPropsWithoutHTML<T extends "single" | "multiple"> = Expan
 		 * at a time. If the type is `"multiple"`, the toggle group allows multiple items
 		 * to be selected at a time.
 		 */
-		type?: T;
+		type?: T | undefined;
 	} & DOMElement
 >;
 
@@ -51,7 +51,7 @@ export type ToggleGroupItemPropsWithoutHTML = Expand<
 		 *
 		 * @defaultValue false
 		 */
-		disabled?: boolean;
+		disabled?: boolean | undefined;
 	} & DOMElement<HTMLButtonElement>
 >;
 

--- a/packages/bits-ui/src/lib/bits/toggle/types.ts
+++ b/packages/bits-ui/src/lib/bits/toggle/types.ts
@@ -11,12 +11,12 @@ export type TogglePropsWithoutHTML = Expand<
 		 *
 		 * @defaultValue false
 		 */
-		pressed?: boolean;
+		pressed?: boolean | undefined;
 
 		/**
 		 * A callback function called when the pressed state changes.
 		 */
-		onPressedChange?: OnChangeFn<boolean>;
+		onPressedChange?: OnChangeFn<boolean> | undefined;
 	} & DOMElement<HTMLButtonElement>
 >;
 

--- a/packages/bits-ui/src/lib/bits/toolbar/types.ts
+++ b/packages/bits-ui/src/lib/bits/toolbar/types.ts
@@ -26,12 +26,12 @@ export type ToolbarGroupPropsWithoutHTML<T extends "single" | "multiple"> = Expa
 		 *
 		 * You can bind to this to programmatically control the value.
 		 */
-		value?: MeltToolbarGroupProps<T>["defaultValue"];
+		value?: MeltToolbarGroupProps<T>["defaultValue"] | undefined;
 
 		/**
 		 * A callback function called when the value changes.
 		 */
-		onValueChange?: OnChangeFn<MeltToolbarGroupProps<T>["defaultValue"]>;
+		onValueChange?: OnChangeFn<MeltToolbarGroupProps<T>["defaultValue"]> | undefined;
 
 		/**
 		 * The type of the toolbar toggle group.
@@ -40,7 +40,7 @@ export type ToolbarGroupPropsWithoutHTML<T extends "single" | "multiple"> = Expa
 		 * at a time. If the type is `"multiple"`, the toolbar toggle group allows multiple items
 		 * to be selected at a time.
 		 */
-		type?: T;
+		type?: T | undefined;
 	} & DOMElement
 >;
 
@@ -60,7 +60,7 @@ export type ToolbarGroupItemPropsWithoutHTML = Expand<
 		 *
 		 * @defaultValue false
 		 */
-		disabled?: boolean;
+		disabled?: boolean | undefined;
 	} & DOMElement<HTMLButtonElement>
 >;
 

--- a/packages/bits-ui/src/lib/bits/tooltip/types.ts
+++ b/packages/bits-ui/src/lib/bits/tooltip/types.ts
@@ -38,12 +38,12 @@ export type TooltipPropsWithoutHTML = Expand<OmitFloating<MeltTooltipProps>> & {
 	 * </Tooltip.Root>
 	 * ```
 	 */
-	open?: boolean & {};
+	open?: (boolean & {}) | undefined;
 
 	/**
 	 * A callback function called when the open state changes.
 	 */
-	onOpenChange?: OnChangeFn<boolean>;
+	onOpenChange?: OnChangeFn<boolean> | undefined;
 };
 
 export type TooltipTriggerPropsWithoutHTML = DOMElement<HTMLButtonElement>;

--- a/packages/bits-ui/src/lib/internal/types.ts
+++ b/packages/bits-ui/src/lib/internal/types.ts
@@ -54,7 +54,7 @@ export type DOMEl<T extends Element = HTMLDivElement> = Expand<{
 	/**
 	 * Wheter to expose the underlying DOM element.
 	 */
-	el?: T;
+	el?: T | undefined;
 }>;
 
 export type DOMElement<T extends Element = HTMLDivElement> = Expand<{
@@ -64,12 +64,12 @@ export type DOMElement<T extends Element = HTMLDivElement> = Expand<{
 	 *
 	 * @see https://www.bits-ui.com/docs/delegation
 	 */
-	asChild?: boolean;
+	asChild?: boolean | undefined;
 
 	/**
 	 * Bind to the underlying DOM element of the component.
 	 */
-	el?: T;
+	el?: T | undefined;
 }>;
 
 export type TransitionProps<
@@ -80,34 +80,34 @@ export type TransitionProps<
 	/**
 	 * A transition function to use during both the in and out transitions.
 	 */
-	transition?: T;
+	transition?: T | undefined;
 
 	/**
 	 * The configuration to pass to the `transition` function.
 	 */
-	transitionConfig?: TransitionParams<T>;
+	transitionConfig?: TransitionParams<T> | undefined;
 
 	/**
 	 * A transition function to use during the in transition.
 	 *
 	 * If provided, this will override the `transition` function.
 	 */
-	inTransition?: In;
+	inTransition?: In | undefined;
 
 	/**
 	 * The configuration to pass to the `inTransition` function.
 	 */
-	inTransitionConfig?: TransitionParams<In>;
+	inTransitionConfig?: TransitionParams<In> | undefined;
 
 	/**
 	 * A transition function to use during the out transition.
 	 *
 	 * If provided, this will override the `transition` function.
 	 */
-	outTransition?: Out;
+	outTransition?: Out | undefined;
 
 	/**
 	 * The configuration to pass to the `outTransition` function.
 	 */
-	outTransitionConfig?: TransitionParams<Out>;
+	outTransitionConfig?: TransitionParams<Out> | undefined;
 }>;

--- a/sites/docs/tsconfig.json
+++ b/sites/docs/tsconfig.json
@@ -11,7 +11,8 @@
 		"strict": true,
 		"moduleResolution": "NodeNext",
 		"module": "NodeNext",
-		"verbatimModuleSyntax": true
+		"verbatimModuleSyntax": true,
+		"exactOptionalPropertyTypes": true
 	},
 	"include": [
 		"./svelte-kit/ambient.d.ts",


### PR DESCRIPTION
With [`exactOptionalPropertyTypes`](https://www.typescriptlang.org/tsconfig/#exactOptionalPropertyTypes) enabled, optional properties cannot be `undefined` unless explicitly allowed. This commit explicitly allowes optional properties to be `undefined`.

Fixes #516.
Supersedes #517.