### PR TITLE
fix: call `onPageChange` after setting the `page`

### DIFF
--- a/.changeset/plenty-pears-add.md
+++ b/.changeset/plenty-pears-add.md
@@ -1,0 +1,5 @@
+---
+"bits-ui": patch
+---
+
+fix(Pagination): call `onPageChange` _after_ setting the `page`

--- a/packages/bits-ui/src/lib/bits/pagination/components/pagination.svelte
+++ b/packages/bits-ui/src/lib/bits/pagination/components/pagination.svelte
@@ -25,8 +25,8 @@
 		defaultPage: page,
 		onPageChange: ({ next }) => {
 			if (page !== next) {
-				onPageChange?.(next);
 				page = next;
+				onPageChange?.(next);
 			}
 
 			return next;


### PR DESCRIPTION
Typically onPageChange calls a function and the state of the function is incorrect for the new page because the bound variable `page` is still old.