### PR TITLE
Update Svelte 5 and correct breaking changes.

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
 		"prettier": "^3.2.5",
 		"prettier-plugin-svelte": "^3.2.2",
 		"prettier-plugin-tailwindcss": "0.5.13",
-		"svelte": "5.0.0-next.208",
+		"svelte": "5.0.0-next.245",
 		"svelte-eslint-parser": "^0.41.0",
 		"wrangler": "^3.44.0"
 	},

--- a/packages/bits-ui/package.json
+++ b/packages/bits-ui/package.json
@@ -44,7 +44,7 @@
 		"jsdom": "^24.1.0",
 		"publint": "^0.2.8",
 		"resize-observer-polyfill": "^1.5.1",
-		"svelte": "5.0.0-next.208",
+		"svelte": "5.0.0-next.245",
 		"svelte-check": "^3.8.4",
 		"tslib": "^2.6.3",
 		"typescript": "^5.5.3",

--- a/packages/bits-ui/src/lib/bits/date-range-picker/components/date-range-picker.svelte
+++ b/packages/bits-ui/src/lib/bits/date-range-picker/components/date-range-picker.svelte
@@ -83,7 +83,7 @@
 		value: box.with(
 			() => value as DateRange,
 			(v) => {
-				if (!$state.is(value, v)) {
+				if (value !== v) {
 					value = v;
 					onValueChange(v);
 				}

--- a/packages/bits-ui/src/lib/bits/range-calendar/components/range-calendar.svelte
+++ b/packages/bits-ui/src/lib/bits/range-calendar/components/range-calendar.svelte
@@ -58,7 +58,7 @@
 		value: box.with(
 			() => (value === undefined ? { start: undefined, end: undefined } : value),
 			(v) => {
-				if (!$state.is(v, value)) {
+				if (value !== v) {
 					value = v;
 					onValueChange(v as any);
 				}

--- a/packages/bits-ui/src/lib/bits/scroll-area/scroll-area.svelte.ts
+++ b/packages/bits-ui/src/lib/bits/scroll-area/scroll-area.svelte.ts
@@ -374,7 +374,7 @@ class ScrollAreaScrollbarVisibleState {
 	root: ScrollAreaRootState;
 	thumbNode = $state<HTMLElement | null>(null);
 	pointerOffset = $state(0);
-	sizes = $state.frozen<Sizes>({
+	sizes = $state.raw<Sizes>({
 		content: 0,
 		viewport: 0,
 		scrollbar: { size: 0, paddingStart: 0, paddingEnd: 0 },
@@ -696,7 +696,7 @@ class ScrollAreaScrollbarSharedState {
 	scrollbarState: ScrollbarAxis;
 	root: ScrollAreaRootState;
 	scrollbarVis: ScrollAreaScrollbarVisibleState;
-	rect = $state.frozen<DOMRect | null>(null);
+	rect = $state.raw<DOMRect | null>(null);
 	prevWebkitUserSelect = $state<string>("");
 	handleResize: () => void;
 	handleThumbPositionChange: () => void;

--- a/packages/bits-ui/src/lib/bits/select/components/select-native.svelte
+++ b/packages/bits-ui/src/lib/bits/select/components/select-native.svelte
@@ -5,7 +5,6 @@
 	import { mergeProps } from "$lib/internal/mergeProps.js";
 
 	type Props = {
-		autocomplete?: string;
 		autofocus?: boolean;
 		disabled?: boolean;
 		form?: string;

--- a/packages/bits-ui/src/lib/bits/select/types.ts
+++ b/packages/bits-ui/src/lib/bits/select/types.ts
@@ -1,3 +1,4 @@
+import type { HTMLSelectAttributes } from "svelte/elements";
 import type { PopperLayerProps } from "../utilities/popper-layer/types.js";
 import type { ArrowProps, ArrowPropsWithoutHTML } from "../utilities/arrow/types.js";
 import type { OnChangeFn, WithChild, WithChildren, Without } from "$lib/internal/types.js";
@@ -43,7 +44,7 @@ export type SelectRootPropsWithoutHTML = WithChildren<{
 	/**
 	 * The native HTML select autocomplete attribute.
 	 */
-	autocomplete?: string;
+	autocomplete?: HTMLSelectAttributes["autocomplete"];
 
 	/**
 	 * The native HTML select `form` attribute.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,7 +13,7 @@ importers:
         version: 2.27.7
       '@huntabyte/eslint-config':
         specifier: ^0.3.2
-        version: 0.3.2(@vue/compiler-sfc@3.4.34)(eslint-plugin-svelte@2.43.0(eslint@9.8.0)(svelte@5.0.0-next.208))(eslint@9.8.0)(svelte-eslint-parser@0.41.0(svelte@5.0.0-next.208))(svelte@5.0.0-next.208)(typescript@5.5.4)(vitest@2.0.4)
+        version: 0.3.2(@vue/compiler-sfc@3.4.34)(eslint-plugin-svelte@2.43.0(eslint@9.8.0)(svelte@5.0.0-next.245))(eslint@9.8.0)(svelte-eslint-parser@0.41.0(svelte@5.0.0-next.245))(svelte@5.0.0-next.245)(typescript@5.5.4)(vitest@2.0.4(@types/node@20.14.13)(jsdom@24.1.1))
       '@huntabyte/eslint-plugin':
         specifier: ^0.1.0
         version: 0.1.0(eslint@9.8.0)
@@ -25,22 +25,22 @@ importers:
         version: 9.8.0
       eslint-plugin-svelte:
         specifier: ^2.37.0
-        version: 2.43.0(eslint@9.8.0)(svelte@5.0.0-next.208)
+        version: 2.43.0(eslint@9.8.0)(svelte@5.0.0-next.245)
       prettier:
         specifier: ^3.2.5
         version: 3.3.3
       prettier-plugin-svelte:
         specifier: ^3.2.2
-        version: 3.2.6(prettier@3.3.3)(svelte@5.0.0-next.208)
+        version: 3.2.6(prettier@3.3.3)(svelte@5.0.0-next.245)
       prettier-plugin-tailwindcss:
         specifier: 0.5.13
-        version: 0.5.13(prettier-plugin-svelte@3.2.6(prettier@3.3.3)(svelte@5.0.0-next.208))(prettier@3.3.3)
+        version: 0.5.13(prettier-plugin-svelte@3.2.6(prettier@3.3.3)(svelte@5.0.0-next.245))(prettier@3.3.3)
       svelte:
-        specifier: 5.0.0-next.208
-        version: 5.0.0-next.208
+        specifier: 5.0.0-next.245
+        version: 5.0.0-next.245
       svelte-eslint-parser:
         specifier: ^0.41.0
-        version: 0.41.0(svelte@5.0.0-next.208)
+        version: 0.41.0(svelte@5.0.0-next.245)
       wrangler:
         specifier: ^3.44.0
         version: 3.67.1(@cloudflare/workers-types@4.20240725.0)
@@ -64,7 +64,7 @@ importers:
         version: 1.0.0
       runed:
         specifier: ^0.15.0
-        version: 0.15.0(svelte@5.0.0-next.208)
+        version: 0.15.0(svelte@5.0.0-next.245)
       scule:
         specifier: ^1.3.0
         version: 1.3.0
@@ -76,17 +76,17 @@ importers:
         version: 1.0.6
       svelte-toolbelt:
         specifier: ^0.1.0
-        version: 0.1.0(svelte@5.0.0-next.208)
+        version: 0.1.0(svelte@5.0.0-next.245)
     devDependencies:
       '@sveltejs/kit':
         specifier: ^2.5.18
-        version: 2.5.18(@sveltejs/vite-plugin-svelte@3.1.1(svelte@5.0.0-next.208)(vite@5.3.5(@types/node@20.14.13)))(svelte@5.0.0-next.208)(vite@5.3.5(@types/node@20.14.13))
+        version: 2.5.18(@sveltejs/vite-plugin-svelte@3.1.1(svelte@5.0.0-next.245)(vite@5.3.5(@types/node@20.14.13)))(svelte@5.0.0-next.245)(vite@5.3.5(@types/node@20.14.13))
       '@sveltejs/package':
         specifier: ^2.3.2
-        version: 2.3.2(svelte@5.0.0-next.208)(typescript@5.5.4)
+        version: 2.3.2(svelte@5.0.0-next.245)(typescript@5.5.4)
       '@sveltejs/vite-plugin-svelte':
         specifier: ^3.1.1
-        version: 3.1.1(svelte@5.0.0-next.208)(vite@5.3.5(@types/node@20.14.13))
+        version: 3.1.1(svelte@5.0.0-next.245)(vite@5.3.5(@types/node@20.14.13))
       '@testing-library/dom':
         specifier: ^10.3.1
         version: 10.4.0
@@ -95,7 +95,7 @@ importers:
         version: 6.4.8
       '@testing-library/svelte':
         specifier: ^5.2.1
-        version: 5.2.1(svelte@5.0.0-next.208)(vite@5.3.5(@types/node@20.14.13))(vitest@2.0.4(@types/node@20.14.13)(@vitest/ui@1.6.0)(jsdom@24.1.1))
+        version: 5.2.1(svelte@5.0.0-next.245)(vite@5.3.5(@types/node@20.14.13))(vitest@2.0.4(@types/node@20.14.13)(@vitest/ui@1.6.0)(jsdom@24.1.1))
       '@testing-library/user-event':
         specifier: ^14.5.2
         version: 14.5.2(@testing-library/dom@10.4.0)
@@ -130,11 +130,11 @@ importers:
         specifier: ^1.5.1
         version: 1.5.1
       svelte:
-        specifier: 5.0.0-next.208
-        version: 5.0.0-next.208
+        specifier: 5.0.0-next.245
+        version: 5.0.0-next.245
       svelte-check:
         specifier: ^3.8.4
-        version: 3.8.4(postcss-load-config@5.1.0(jiti@1.21.6)(postcss@8.4.40))(postcss@8.4.40)(svelte@5.0.0-next.208)
+        version: 3.8.4(postcss-load-config@5.1.0(jiti@1.21.6)(postcss@8.4.45))(postcss@8.4.45)(svelte@5.0.0-next.245)
       tslib:
         specifier: ^2.6.3
         version: 2.6.3
@@ -155,26 +155,26 @@ importers:
         version: 3.5.5
       '@melt-ui/svelte':
         specifier: 0.76.2
-        version: 0.76.2(svelte@5.0.0-next.208)
+        version: 0.76.2(svelte@5.0.0-next.245)
       bits-ui:
         specifier: workspace:*
         version: link:../../packages/bits-ui
     devDependencies:
       '@melt-ui/pp':
         specifier: ^0.3.0
-        version: 0.3.2(@melt-ui/svelte@0.76.2(svelte@5.0.0-next.208))(svelte@5.0.0-next.208)
+        version: 0.3.2(@melt-ui/svelte@0.76.2(svelte@5.0.0-next.245))(svelte@5.0.0-next.245)
       '@prettier/sync':
         specifier: 0.3.0
         version: 0.3.0(prettier@3.3.3)
       '@sveltejs/adapter-cloudflare':
         specifier: ^4.2.0
-        version: 4.7.0(@sveltejs/kit@2.5.18(@sveltejs/vite-plugin-svelte@3.1.1(svelte@5.0.0-next.208)(vite@5.3.5(@types/node@20.14.13)))(svelte@5.0.0-next.208)(vite@5.3.5(@types/node@20.14.13)))(wrangler@3.67.1(@cloudflare/workers-types@4.20240725.0))
+        version: 4.7.0(@sveltejs/kit@2.5.18(@sveltejs/vite-plugin-svelte@3.1.1(svelte@5.0.0-next.245)(vite@5.3.5(@types/node@20.14.13)))(svelte@5.0.0-next.245)(vite@5.3.5(@types/node@20.14.13)))(wrangler@3.67.1(@cloudflare/workers-types@4.20240725.0))
       '@sveltejs/kit':
         specifier: ^2.5.0
-        version: 2.5.18(@sveltejs/vite-plugin-svelte@3.1.1(svelte@5.0.0-next.208)(vite@5.3.5(@types/node@20.14.13)))(svelte@5.0.0-next.208)(vite@5.3.5(@types/node@20.14.13))
+        version: 2.5.18(@sveltejs/vite-plugin-svelte@3.1.1(svelte@5.0.0-next.245)(vite@5.3.5(@types/node@20.14.13)))(svelte@5.0.0-next.245)(vite@5.3.5(@types/node@20.14.13))
       '@sveltejs/vite-plugin-svelte':
         specifier: ^3.1.0
-        version: 3.1.1(svelte@5.0.0-next.208)(vite@5.3.5(@types/node@20.14.13))
+        version: 3.1.1(svelte@5.0.0-next.245)(vite@5.3.5(@types/node@20.14.13))
       '@tailwindcss/typography':
         specifier: ^0.5.10
         version: 0.5.13(tailwindcss@3.4.7)
@@ -207,13 +207,13 @@ importers:
         version: 3.2.1
       mdsx:
         specifier: ^0.0.6
-        version: 0.0.6(svelte@5.0.0-next.208)
+        version: 0.0.6(svelte@5.0.0-next.245)
       mode-watcher:
         specifier: ^0.2.0
-        version: 0.2.2(svelte@5.0.0-next.208)
+        version: 0.2.2(svelte@5.0.0-next.245)
       phosphor-svelte:
         specifier: ^2.0.1
-        version: 2.0.1(svelte@5.0.0-next.208)
+        version: 2.0.1(svelte@5.0.0-next.245)
       postcss:
         specifier: ^8.4.33
         version: 8.4.40
@@ -233,14 +233,14 @@ importers:
         specifier: ^1.1.1
         version: 1.12.0
       svelte:
-        specifier: 5.0.0-next.208
-        version: 5.0.0-next.208
+        specifier: 5.0.0-next.245
+        version: 5.0.0-next.245
       svelte-check:
         specifier: ^3.6.9
-        version: 3.8.4(postcss-load-config@5.1.0(jiti@1.21.6)(postcss@8.4.40))(postcss@8.4.40)(svelte@5.0.0-next.208)
+        version: 3.8.4(postcss-load-config@5.1.0(jiti@1.21.6)(postcss@8.4.40))(postcss@8.4.40)(svelte@5.0.0-next.245)
       svelte-sonner:
         specifier: ^0.3.24
-        version: 0.3.27(svelte@5.0.0-next.208)
+        version: 0.3.27(svelte@5.0.0-next.245)
       tailwind-merge:
         specifier: ^2.2.1
         version: 2.4.0
@@ -353,8 +353,8 @@ packages:
     resolution: {integrity: sha512-EStJpq4OuY8xYfhGVXngigBJRWxftKX9ksiGDnmlY3o7B/V7KIAc9X4oiK87uPJSc/vs5L869bem5fhZa8caZw==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/parser@7.25.0':
-    resolution: {integrity: sha512-CzdIU9jdP0dg7HdyB+bHvDJGagUv+qtzZt5rYCWwW6tITNqV9odjp6Qu41gkG0ca5UfdDUWrKkiAnHHdGRnOrA==}
+  '@babel/parser@7.25.6':
+    resolution: {integrity: sha512-trGdfBdbD0l1ZPmcJ83eNxB9rbEax4ALFTF7fN386TMYbeCQbyme5cOEXQhbGXKebwGaB/J52w1mrklMcbgy6Q==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -362,8 +362,8 @@ packages:
     resolution: {integrity: sha512-7dRy4DwXwtzBrPbZflqxnvfxLF8kdZXPkhymtDeFoFqE6ldzjQFgYTtYIFARcLEYDrqfBfYcZt1WqFxRoyC9Rw==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/types@7.25.0':
-    resolution: {integrity: sha512-LcnxQSsd9aXOIgmmSpvZ/1yo46ra2ESYyqLcryaBZOghxy5qqOBjvCWP5JfkI8yl9rlxRgdLTTMCQQRcN2hdCg==}
+  '@babel/types@7.25.6':
+    resolution: {integrity: sha512-/l42B1qxpG6RdfYf343Uw1vmDjeNhneUXtzhojE7pDgfpEypmRhI6j1kr17XCVv4Cgl9HdAiQY2x0GwKm7rWCw==}
     engines: {node: '>=6.9.0'}
 
   '@changesets/apply-release-plan@7.0.4':
@@ -1850,6 +1850,10 @@ packages:
 
   aria-query@5.3.0:
     resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
+
+  aria-query@5.3.1:
+    resolution: {integrity: sha512-Z/ZeOgVl7bcSYZ/u/rh0fOpvEpq//LZmdbkXyc7syVzjPAhfOa9ebsdTSjEBDU4vs5nC98Kfduj1uFo0qyET3g==}
+    engines: {node: '>= 0.4'}
 
   array-timsort@1.0.3:
     resolution: {integrity: sha512-/+3GRL7dDAGEfM6TseQk/U+mi18TU2Ms9I3UlLdUMhz2hbvGNTKdj9xniwXfUqgYhHxRx0+8UnKkvlNwVU+cWQ==}
@@ -3793,6 +3797,9 @@ packages:
   picocolors@1.0.1:
     resolution: {integrity: sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew==}
 
+  picocolors@1.1.0:
+    resolution: {integrity: sha512-TQ92mBOW0l3LeMeyLV6mzy/kWr8lkd/hp3mTg7wYK7zJhuBStmGMBG0BdeDZS/dZx1IukaX6Bk11zcln25o1Aw==}
+
   picomatch@2.3.1:
     resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
     engines: {node: '>=8.6'}
@@ -3906,6 +3913,10 @@ packages:
 
   postcss@8.4.40:
     resolution: {integrity: sha512-YF2kKIUzAofPMpfH6hOi2cGnv/HrUlfucspc7pDyvv7kGdqXrfj8SCl/t8owkEgKEuu8ZcRjSOxFxVLqwChZ2Q==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  postcss@8.4.45:
+    resolution: {integrity: sha512-7KTLTdzdZZYscUc65XmjFiB73vBhBfbPztCYdUNvlaso9PrzjzcmjqBPR0lNGkcVlcO4BjiO5rK/qNz+XAen1Q==}
     engines: {node: ^10 || ^12 || >=14}
 
   preferred-pm@3.1.4:
@@ -4290,6 +4301,10 @@ packages:
     resolution: {integrity: sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg==}
     engines: {node: '>=0.10.0'}
 
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
   source-map-support@0.5.21:
     resolution: {integrity: sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==}
 
@@ -4500,8 +4515,8 @@ packages:
       svelte: ^3.55 || ^4.0.0-next.0 || ^4.0 || ^5.0.0-next.0
       typescript: ^4.9.4 || ^5.0.0
 
-  svelte@5.0.0-next.208:
-    resolution: {integrity: sha512-gYABb68367fGnY/GIpb/j3DD5DUqhVWi6EodEBVpiRA9wLQTpY8QmuPg04xut/0EHqlFU3a40wbpjJKmpL3Y/g==}
+  svelte@5.0.0-next.245:
+    resolution: {integrity: sha512-tQ0liBr/b8krDKnlWjh2XBtqTeUdTHR+i759gviRqUNsT/h39VnLsm7jQf8cika9YY/CS1zg6KtIh+m6nEHU6Q==}
     engines: {node: '>=18'}
 
   symbol-tree@3.2.4:
@@ -5022,12 +5037,12 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.5
       '@jridgewell/trace-mapping': 0.3.25
 
-  '@antfu/eslint-config@2.24.0(@vue/compiler-sfc@3.4.34)(eslint-plugin-svelte@2.43.0(eslint@9.8.0)(svelte@5.0.0-next.208))(eslint@9.8.0)(svelte-eslint-parser@0.41.0(svelte@5.0.0-next.208))(svelte@5.0.0-next.208)(typescript@5.5.4)(vitest@2.0.4)':
+  '@antfu/eslint-config@2.24.0(@vue/compiler-sfc@3.4.34)(eslint-plugin-svelte@2.43.0(eslint@9.8.0)(svelte@5.0.0-next.245))(eslint@9.8.0)(svelte-eslint-parser@0.41.0(svelte@5.0.0-next.245))(svelte@5.0.0-next.245)(typescript@5.5.4)(vitest@2.0.4(@types/node@20.14.13)(jsdom@24.1.1))':
     dependencies:
       '@antfu/install-pkg': 0.3.3
       '@clack/prompts': 0.7.0
       '@stylistic/eslint-plugin': 2.6.0-beta.1(eslint@9.8.0)(typescript@5.5.4)
-      '@typescript-eslint/eslint-plugin': 8.0.0-alpha.40(@typescript-eslint/parser@8.0.0-alpha.40(eslint@9.8.0)(typescript@5.5.4))(eslint@9.8.0)(typescript@5.5.4)
+      '@typescript-eslint/eslint-plugin': 8.0.0-alpha.40(@typescript-eslint/parser@7.18.0(eslint@9.8.0)(typescript@5.5.4))(eslint@9.8.0)(typescript@5.5.4)
       '@typescript-eslint/parser': 8.0.0-alpha.40(eslint@9.8.0)(typescript@5.5.4)
       eslint: 9.8.0
       eslint-config-flat-gitignore: 0.1.8
@@ -5042,12 +5057,12 @@ snapshots:
       eslint-plugin-markdown: 5.1.0(eslint@9.8.0)
       eslint-plugin-n: 17.10.1(eslint@9.8.0)
       eslint-plugin-no-only-tests: 3.1.0
-      eslint-plugin-perfectionist: 3.0.0(eslint@9.8.0)(svelte-eslint-parser@0.41.0(svelte@5.0.0-next.208))(svelte@5.0.0-next.208)(typescript@5.5.4)(vue-eslint-parser@9.4.3(eslint@9.8.0))
+      eslint-plugin-perfectionist: 3.0.0(eslint@9.8.0)(svelte-eslint-parser@0.41.0(svelte@5.0.0-next.245))(svelte@5.0.0-next.245)(typescript@5.5.4)(vue-eslint-parser@9.4.3(eslint@9.8.0))
       eslint-plugin-regexp: 2.6.0(eslint@9.8.0)
       eslint-plugin-toml: 0.11.1(eslint@9.8.0)
       eslint-plugin-unicorn: 55.0.0(eslint@9.8.0)
       eslint-plugin-unused-imports: 4.0.1(@typescript-eslint/eslint-plugin@8.0.0-alpha.40(@typescript-eslint/parser@8.0.0-alpha.40(eslint@9.8.0)(typescript@5.5.4))(eslint@9.8.0)(typescript@5.5.4))(eslint@9.8.0)
-      eslint-plugin-vitest: 0.5.4(@typescript-eslint/eslint-plugin@8.0.0-alpha.40(@typescript-eslint/parser@8.0.0-alpha.40(eslint@9.8.0)(typescript@5.5.4))(eslint@9.8.0)(typescript@5.5.4))(eslint@9.8.0)(typescript@5.5.4)(vitest@2.0.4)
+      eslint-plugin-vitest: 0.5.4(@typescript-eslint/eslint-plugin@8.0.0-alpha.40(@typescript-eslint/parser@8.0.0-alpha.40(eslint@9.8.0)(typescript@5.5.4))(eslint@9.8.0)(typescript@5.5.4))(eslint@9.8.0)(typescript@5.5.4)(vitest@2.0.4(@types/node@20.14.13)(jsdom@24.1.1))
       eslint-plugin-vue: 9.27.0(eslint@9.8.0)
       eslint-plugin-yml: 1.14.0(eslint@9.8.0)
       eslint-processor-vue-blocks: 0.1.2(@vue/compiler-sfc@3.4.34)(eslint@9.8.0)
@@ -5061,8 +5076,8 @@ snapshots:
       yaml-eslint-parser: 1.2.3
       yargs: 17.7.2
     optionalDependencies:
-      eslint-plugin-svelte: 2.43.0(eslint@9.8.0)(svelte@5.0.0-next.208)
-      svelte-eslint-parser: 0.41.0(svelte@5.0.0-next.208)
+      eslint-plugin-svelte: 2.43.0(eslint@9.8.0)(svelte@5.0.0-next.245)
+      svelte-eslint-parser: 0.41.0(svelte@5.0.0-next.245)
     transitivePeerDependencies:
       - '@vue/compiler-sfc'
       - supports-color
@@ -5092,15 +5107,15 @@ snapshots:
       js-tokens: 4.0.0
       picocolors: 1.0.1
 
-  '@babel/parser@7.25.0':
+  '@babel/parser@7.25.6':
     dependencies:
-      '@babel/types': 7.25.0
+      '@babel/types': 7.25.6
 
   '@babel/runtime@7.25.0':
     dependencies:
       regenerator-runtime: 0.14.1
 
-  '@babel/types@7.25.0':
+  '@babel/types@7.25.6':
     dependencies:
       '@babel/helper-string-parser': 7.24.8
       '@babel/helper-validator-identifier': 7.24.7
@@ -5735,9 +5750,9 @@ snapshots:
 
   '@humanwhocodes/retry@0.3.0': {}
 
-  '@huntabyte/eslint-config@0.3.2(@vue/compiler-sfc@3.4.34)(eslint-plugin-svelte@2.43.0(eslint@9.8.0)(svelte@5.0.0-next.208))(eslint@9.8.0)(svelte-eslint-parser@0.41.0(svelte@5.0.0-next.208))(svelte@5.0.0-next.208)(typescript@5.5.4)(vitest@2.0.4)':
+  '@huntabyte/eslint-config@0.3.2(@vue/compiler-sfc@3.4.34)(eslint-plugin-svelte@2.43.0(eslint@9.8.0)(svelte@5.0.0-next.245))(eslint@9.8.0)(svelte-eslint-parser@0.41.0(svelte@5.0.0-next.245))(svelte@5.0.0-next.245)(typescript@5.5.4)(vitest@2.0.4(@types/node@20.14.13)(jsdom@24.1.1))':
     dependencies:
-      '@antfu/eslint-config': 2.24.0(@vue/compiler-sfc@3.4.34)(eslint-plugin-svelte@2.43.0(eslint@9.8.0)(svelte@5.0.0-next.208))(eslint@9.8.0)(svelte-eslint-parser@0.41.0(svelte@5.0.0-next.208))(svelte@5.0.0-next.208)(typescript@5.5.4)(vitest@2.0.4)
+      '@antfu/eslint-config': 2.24.0(@vue/compiler-sfc@3.4.34)(eslint-plugin-svelte@2.43.0(eslint@9.8.0)(svelte@5.0.0-next.245))(eslint@9.8.0)(svelte-eslint-parser@0.41.0(svelte@5.0.0-next.245))(svelte@5.0.0-next.245)(typescript@5.5.4)(vitest@2.0.4(@types/node@20.14.13)(jsdom@24.1.1))
       '@antfu/install-pkg': 0.3.3
       '@clack/prompts': 0.7.0
       '@huntabyte/eslint-plugin': 0.1.0(eslint@9.8.0)
@@ -5746,10 +5761,10 @@ snapshots:
       chalk: 5.3.0
       eslint: 9.8.0
       eslint-flat-config-utils: 0.2.5
-      eslint-plugin-svelte: 2.43.0(eslint@9.8.0)(svelte@5.0.0-next.208)
+      eslint-plugin-svelte: 2.43.0(eslint@9.8.0)(svelte@5.0.0-next.245)
       local-pkg: 0.5.0
       parse-gitignore: 2.0.0
-      svelte-eslint-parser: 0.41.0(svelte@5.0.0-next.208)
+      svelte-eslint-parser: 0.41.0(svelte@5.0.0-next.245)
       yargs: 17.7.2
     transitivePeerDependencies:
       - '@eslint-react/eslint-plugin'
@@ -5886,14 +5901,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@melt-ui/pp@0.3.2(@melt-ui/svelte@0.76.2(svelte@5.0.0-next.208))(svelte@5.0.0-next.208)':
+  '@melt-ui/pp@0.3.2(@melt-ui/svelte@0.76.2(svelte@5.0.0-next.245))(svelte@5.0.0-next.245)':
     dependencies:
-      '@melt-ui/svelte': 0.76.2(svelte@5.0.0-next.208)
+      '@melt-ui/svelte': 0.76.2(svelte@5.0.0-next.245)
       estree-walker: 3.0.3
       magic-string: 0.30.11
-      svelte: 5.0.0-next.208
+      svelte: 5.0.0-next.245
 
-  '@melt-ui/svelte@0.76.2(svelte@5.0.0-next.208)':
+  '@melt-ui/svelte@0.76.2(svelte@5.0.0-next.245)':
     dependencies:
       '@floating-ui/core': 1.6.5
       '@floating-ui/dom': 1.6.8
@@ -5901,7 +5916,7 @@ snapshots:
       dequal: 2.0.3
       focus-trap: 7.5.4
       nanoid: 5.0.7
-      svelte: 5.0.0-next.208
+      svelte: 5.0.0-next.245
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
@@ -6167,17 +6182,17 @@ snapshots:
       - supports-color
       - typescript
 
-  '@sveltejs/adapter-cloudflare@4.7.0(@sveltejs/kit@2.5.18(@sveltejs/vite-plugin-svelte@3.1.1(svelte@5.0.0-next.208)(vite@5.3.5(@types/node@20.14.13)))(svelte@5.0.0-next.208)(vite@5.3.5(@types/node@20.14.13)))(wrangler@3.67.1(@cloudflare/workers-types@4.20240725.0))':
+  '@sveltejs/adapter-cloudflare@4.7.0(@sveltejs/kit@2.5.18(@sveltejs/vite-plugin-svelte@3.1.1(svelte@5.0.0-next.245)(vite@5.3.5(@types/node@20.14.13)))(svelte@5.0.0-next.245)(vite@5.3.5(@types/node@20.14.13)))(wrangler@3.67.1(@cloudflare/workers-types@4.20240725.0))':
     dependencies:
       '@cloudflare/workers-types': 4.20240725.0
-      '@sveltejs/kit': 2.5.18(@sveltejs/vite-plugin-svelte@3.1.1(svelte@5.0.0-next.208)(vite@5.3.5(@types/node@20.14.13)))(svelte@5.0.0-next.208)(vite@5.3.5(@types/node@20.14.13))
+      '@sveltejs/kit': 2.5.18(@sveltejs/vite-plugin-svelte@3.1.1(svelte@5.0.0-next.245)(vite@5.3.5(@types/node@20.14.13)))(svelte@5.0.0-next.245)(vite@5.3.5(@types/node@20.14.13))
       esbuild: 0.21.5
       worktop: 0.8.0-next.18
       wrangler: 3.67.1(@cloudflare/workers-types@4.20240725.0)
 
-  '@sveltejs/kit@2.5.18(@sveltejs/vite-plugin-svelte@3.1.1(svelte@5.0.0-next.208)(vite@5.3.5(@types/node@20.14.13)))(svelte@5.0.0-next.208)(vite@5.3.5(@types/node@20.14.13))':
+  '@sveltejs/kit@2.5.18(@sveltejs/vite-plugin-svelte@3.1.1(svelte@5.0.0-next.245)(vite@5.3.5(@types/node@20.14.13)))(svelte@5.0.0-next.245)(vite@5.3.5(@types/node@20.14.13))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 3.1.1(svelte@5.0.0-next.208)(vite@5.3.5(@types/node@20.14.13))
+      '@sveltejs/vite-plugin-svelte': 3.1.1(svelte@5.0.0-next.245)(vite@5.3.5(@types/node@20.14.13))
       '@types/cookie': 0.6.0
       cookie: 0.6.0
       devalue: 5.0.0
@@ -6189,39 +6204,39 @@ snapshots:
       sade: 1.8.1
       set-cookie-parser: 2.6.0
       sirv: 2.0.4
-      svelte: 5.0.0-next.208
+      svelte: 5.0.0-next.245
       tiny-glob: 0.2.9
       vite: 5.3.5(@types/node@20.14.13)
 
-  '@sveltejs/package@2.3.2(svelte@5.0.0-next.208)(typescript@5.5.4)':
+  '@sveltejs/package@2.3.2(svelte@5.0.0-next.245)(typescript@5.5.4)':
     dependencies:
       chokidar: 3.6.0
       kleur: 4.1.5
       sade: 1.8.1
       semver: 7.6.3
-      svelte: 5.0.0-next.208
-      svelte2tsx: 0.7.13(svelte@5.0.0-next.208)(typescript@5.5.4)
+      svelte: 5.0.0-next.245
+      svelte2tsx: 0.7.13(svelte@5.0.0-next.245)(typescript@5.5.4)
     transitivePeerDependencies:
       - typescript
 
-  '@sveltejs/vite-plugin-svelte-inspector@2.1.0(@sveltejs/vite-plugin-svelte@3.1.1(svelte@5.0.0-next.208)(vite@5.3.5(@types/node@20.14.13)))(svelte@5.0.0-next.208)(vite@5.3.5(@types/node@20.14.13))':
+  '@sveltejs/vite-plugin-svelte-inspector@2.1.0(@sveltejs/vite-plugin-svelte@3.1.1(svelte@5.0.0-next.245)(vite@5.3.5(@types/node@20.14.13)))(svelte@5.0.0-next.245)(vite@5.3.5(@types/node@20.14.13))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 3.1.1(svelte@5.0.0-next.208)(vite@5.3.5(@types/node@20.14.13))
+      '@sveltejs/vite-plugin-svelte': 3.1.1(svelte@5.0.0-next.245)(vite@5.3.5(@types/node@20.14.13))
       debug: 4.3.6
-      svelte: 5.0.0-next.208
+      svelte: 5.0.0-next.245
       vite: 5.3.5(@types/node@20.14.13)
     transitivePeerDependencies:
       - supports-color
 
-  '@sveltejs/vite-plugin-svelte@3.1.1(svelte@5.0.0-next.208)(vite@5.3.5(@types/node@20.14.13))':
+  '@sveltejs/vite-plugin-svelte@3.1.1(svelte@5.0.0-next.245)(vite@5.3.5(@types/node@20.14.13))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte-inspector': 2.1.0(@sveltejs/vite-plugin-svelte@3.1.1(svelte@5.0.0-next.208)(vite@5.3.5(@types/node@20.14.13)))(svelte@5.0.0-next.208)(vite@5.3.5(@types/node@20.14.13))
+      '@sveltejs/vite-plugin-svelte-inspector': 2.1.0(@sveltejs/vite-plugin-svelte@3.1.1(svelte@5.0.0-next.245)(vite@5.3.5(@types/node@20.14.13)))(svelte@5.0.0-next.245)(vite@5.3.5(@types/node@20.14.13))
       debug: 4.3.6
       deepmerge: 4.3.1
       kleur: 4.1.5
       magic-string: 0.30.11
-      svelte: 5.0.0-next.208
-      svelte-hmr: 0.16.0(svelte@5.0.0-next.208)
+      svelte: 5.0.0-next.245
+      svelte-hmr: 0.16.0(svelte@5.0.0-next.245)
       vite: 5.3.5(@types/node@20.14.13)
       vitefu: 0.2.5(vite@5.3.5(@types/node@20.14.13))
     transitivePeerDependencies:
@@ -6268,10 +6283,10 @@ snapshots:
       lodash: 4.17.21
       redent: 3.0.0
 
-  '@testing-library/svelte@5.2.1(svelte@5.0.0-next.208)(vite@5.3.5(@types/node@20.14.13))(vitest@2.0.4(@types/node@20.14.13)(@vitest/ui@1.6.0)(jsdom@24.1.1))':
+  '@testing-library/svelte@5.2.1(svelte@5.0.0-next.245)(vite@5.3.5(@types/node@20.14.13))(vitest@2.0.4(@types/node@20.14.13)(@vitest/ui@1.6.0)(jsdom@24.1.1))':
     dependencies:
       '@testing-library/dom': 10.4.0
-      svelte: 5.0.0-next.208
+      svelte: 5.0.0-next.245
     optionalDependencies:
       vite: 5.3.5(@types/node@20.14.13)
       vitest: 2.0.4(@types/node@20.14.13)(@vitest/ui@1.6.0)(jsdom@24.1.1)
@@ -6406,10 +6421,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/eslint-plugin@8.0.0-alpha.40(@typescript-eslint/parser@8.0.0-alpha.40(eslint@9.8.0)(typescript@5.5.4))(eslint@9.8.0)(typescript@5.5.4)':
+  '@typescript-eslint/eslint-plugin@8.0.0-alpha.40(@typescript-eslint/parser@7.18.0(eslint@9.8.0)(typescript@5.5.4))(eslint@9.8.0)(typescript@5.5.4)':
     dependencies:
       '@eslint-community/regexpp': 4.11.0
-      '@typescript-eslint/parser': 8.0.0-alpha.40(eslint@9.8.0)(typescript@5.5.4)
+      '@typescript-eslint/parser': 7.18.0(eslint@9.8.0)(typescript@5.5.4)
       '@typescript-eslint/scope-manager': 8.0.0-alpha.40
       '@typescript-eslint/type-utils': 8.0.0-alpha.40(eslint@9.8.0)(typescript@5.5.4)
       '@typescript-eslint/utils': 8.0.0-alpha.40(eslint@9.8.0)(typescript@5.5.4)
@@ -6643,11 +6658,11 @@ snapshots:
 
   '@vue/compiler-core@3.4.34':
     dependencies:
-      '@babel/parser': 7.25.0
+      '@babel/parser': 7.25.6
       '@vue/shared': 3.4.34
       entities: 4.5.0
       estree-walker: 2.0.2
-      source-map-js: 1.2.0
+      source-map-js: 1.2.1
 
   '@vue/compiler-dom@3.4.34':
     dependencies:
@@ -6656,15 +6671,15 @@ snapshots:
 
   '@vue/compiler-sfc@3.4.34':
     dependencies:
-      '@babel/parser': 7.25.0
+      '@babel/parser': 7.25.6
       '@vue/compiler-core': 3.4.34
       '@vue/compiler-dom': 3.4.34
       '@vue/compiler-ssr': 3.4.34
       '@vue/shared': 3.4.34
       estree-walker: 2.0.2
       magic-string: 0.30.11
-      postcss: 8.4.40
-      source-map-js: 1.2.0
+      postcss: 8.4.45
+      source-map-js: 1.2.1
 
   '@vue/compiler-ssr@3.4.34':
     dependencies:
@@ -6738,6 +6753,8 @@ snapshots:
   aria-query@5.3.0:
     dependencies:
       dequal: 2.0.3
+
+  aria-query@5.3.1: {}
 
   array-timsort@1.0.3: {}
 
@@ -7316,7 +7333,7 @@ snapshots:
 
   eslint-plugin-no-only-tests@3.1.0: {}
 
-  eslint-plugin-perfectionist@3.0.0(eslint@9.8.0)(svelte-eslint-parser@0.41.0(svelte@5.0.0-next.208))(svelte@5.0.0-next.208)(typescript@5.5.4)(vue-eslint-parser@9.4.3(eslint@9.8.0)):
+  eslint-plugin-perfectionist@3.0.0(eslint@9.8.0)(svelte-eslint-parser@0.41.0(svelte@5.0.0-next.245))(svelte@5.0.0-next.245)(typescript@5.5.4)(vue-eslint-parser@9.4.3(eslint@9.8.0)):
     dependencies:
       '@typescript-eslint/types': 7.18.0
       '@typescript-eslint/utils': 7.18.0(eslint@9.8.0)(typescript@5.5.4)
@@ -7324,8 +7341,8 @@ snapshots:
       minimatch: 10.0.1
       natural-compare-lite: 1.4.0
     optionalDependencies:
-      svelte: 5.0.0-next.208
-      svelte-eslint-parser: 0.41.0(svelte@5.0.0-next.208)
+      svelte: 5.0.0-next.245
+      svelte-eslint-parser: 0.41.0(svelte@5.0.0-next.245)
       vue-eslint-parser: 9.4.3(eslint@9.8.0)
     transitivePeerDependencies:
       - supports-color
@@ -7342,7 +7359,7 @@ snapshots:
       regexp-ast-analysis: 0.7.1
       scslre: 0.3.0
 
-  eslint-plugin-svelte@2.43.0(eslint@9.8.0)(svelte@5.0.0-next.208):
+  eslint-plugin-svelte@2.43.0(eslint@9.8.0)(svelte@5.0.0-next.245):
     dependencies:
       '@eslint-community/eslint-utils': 4.4.0(eslint@9.8.0)
       '@jridgewell/sourcemap-codec': 1.5.0
@@ -7355,9 +7372,9 @@ snapshots:
       postcss-safe-parser: 6.0.0(postcss@8.4.40)
       postcss-selector-parser: 6.1.1
       semver: 7.6.3
-      svelte-eslint-parser: 0.41.0(svelte@5.0.0-next.208)
+      svelte-eslint-parser: 0.41.0(svelte@5.0.0-next.245)
     optionalDependencies:
-      svelte: 5.0.0-next.208
+      svelte: 5.0.0-next.245
     transitivePeerDependencies:
       - ts-node
 
@@ -7396,14 +7413,14 @@ snapshots:
       eslint: 9.8.0
       eslint-rule-composer: 0.3.0
     optionalDependencies:
-      '@typescript-eslint/eslint-plugin': 8.0.0-alpha.40(@typescript-eslint/parser@8.0.0-alpha.40(eslint@9.8.0)(typescript@5.5.4))(eslint@9.8.0)(typescript@5.5.4)
+      '@typescript-eslint/eslint-plugin': 8.0.0-alpha.40(@typescript-eslint/parser@7.18.0(eslint@9.8.0)(typescript@5.5.4))(eslint@9.8.0)(typescript@5.5.4)
 
-  eslint-plugin-vitest@0.5.4(@typescript-eslint/eslint-plugin@8.0.0-alpha.40(@typescript-eslint/parser@8.0.0-alpha.40(eslint@9.8.0)(typescript@5.5.4))(eslint@9.8.0)(typescript@5.5.4))(eslint@9.8.0)(typescript@5.5.4)(vitest@2.0.4):
+  eslint-plugin-vitest@0.5.4(@typescript-eslint/eslint-plugin@8.0.0-alpha.40(@typescript-eslint/parser@8.0.0-alpha.40(eslint@9.8.0)(typescript@5.5.4))(eslint@9.8.0)(typescript@5.5.4))(eslint@9.8.0)(typescript@5.5.4)(vitest@2.0.4(@types/node@20.14.13)(jsdom@24.1.1)):
     dependencies:
       '@typescript-eslint/utils': 7.18.0(eslint@9.8.0)(typescript@5.5.4)
       eslint: 9.8.0
     optionalDependencies:
-      '@typescript-eslint/eslint-plugin': 8.0.0-alpha.40(@typescript-eslint/parser@8.0.0-alpha.40(eslint@9.8.0)(typescript@5.5.4))(eslint@9.8.0)(typescript@5.5.4)
+      '@typescript-eslint/eslint-plugin': 8.0.0-alpha.40(@typescript-eslint/parser@7.18.0(eslint@9.8.0)(typescript@5.5.4))(eslint@9.8.0)(typescript@5.5.4)
       vitest: 2.0.4(@types/node@20.14.13)(@vitest/ui@1.6.0)(jsdom@24.1.1)
     transitivePeerDependencies:
       - supports-color
@@ -8557,7 +8574,7 @@ snapshots:
     dependencies:
       '@types/mdast': 4.0.4
 
-  mdsx@0.0.6(svelte@5.0.0-next.208):
+  mdsx@0.0.6(svelte@5.0.0-next.245):
     dependencies:
       esrap: 1.2.2
       hast-util-to-html: 9.0.1
@@ -8566,7 +8583,7 @@ snapshots:
       rehype-stringify: 10.0.0
       remark-parse: 11.0.0
       remark-rehype: 11.1.0
-      svelte: 5.0.0-next.208
+      svelte: 5.0.0-next.245
       unified: 11.0.5
       unist-util-visit: 5.0.0
       vfile: 6.0.2
@@ -9076,9 +9093,9 @@ snapshots:
       pkg-types: 1.1.3
       ufo: 1.5.4
 
-  mode-watcher@0.2.2(svelte@5.0.0-next.208):
+  mode-watcher@0.2.2(svelte@5.0.0-next.245):
     dependencies:
-      svelte: 5.0.0-next.208
+      svelte: 5.0.0-next.245
 
   mri@1.2.0: {}
 
@@ -9294,11 +9311,13 @@ snapshots:
       estree-walker: 3.0.3
       is-reference: 3.0.2
 
-  phosphor-svelte@2.0.1(svelte@5.0.0-next.208):
+  phosphor-svelte@2.0.1(svelte@5.0.0-next.245):
     dependencies:
-      svelte: 5.0.0-next.208
+      svelte: 5.0.0-next.245
 
   picocolors@1.0.1: {}
+
+  picocolors@1.1.0: {}
 
   picomatch@2.3.1: {}
 
@@ -9356,6 +9375,15 @@ snapshots:
       jiti: 1.21.6
       postcss: 8.4.40
 
+  postcss-load-config@5.1.0(jiti@1.21.6)(postcss@8.4.45):
+    dependencies:
+      lilconfig: 3.1.2
+      yaml: 2.5.0
+    optionalDependencies:
+      jiti: 1.21.6
+      postcss: 8.4.45
+    optional: true
+
   postcss-nested@6.2.0(postcss@8.4.40):
     dependencies:
       postcss: 8.4.40
@@ -9387,6 +9415,12 @@ snapshots:
       picocolors: 1.0.1
       source-map-js: 1.2.0
 
+  postcss@8.4.45:
+    dependencies:
+      nanoid: 3.3.7
+      picocolors: 1.1.0
+      source-map-js: 1.2.1
+
   preferred-pm@3.1.4:
     dependencies:
       find-up: 5.0.0
@@ -9396,16 +9430,16 @@ snapshots:
 
   prelude-ls@1.2.1: {}
 
-  prettier-plugin-svelte@3.2.6(prettier@3.3.3)(svelte@5.0.0-next.208):
+  prettier-plugin-svelte@3.2.6(prettier@3.3.3)(svelte@5.0.0-next.245):
     dependencies:
       prettier: 3.3.3
-      svelte: 5.0.0-next.208
+      svelte: 5.0.0-next.245
 
-  prettier-plugin-tailwindcss@0.5.13(prettier-plugin-svelte@3.2.6(prettier@3.3.3)(svelte@5.0.0-next.208))(prettier@3.3.3):
+  prettier-plugin-tailwindcss@0.5.13(prettier-plugin-svelte@3.2.6(prettier@3.3.3)(svelte@5.0.0-next.245))(prettier@3.3.3):
     dependencies:
       prettier: 3.3.3
     optionalDependencies:
-      prettier-plugin-svelte: 3.2.6(prettier@3.3.3)(svelte@5.0.0-next.208)
+      prettier-plugin-svelte: 3.2.6(prettier@3.3.3)(svelte@5.0.0-next.245)
 
   prettier@2.8.8: {}
 
@@ -9692,10 +9726,10 @@ snapshots:
     dependencies:
       queue-microtask: 1.2.3
 
-  runed@0.15.0(svelte@5.0.0-next.208):
+  runed@0.15.0(svelte@5.0.0-next.245):
     dependencies:
       esm-env: 1.0.0
-      svelte: 5.0.0-next.208
+      svelte: 5.0.0-next.245
 
   rxjs@7.8.1:
     dependencies:
@@ -9787,6 +9821,8 @@ snapshots:
       sander: 0.5.1
 
   source-map-js@1.2.0: {}
+
+  source-map-js@1.2.1: {}
 
   source-map-support@0.5.21:
     dependencies:
@@ -9919,14 +9955,14 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
-  svelte-check@3.8.4(postcss-load-config@5.1.0(jiti@1.21.6)(postcss@8.4.40))(postcss@8.4.40)(svelte@5.0.0-next.208):
+  svelte-check@3.8.4(postcss-load-config@5.1.0(jiti@1.21.6)(postcss@8.4.40))(postcss@8.4.40)(svelte@5.0.0-next.245):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.25
       chokidar: 3.6.0
       picocolors: 1.0.1
       sade: 1.8.1
-      svelte: 5.0.0-next.208
-      svelte-preprocess: 5.1.4(postcss-load-config@5.1.0(jiti@1.21.6)(postcss@8.4.40))(postcss@8.4.40)(svelte@5.0.0-next.208)(typescript@5.5.4)
+      svelte: 5.0.0-next.245
+      svelte-preprocess: 5.1.4(postcss-load-config@5.1.0(jiti@1.21.6)(postcss@8.4.40))(postcss@8.4.40)(svelte@5.0.0-next.245)(typescript@5.5.4)
       typescript: 5.5.4
     transitivePeerDependencies:
       - '@babel/core'
@@ -9939,7 +9975,27 @@ snapshots:
       - stylus
       - sugarss
 
-  svelte-eslint-parser@0.41.0(svelte@5.0.0-next.208):
+  svelte-check@3.8.4(postcss-load-config@5.1.0(jiti@1.21.6)(postcss@8.4.45))(postcss@8.4.45)(svelte@5.0.0-next.245):
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.25
+      chokidar: 3.6.0
+      picocolors: 1.0.1
+      sade: 1.8.1
+      svelte: 5.0.0-next.245
+      svelte-preprocess: 5.1.4(postcss-load-config@5.1.0(jiti@1.21.6)(postcss@8.4.45))(postcss@8.4.45)(svelte@5.0.0-next.245)(typescript@5.5.4)
+      typescript: 5.5.4
+    transitivePeerDependencies:
+      - '@babel/core'
+      - coffeescript
+      - less
+      - postcss
+      - postcss-load-config
+      - pug
+      - sass
+      - stylus
+      - sugarss
+
+  svelte-eslint-parser@0.41.0(svelte@5.0.0-next.245):
     dependencies:
       eslint-scope: 7.2.2
       eslint-visitor-keys: 3.4.3
@@ -9947,48 +10003,61 @@ snapshots:
       postcss: 8.4.40
       postcss-scss: 4.0.9(postcss@8.4.40)
     optionalDependencies:
-      svelte: 5.0.0-next.208
+      svelte: 5.0.0-next.245
 
-  svelte-hmr@0.16.0(svelte@5.0.0-next.208):
+  svelte-hmr@0.16.0(svelte@5.0.0-next.245):
     dependencies:
-      svelte: 5.0.0-next.208
+      svelte: 5.0.0-next.245
 
-  svelte-preprocess@5.1.4(postcss-load-config@5.1.0(jiti@1.21.6)(postcss@8.4.40))(postcss@8.4.40)(svelte@5.0.0-next.208)(typescript@5.5.4):
+  svelte-preprocess@5.1.4(postcss-load-config@5.1.0(jiti@1.21.6)(postcss@8.4.40))(postcss@8.4.40)(svelte@5.0.0-next.245)(typescript@5.5.4):
     dependencies:
       '@types/pug': 2.0.10
       detect-indent: 6.1.0
       magic-string: 0.30.11
       sorcery: 0.11.1
       strip-indent: 3.0.0
-      svelte: 5.0.0-next.208
+      svelte: 5.0.0-next.245
     optionalDependencies:
       postcss: 8.4.40
       postcss-load-config: 5.1.0(jiti@1.21.6)(postcss@8.4.40)
       typescript: 5.5.4
 
-  svelte-sonner@0.3.27(svelte@5.0.0-next.208):
+  svelte-preprocess@5.1.4(postcss-load-config@5.1.0(jiti@1.21.6)(postcss@8.4.45))(postcss@8.4.45)(svelte@5.0.0-next.245)(typescript@5.5.4):
     dependencies:
-      svelte: 5.0.0-next.208
+      '@types/pug': 2.0.10
+      detect-indent: 6.1.0
+      magic-string: 0.30.11
+      sorcery: 0.11.1
+      strip-indent: 3.0.0
+      svelte: 5.0.0-next.245
+    optionalDependencies:
+      postcss: 8.4.45
+      postcss-load-config: 5.1.0(jiti@1.21.6)(postcss@8.4.45)
+      typescript: 5.5.4
 
-  svelte-toolbelt@0.1.0(svelte@5.0.0-next.208):
+  svelte-sonner@0.3.27(svelte@5.0.0-next.245):
     dependencies:
-      svelte: 5.0.0-next.208
+      svelte: 5.0.0-next.245
 
-  svelte2tsx@0.7.13(svelte@5.0.0-next.208)(typescript@5.5.4):
+  svelte-toolbelt@0.1.0(svelte@5.0.0-next.245):
+    dependencies:
+      svelte: 5.0.0-next.245
+
+  svelte2tsx@0.7.13(svelte@5.0.0-next.245)(typescript@5.5.4):
     dependencies:
       dedent-js: 1.0.1
       pascal-case: 3.1.2
-      svelte: 5.0.0-next.208
+      svelte: 5.0.0-next.245
       typescript: 5.5.4
 
-  svelte@5.0.0-next.208:
+  svelte@5.0.0-next.245:
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@jridgewell/sourcemap-codec': 1.5.0
       '@types/estree': 1.0.5
       acorn: 8.12.1
       acorn-typescript: 1.4.13(acorn@8.12.1)
-      aria-query: 5.3.0
+      aria-query: 5.3.1
       axobject-query: 4.1.0
       esm-env: 1.0.0
       esrap: 1.2.2

--- a/sites/docs/package.json
+++ b/sites/docs/package.json
@@ -39,7 +39,7 @@
 		"rehype-slug": "^6.0.0",
 		"remark-gfm": "^4.0.0",
 		"shiki": "^1.1.1",
-		"svelte": "5.0.0-next.208",
+		"svelte": "5.0.0-next.245",
 		"svelte-check": "^3.6.9",
 		"svelte-sonner": "^0.3.24",
 		"tailwind-merge": "^2.2.1",


### PR DESCRIPTION
Updated svelte 5 and updated code for breaking changes. I did not update the deprecated features such as `<svelte:component />` and `context="module"`. there are still some tooling issues i've seen around `context="module"` and these warning wont prevent bits-ui from working with the latest version.