### PR TITLE
next: fix pin input

### DIFF
--- a/packages/bits-ui/src/lib/bits/pin-input/pin-input.svelte.ts
+++ b/packages/bits-ui/src/lib/bits/pin-input/pin-input.svelte.ts
@@ -296,6 +296,13 @@ class PinInputRootState {
 			return;
 		}
 
+		if (this.#regexPattern) {
+			input.value = input.value.replace(
+				new RegExp(`[^${this.#regexPattern.source}]`, "g"),
+				""
+			);
+		}
+
 		const selStart = input.selectionStart;
 		const selEnd = input.selectionEnd;
 		const selDir = input.selectionDirection ?? "none";
@@ -350,11 +357,12 @@ class PinInputRootState {
 	};
 
 	#oninput = (e: Event & { currentTarget: HTMLInputElement }) => {
-		const newValue = e.currentTarget.value.slice(0, this.#maxLength.current);
-		if (newValue.length > 0 && this.#regexPattern && !this.#regexPattern.test(newValue)) {
-			e.preventDefault();
-			return;
+		const rawValue = e.currentTarget.value;
+		let newValue = rawValue;
+		if (this.#regexPattern) {
+			newValue = newValue.replace(new RegExp(`[^${this.#regexPattern.source}]`, "g"), "");
 		}
+		newValue = newValue.slice(0, this.#maxLength.current);
 
 		const maybeHasDeleted =
 			typeof this.#previousValue.current === "string" &&
@@ -437,7 +445,6 @@ class PinInputRootState {
 		"data-pin-input-input-mse": this.#mirrorSelectionEnd,
 		inputmode: this.#inputmode.current,
 		pattern: this.#regexPattern?.source,
-		maxlength: this.#maxLength.current,
 		value: this.value.current,
 		disabled: getDisabled(this.#disabled.current),
 		//


### PR DESCRIPTION
There's an unpleasant bug where if you start typing in the input, the focus of the active block starts to shift.
Or if you paste a code like 999-999, everything breaks due to the hyphen between the numbers.

Changes made:
- Removed the `maxlength` prop, as it cuts off during `onpaste`. For example, if `maxlength` is 6 characters, pasting would result in 999-99.
- Now all characters that don't match the `regexPattern` are removed from the value.

P.S. Sorry, this is my very first pull request. I welcome any suggestions or feedback.