### PR TITLE
docs: use correct reference to label

### DIFF
--- a/sites/docs/content/components/select.md
+++ b/sites/docs/content/components/select.md
@@ -94,7 +94,7 @@ Here's an example of how you might create a reusable `MySelect` component that r
 						{#snippet children({ selected })}
 							{selected ? "✅" : ""}
 							<Select.ItemText>
-								{item.label}
+								{label}
 							</Select.ItemText>
 						{/snippet}
 					</Select.Item>


### PR DESCRIPTION
A simple fix for a small mistake in the select documentation. As you can see the `label` is destructured from the item on line 92