### PR TITLE
fix: calendars not rendering first day of next month

### DIFF
--- a/.changeset/green-pumpkins-provide.md
+++ b/.changeset/green-pumpkins-provide.md
@@ -1,0 +1,5 @@
+---
+"bits-ui": patch
+---
+
+fix: bug with calendar months sometimes not rendering the first day of the month

--- a/packages/bits-ui/src/lib/internal/date-time/calendar-helpers.svelte.ts
+++ b/packages/bits-ui/src/lib/internal/date-time/calendar-helpers.svelte.ts
@@ -105,7 +105,13 @@ function createMonth(props: CreateMonthProps): Month<DateValue> {
 			startFrom = dateObj.add({ months: 1 }).set({ day: 1 });
 		}
 
-		const extraDaysArray = Array.from({ length: extraDays }, (_, i) => {
+		let length = extraDays;
+		if (nextMonthDays.length === 0) {
+			length = extraDays - 1;
+			nextMonthDays.push(startFrom);
+		}
+
+		const extraDaysArray = Array.from({ length }, (_, i) => {
 			const incr = i + 1;
 			return startFrom.add({ days: incr });
 		});


### PR DESCRIPTION
Closes #768