### PR TITLE
Running value setting for input components before the onChange function

### DIFF
--- a/packages/bits-ui/src/lib/bits/checkbox/components/checkbox.svelte
+++ b/packages/bits-ui/src/lib/bits/checkbox/components/checkbox.svelte
@@ -28,8 +28,8 @@
 		value,
 		onCheckedChange: ({ next }) => {
 			if (checked !== next) {
-				onCheckedChange?.(next);
 				checked = next;
+				onCheckedChange?.(next);
 			}
 			return next;
 		},

--- a/packages/bits-ui/src/lib/bits/select/components/select.svelte
+++ b/packages/bits-ui/src/lib/bits/select/components/select.svelte
@@ -51,8 +51,8 @@
 		onSelectedChange: (({ next }: { next: $$Props["selected"] }) => {
 			if (Array.isArray(next)) {
 				if (!Array.isArray(selected) || !arraysAreEqual(selected, next)) {
-					onSelectedChange?.(next);
 					selected = next;
+					onSelectedChange?.(next);
 					return next;
 				}
 				return next;

--- a/packages/bits-ui/src/lib/bits/switch/components/switch.svelte
+++ b/packages/bits-ui/src/lib/bits/switch/components/switch.svelte
@@ -31,8 +31,8 @@
 		defaultChecked: checked,
 		onCheckedChange: ({ next }) => {
 			if (checked !== next) {
+				selected = next;
 				onCheckedChange?.(next);
-				checked = next;
 			}
 			return next;
 		},

--- a/packages/bits-ui/src/lib/bits/switch/components/switch.svelte
+++ b/packages/bits-ui/src/lib/bits/switch/components/switch.svelte
@@ -31,7 +31,7 @@
 		defaultChecked: checked,
 		onCheckedChange: ({ next }) => {
 			if (checked !== next) {
-				selected = next;
+				checked = next;
 				onCheckedChange?.(next);
 			}
 			return next;

--- a/packages/bits-ui/src/lib/bits/toggle/components/toggle.svelte
+++ b/packages/bits-ui/src/lib/bits/toggle/components/toggle.svelte
@@ -23,8 +23,8 @@
 		defaultPressed: pressed,
 		onPressedChange: ({ next }) => {
 			if (pressed !== next) {
+				selected = next;
 				onPressedChange?.(next);
-				pressed = next;
 			}
 			return next;
 		},

--- a/packages/bits-ui/src/lib/bits/toggle/components/toggle.svelte
+++ b/packages/bits-ui/src/lib/bits/toggle/components/toggle.svelte
@@ -23,7 +23,7 @@
 		defaultPressed: pressed,
 		onPressedChange: ({ next }) => {
 			if (pressed !== next) {
-				selected = next;
+				pressed = next;
 				onPressedChange?.(next);
 			}
 			return next;


### PR DESCRIPTION
When you run onChange before you set the value it doesn't allow the onChange function to use the selected value.