### PR TITLE
next: export regexp helpers for pin input

### DIFF
--- a/.changeset/two-pugs-tease.md
+++ b/.changeset/two-pugs-tease.md
@@ -1,0 +1,5 @@
+---
+"bits-ui": patch
+---
+
+export REGEXP helpers from pin input

--- a/packages/bits-ui/src/lib/shared/index.ts
+++ b/packages/bits-ui/src/lib/shared/index.ts
@@ -1,5 +1,11 @@
 import type * as CSS from "csstype";
 
+export {
+	REGEXP_ONLY_DIGITS,
+	REGEXP_ONLY_CHARS,
+	REGEXP_ONLY_DIGITS_AND_CHARS,
+} from "$lib/bits/pin-input/pin-input.svelte.js";
+
 export type Selected<Value> = {
 	value: Value;
 	label?: string;


### PR DESCRIPTION
Exports `REGEXP_ONLY_DIGITS`, `REGEXP_ONLY_CHARS`, and  `REGEXP_ONLY_DIGITS_AND_CHARS` for use with the `PinInput` component.