### PR TITLE
feat: add ID Attribute to Toggle Root Component

### DIFF
--- a/.changeset/calm-snails-refuse.md
+++ b/.changeset/calm-snails-refuse.md
@@ -1,0 +1,5 @@
+---
+"bits-ui": patch
+---
+
+Add ID Attribute to Toggle Root Component

--- a/packages/bits-ui/src/lib/bits/toggle/toggle.svelte.ts
+++ b/packages/bits-ui/src/lib/bits/toggle/toggle.svelte.ts
@@ -48,6 +48,7 @@ class ToggleRootState {
 		() =>
 			({
 				[ROOT_ATTR]: "",
+				id: this.#id.current,
 				"data-disabled": getDataDisabled(this.#disabled.current),
 				"aria-pressed": getAriaPressed(this.pressed.current),
 				"data-state": getToggleDataState(this.pressed.current),


### PR DESCRIPTION
## Changes
It's me again. While working on nesting Toggle components within Tooltips (as part of the Origin UI to Svelte port), I discovered that the Toggle.Root component wasn't exposing its internal ID to the DOM. This made it particularly difficult to use the `child` snippet as using the `Toggle.Root`Component as a `Tooltip.Trigger` is not possible. 
[See Stackblitz Repro](https://stackblitz.com/edit/stackblitz-starters-xdgpeu?file=src%2Froutes%2F%2Bpage.svelte)

so i added the ID attribute to the Toggle Root element props for proper DOM referencing. All tests are still passing, so that is something.

## Current Behavior
- Toggle.Root uses ID internally for ref binding
- The ID is not exposed in the rendered element's attributes

## Implemented Solution
Added ID propagation to the rendered element's attributes in the ToggleRootState class:
```diff
props = $derived.by(
  () => ({
    [ROOT_ATTR]: "",
++   id: this.#id.current,
    "data-disabled": getDataDisabled(this.#disabled.current),
    // ... other existing props
  }) as const
);
```

## Known Issues & Future Considerations
Note: There is a potential future conflict when using Toggle within Tooltip (and likely other bits) due to competing `data-state` attributes. This is not addressed in this PR but should be considered. A potential solution would be to just name the `data-state` attributes corresponding to the component, like `data-tooltip-state`, `data-trigger-state`,... (?)