### PR TITLE
chore: update svelte peer dependency

### DIFF
--- a/.changeset/real-houses-talk.md
+++ b/.changeset/real-houses-talk.md
@@ -1,5 +1,5 @@
 ---
-"bits-ui": patch
+"bits-ui": minor
 ---
 
 Resolves peer dependency issues for Svelte 5 projects

--- a/.changeset/real-houses-talk.md
+++ b/.changeset/real-houses-talk.md
@@ -1,0 +1,5 @@
+---
+"bits-ui": patch
+---
+
+Resolves peer dependency issues for Svelte 5 projects

--- a/packages/bits-ui/package.json
+++ b/packages/bits-ui/package.json
@@ -58,6 +58,6 @@
 		"nanoid": "^5.0.5"
 	},
 	"peerDependencies": {
-		"svelte": "^4.0.0 || ^5.0.0-next.118"
+		"svelte": "^4.0.0 || ^5.0.0"
 	}
 }


### PR DESCRIPTION
Resolves `warn: incorrect peer dependency "svelte@5.1.9"` for Svelte 5 projects using `bits-ui`.