### PR TITLE
fix: `PinInput` paste not working without pattern

### DIFF
--- a/.changeset/metal-books-sniff.md
+++ b/.changeset/metal-books-sniff.md
@@ -1,0 +1,5 @@
+---
+"bits-ui": patch
+---
+
+fix: pin input paste not working without pattern

--- a/packages/bits-ui/src/lib/bits/pin-input/components/pin-input.svelte
+++ b/packages/bits-ui/src/lib/bits/pin-input/components/pin-input.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { box, mergeProps } from "svelte-toolbelt";
 	import type { PinInputRootProps } from "../types.js";
-	import { REGEXP_ONLY_DIGITS, usePinInput } from "../pin-input.svelte.js";
+	import { usePinInput } from "../pin-input.svelte.js";
 	import { useId } from "$lib/internal/use-id.js";
 	import { noop } from "$lib/internal/noop.js";
 
@@ -11,7 +11,7 @@
 		ref = $bindable(null),
 		maxlength = 6,
 		textalign = "left",
-		pattern = REGEXP_ONLY_DIGITS,
+		pattern,
 		inputmode = "numeric",
 		onComplete = noop,
 		pushPasswordManagerStrategy = "increase-width",

--- a/packages/bits-ui/src/lib/bits/pin-input/pin-input.svelte.ts
+++ b/packages/bits-ui/src/lib/bits/pin-input/pin-input.svelte.ts
@@ -222,6 +222,7 @@ class PinInputRootState {
 		"Tab",
 		"Shift",
 		"Control",
+		"Meta",
 	];
 
 	#onkeydown = (e: KeyboardEvent) => {

--- a/sites/docs/src/lib/components/demos/pin-input-demo.svelte
+++ b/sites/docs/src/lib/components/demos/pin-input-demo.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { PinInput, type PinInputRootSnippetProps, REGEXP_ONLY_DIGITS_AND_CHARS } from "bits-ui";
+	import { PinInput, type PinInputRootSnippetProps } from "bits-ui";
 	import { toast } from "svelte-sonner";
 	import { cn } from "$lib/utils/styles.js";
 
@@ -18,7 +18,6 @@
 	class="group/pininput flex items-center text-foreground has-[:disabled]:opacity-30"
 	maxlength={6}
 	{onComplete}
-	pattern={REGEXP_ONLY_DIGITS_AND_CHARS}
 >
 	{#snippet children({ cells })}
 		<div class="flex">


### PR DESCRIPTION
For some reason, we were defaulting the `pattern` prop in the `pin-input.svelte` component to `REGEXP_ONLY_DIGITS`, meaning if you didn't provide a pattern (aka you don't want to enforce one), it would fallback to digits.

That default has been removed.

Closes #867 