### PR TITLE
next(breaking): change `checked` type for checkbox components

### DIFF
--- a/.changeset/silver-pianos-wink.md
+++ b/.changeset/silver-pianos-wink.md
@@ -1,0 +1,5 @@
+---
+"bits-ui": patch
+---
+
+BREAKING: `Checkbox` and `*Menu.CheckboxItem` `checked` prop is now of type `boolean` with `indeterminate` being a separate prop

--- a/packages/bits-ui/src/lib/bits/checkbox/checkbox.svelte.ts
+++ b/packages/bits-ui/src/lib/bits/checkbox/checkbox.svelte.ts
@@ -15,7 +15,8 @@ type CheckboxRootStateProps = WithRefProps<
 		value: string | undefined;
 	}> &
 		WritableBoxedValues<{
-			checked: boolean | "indeterminate";
+			checked: boolean;
+			indeterminate: boolean;
 		}>
 >;
 
@@ -27,6 +28,7 @@ class CheckboxRootState {
 	required: CheckboxRootStateProps["required"];
 	name: CheckboxRootStateProps["name"];
 	value: CheckboxRootStateProps["value"];
+	indeterminate: CheckboxRootStateProps["indeterminate"];
 
 	constructor(props: CheckboxRootStateProps) {
 		this.checked = props.checked;
@@ -36,6 +38,7 @@ class CheckboxRootState {
 		this.value = props.value;
 		this.#ref = props.ref;
 		this.#id = props.id;
+		this.indeterminate = props.indeterminate;
 
 		useRefById({
 			id: this.#id,
@@ -53,7 +56,8 @@ class CheckboxRootState {
 	};
 
 	#toggle = () => {
-		if (this.checked.current === "indeterminate") {
+		if (this.indeterminate.current) {
+			this.indeterminate.current = false;
 			this.checked.current = true;
 		} else {
 			this.checked.current = !this.checked.current;
@@ -72,10 +76,13 @@ class CheckboxRootState {
 				role: "checkbox",
 				type: "button",
 				disabled: this.disabled.current,
-				"aria-checked": getAriaChecked(this.checked.current),
+				"aria-checked": getAriaChecked(this.checked.current, this.indeterminate.current),
 				"aria-required": getAriaRequired(this.required.current),
 				"data-disabled": getDataDisabled(this.disabled.current),
-				"data-state": getCheckboxDataState(this.checked.current),
+				"data-state": getCheckboxDataState(
+					this.checked.current,
+					this.indeterminate.current
+				),
 				[CHECKBOX_ROOT_ATTR]: "",
 				//
 				onclick: this.#onclick,
@@ -115,8 +122,8 @@ class CheckboxInputState {
 // HELPERS
 //
 
-function getCheckboxDataState(checked: boolean | "indeterminate") {
-	if (checked === "indeterminate") {
+function getCheckboxDataState(checked: boolean, indeterminate: boolean) {
+	if (indeterminate) {
 		return "indeterminate";
 	}
 	return checked ? "checked" : "unchecked";

--- a/packages/bits-ui/src/lib/bits/checkbox/components/checkbox.svelte
+++ b/packages/bits-ui/src/lib/bits/checkbox/components/checkbox.svelte
@@ -16,6 +16,9 @@
 		value = "on",
 		id = useId(),
 		controlledChecked = false,
+		indeterminate = $bindable(false),
+		controlledIndeterminate = false,
+		onIndeterminateChange,
 		child,
 		...restProps
 	}: CheckboxRootProps = $props();
@@ -41,17 +44,33 @@
 			() => ref,
 			(v) => (ref = v)
 		),
+		indeterminate: box.with(
+			() => indeterminate,
+			(v) => {
+				if (controlledIndeterminate) {
+					onIndeterminateChange?.(v);
+				} else {
+					indeterminate = v;
+					onIndeterminateChange?.(v);
+				}
+			}
+		),
 	});
 
 	const mergedProps = $derived(mergeProps({ ...restProps }, rootState.props));
 </script>
 
 {#if child}
-	{@render child({ props: mergedProps, checked: rootState.checked.current })}
+	{@render child({
+		props: mergedProps,
+		checked: rootState.checked.current,
+		indeterminate: rootState.indeterminate.current,
+	})}
 {:else}
 	<button {...mergedProps}>
 		{@render children?.({
 			checked: rootState.checked.current,
+			indeterminate: rootState.indeterminate.current,
 		})}
 	</button>
 {/if}

--- a/packages/bits-ui/src/lib/bits/checkbox/types.ts
+++ b/packages/bits-ui/src/lib/bits/checkbox/types.ts
@@ -1,7 +1,7 @@
 import type { OnChangeFn, WithChild, Without } from "$lib/internal/types.js";
 import type { BitsPrimitiveButtonAttributes } from "$lib/shared/attributes.js";
 
-export type CheckboxRootSnippetProps = { checked: boolean | "indeterminate" };
+export type CheckboxRootSnippetProps = { checked: boolean; indeterminate: boolean };
 
 export type CheckboxRootPropsWithoutHTML = WithChild<
 	{
@@ -39,16 +39,15 @@ export type CheckboxRootPropsWithoutHTML = WithChild<
 		 * The checked state of the checkbox. It can be one of:
 		 * - `true` for checked
 		 * - `false` for unchecked
-		 * - `"indeterminate"` for indeterminate
 		 *
 		 * @defaultValue false
 		 */
-		checked?: boolean | "indeterminate" | undefined;
+		checked?: boolean;
 
 		/**
 		 * A callback function called when the checked state changes.
 		 */
-		onCheckedChange?: OnChangeFn<boolean | "indeterminate">;
+		onCheckedChange?: OnChangeFn<boolean>;
 
 		/**
 		 * Whether or not the checkbox is controlled or not. If `true`, the checkbox will not update
@@ -59,6 +58,28 @@ export type CheckboxRootPropsWithoutHTML = WithChild<
 		 * @defaultValue false
 		 */
 		controlledChecked?: boolean;
+
+		/**
+		 * Whether the checkbox is in an indeterminate state or not.
+		 *
+		 * @defaultValue false
+		 */
+		indeterminate?: boolean;
+
+		/**
+		 * A callback function called when the indeterminate state changes.
+		 */
+		onIndeterminateChange?: OnChangeFn<boolean>;
+
+		/**
+		 * Whether the indeterminate state is controlled or not. If `true`, the checkbox will
+		 * not update the indeterminate state internally, instead it will call
+		 * `onIndeterminateChange` when it would have otherwise, and it is up to you to update
+		 * the `indeterminate` prop that is passed to the component.
+		 *
+		 * @defaultValue false
+		 */
+		controlledIndeterminate?: boolean;
 	},
 	CheckboxRootSnippetProps
 >;

--- a/packages/bits-ui/src/lib/bits/menu/components/menu-checkbox-item.svelte
+++ b/packages/bits-ui/src/lib/bits/menu/components/menu-checkbox-item.svelte
@@ -16,6 +16,9 @@
 		onSelect = noop,
 		controlledChecked = false,
 		closeOnSelect = true,
+		indeterminate = false,
+		controlledIndeterminate = false,
+		onIndeterminateChange = noop,
 		...restProps
 	}: MenuCheckboxItemProps = $props();
 
@@ -39,6 +42,17 @@
 			(v) => (ref = v)
 		),
 		closeOnSelect: box.with(() => closeOnSelect),
+		indeterminate: box.with(
+			() => indeterminate,
+			(v) => {
+				if (controlledIndeterminate) {
+					onIndeterminateChange(v);
+				} else {
+					indeterminate = v;
+					onIndeterminateChange(v);
+				}
+			}
+		),
 	});
 
 	function handleSelect(e: Event) {
@@ -51,9 +65,9 @@
 </script>
 
 {#if child}
-	{@render child({ props: mergedProps, checked })}
+	{@render child({ props: mergedProps, ...checkboxItemState.snippetProps })}
 {:else}
 	<div {...mergedProps}>
-		{@render children?.({ checked })}
+		{@render children?.(checkboxItemState.snippetProps)}
 	</div>
 {/if}

--- a/packages/bits-ui/src/lib/bits/menu/menu.svelte.ts
+++ b/packages/bits-ui/src/lib/bits/menu/menu.svelte.ts
@@ -651,34 +651,41 @@ class MenuSubTriggerState {
 }
 
 type MenuCheckboxItemStateProps = WritableBoxedValues<{
-	checked: boolean | "indeterminate";
+	checked: boolean;
+	indeterminate: boolean;
 }>;
 
 class MenuCheckboxItemState {
 	#item: MenuItemState;
 	#checked: MenuCheckboxItemStateProps["checked"];
+	#indeterminate: MenuCheckboxItemStateProps["indeterminate"];
 
 	constructor(props: MenuCheckboxItemStateProps, item: MenuItemState) {
 		this.#item = item;
 		this.#checked = props.checked;
+		this.#indeterminate = props.indeterminate;
 	}
 
 	toggleChecked = () => {
-		if (this.#checked.current === true) {
-			this.#checked.current = false;
-		} else if (this.#checked.current === false) {
+		if (this.#indeterminate.current) {
+			this.#indeterminate.current = false;
 			this.#checked.current = true;
-		} else if (this.#checked.current === "indeterminate") {
-			this.#checked.current = true;
+		} else {
+			this.#checked.current = !this.#checked.current;
 		}
 	};
+
+	snippetProps = $derived.by(() => ({
+		checked: this.#checked.current,
+		indeterminate: this.#indeterminate.current,
+	}));
 
 	props = $derived.by(
 		() =>
 			({
 				...this.#item.props,
 				role: "menuitemcheckbox",
-				"aria-checked": getAriaChecked(this.#checked.current),
+				"aria-checked": getAriaChecked(this.#checked.current, this.#indeterminate.current),
 				"data-state": getCheckedState(this.#checked.current),
 				[this.#item.root.getAttr("checkbox-item")]: "",
 			}) as const
@@ -874,7 +881,7 @@ class MenuRadioItemState {
 				[this.#group.root.getAttr("radio-item")]: "",
 				...this.#item.props,
 				role: "menuitemradio",
-				"aria-checked": getAriaChecked(this.isChecked),
+				"aria-checked": getAriaChecked(this.isChecked, false),
 				"data-state": getCheckedState(this.isChecked),
 			}) as const
 	);

--- a/packages/bits-ui/src/lib/bits/menu/types.ts
+++ b/packages/bits-ui/src/lib/bits/menu/types.ts
@@ -120,21 +120,23 @@ export type MenuItemPropsWithoutHTML<U extends Record<PropertyKey, unknown> = { 
 export type MenuItemProps = MenuItemPropsWithoutHTML &
 	Without<BitsPrimitiveDivAttributes, MenuItemPropsWithoutHTML>;
 
-export type MenuCheckboxItemSnippetProps = { checked: boolean | "indeterminate" };
+export type MenuCheckboxItemSnippetProps = { checked: boolean; indeterminate: boolean };
 
 export type MenuCheckboxItemPropsWithoutHTML =
 	MenuItemPropsWithoutHTML<MenuCheckboxItemSnippetProps> & {
 		/**
-		 * The checked state of the checkbox item.
+		 * The checked state of the checkbox. It can be one of:
+		 * - `true` for checked
+		 * - `false` for unchecked
 		 *
-		 * Supports two-way binding with `bind:checked`.
+		 * @defaultValue false
 		 */
-		checked?: boolean | "indeterminate";
+		checked?: boolean;
 
 		/**
 		 * A callback that is fired when the checked state changes.
 		 */
-		onCheckedChange?: OnChangeFn<boolean | "indeterminate">;
+		onCheckedChange?: OnChangeFn<boolean>;
 
 		/**
 		 * Whether or not the checked state is controlled or not. If `true`, the component will not
@@ -145,6 +147,28 @@ export type MenuCheckboxItemPropsWithoutHTML =
 		 * @defaultValue false
 		 */
 		controlledChecked?: boolean;
+
+		/**
+		 * Whether the checkbox is in an indeterminate state or not.
+		 *
+		 * @defaultValue false
+		 */
+		indeterminate?: boolean;
+
+		/**
+		 * A callback function called when the indeterminate state changes.
+		 */
+		onIndeterminateChange?: OnChangeFn<boolean>;
+
+		/**
+		 * Whether the indeterminate state is controlled or not. If `true`, the checkbox will
+		 * not update the indeterminate state internally, instead it will call
+		 * `onIndeterminateChange` when it would have otherwise, and it is up to you to update
+		 * the `indeterminate` prop that is passed to the component.
+		 *
+		 * @defaultValue false
+		 */
+		controlledIndeterminate?: boolean;
 
 		/**
 		 * Whether or not the menu item should close when selected.

--- a/packages/bits-ui/src/lib/bits/radio-group/radio-group.svelte.ts
+++ b/packages/bits-ui/src/lib/bits/radio-group/radio-group.svelte.ts
@@ -149,7 +149,7 @@ class RadioGroupItemState {
 				"data-orientation": this.#root.orientation.current,
 				"data-disabled": getDataDisabled(this.#isDisabled),
 				"data-state": this.#isChecked ? "checked" : "unchecked",
-				"aria-checked": getAriaChecked(this.#isChecked),
+				"aria-checked": getAriaChecked(this.#isChecked, false),
 				[RADIO_GROUP_ITEM_ATTR]: "",
 				type: "button",
 				role: "radio",

--- a/packages/bits-ui/src/lib/bits/switch/switch.svelte.ts
+++ b/packages/bits-ui/src/lib/bits/switch/switch.svelte.ts
@@ -79,7 +79,7 @@ class SwitchRootState {
 				id: this.#id.current,
 				role: "switch",
 				disabled: getDisabled(this.disabled.current),
-				"aria-checked": getAriaChecked(this.checked.current),
+				"aria-checked": getAriaChecked(this.checked.current, false),
 				"aria-required": getAriaRequired(this.required.current),
 				[ROOT_ATTR]: "",
 				//

--- a/packages/bits-ui/src/lib/bits/toggle-group/toggle-group.svelte.ts
+++ b/packages/bits-ui/src/lib/bits/toggle-group/toggle-group.svelte.ts
@@ -204,7 +204,7 @@ class ToggleGroupItemState {
 	isPressed = $derived.by(() => this.#root.includesItem(this.#value.current));
 
 	#ariaChecked = $derived.by(() => {
-		return this.#root.isMulti ? undefined : getAriaChecked(this.isPressed);
+		return this.#root.isMulti ? undefined : getAriaChecked(this.isPressed, false);
 	});
 
 	#ariaPressed = $derived.by(() => {

--- a/packages/bits-ui/src/lib/bits/toolbar/toolbar.svelte.ts
+++ b/packages/bits-ui/src/lib/bits/toolbar/toolbar.svelte.ts
@@ -240,7 +240,7 @@ class ToolbarGroupItemState {
 	isPressed = $derived.by(() => this.#group.includesItem(this.#value.current));
 
 	#ariaChecked = $derived.by(() => {
-		return this.#group.isMulti ? undefined : getAriaChecked(this.isPressed);
+		return this.#group.isMulti ? undefined : getAriaChecked(this.isPressed, false);
 	});
 
 	#ariaPressed = $derived.by(() => {

--- a/packages/bits-ui/src/lib/internal/attrs.ts
+++ b/packages/bits-ui/src/lib/internal/attrs.ts
@@ -30,11 +30,14 @@ export function getAriaSelected(condition: boolean): "true" | "false" {
 	return condition ? "true" : "false";
 }
 
-export function getAriaChecked(condition: boolean | "indeterminate"): "true" | "false" | "mixed" {
-	if (condition === "indeterminate") {
+export function getAriaChecked(
+	checked: boolean,
+	indeterminate: boolean
+): "true" | "false" | "mixed" {
+	if (indeterminate) {
 		return "mixed";
 	}
-	return condition ? "true" : "false";
+	return checked ? "true" : "false";
 }
 
 export function getAriaOrientation(

--- a/packages/tests/src/tests/checkbox/checkbox-test.svelte
+++ b/packages/tests/src/tests/checkbox/checkbox-test.svelte
@@ -7,9 +7,13 @@
 <main>
 	<p data-testid="binding">{checked}</p>
 	<Checkbox.Root name="terms" data-testid="root" bind:checked {...restProps}>
-		{#snippet children({ checked })}
+		{#snippet children({ checked, indeterminate })}
 			<span data-testid="indicator">
-				{checked}
+				{#if indeterminate}
+					indeterminate
+				{:else}
+					{checked}
+				{/if}
 			</span>
 		{/snippet}
 	</Checkbox.Root>

--- a/packages/tests/src/tests/checkbox/checkbox.test.ts
+++ b/packages/tests/src/tests/checkbox/checkbox.test.ts
@@ -50,7 +50,7 @@ describe("checkbox", () => {
 	});
 
 	it("should be able to be indeterminate", async () => {
-		const { getByTestId, root, input } = setup({ checked: "indeterminate" });
+		const { getByTestId, root, input } = setup({ indeterminate: true });
 		const indicator = getByTestId("indicator");
 		expect(root).toHaveAttribute("data-state", "indeterminate");
 		expect(root).toHaveAttribute("aria-checked", "mixed");

--- a/sites/docs/content/components/checkbox.md
+++ b/sites/docs/content/components/checkbox.md
@@ -42,8 +42,8 @@ Here's an overview of how the Checkbox component is structured in code:
 </script>
 
 <Checkbox.Root>
-	{#snippet children({ checked })}
-		{#if checked === "indeterminate"}
+	{#snippet children({ checked, indeterminate })}
+		{#if indeterminate}
 			-
 		{:else if checked}
 			✅
@@ -75,8 +75,8 @@ It's recommended to use the `Checkbox` primitive to create your own custom check
 </script>
 
 <Checkbox.Root bind:checked bind:ref {...restProps}>
-	{#snippet children({ checked })}
-		{#if checked === "indeterminate"}
+	{#snippet children({ checked, indeterminate })}
+		{#if indeterminate}
 			-
 		{:else if checked}
 			✅
@@ -179,6 +179,95 @@ To implement controlled state:
 #### When to Use
 
 -   Implementing complex checked/unchecked logic
+-   Coordinating multiple UI elements
+-   Debugging state-related issues
+
+<Callout>
+
+While powerful, fully controlled state should be used judiciously as it increases complexity and can cause unexpected behaviors if not handled carefully.
+
+For more in-depth information on controlled components and advanced state management techniques, refer to our [Controlled State](/docs/controlled-state) documentation.
+
+</Callout>
+
+## Managing Indeterminate State
+
+Bits UI offers several approaches to manage and synchronize the Checkbox's `indeterminate` state, catering to different levels of control and integration needs.
+
+### 1. Two-Way Binding
+
+For seamless state synchronization, use Svelte's `bind:indeterminate` directive. This method automatically keeps your local state in sync with the checkbox's internal state.
+
+```svelte
+<script lang="ts">
+	import MyCheckbox from "$lib/components/MyCheckbox.svelte";
+	let myIndeterminate = $state(true);
+</script>
+
+<button onclick={() => (myIndeterminate = false)}> clear indeterminate </button>
+
+<MyCheckbox bind:indeterminate={myIndeterminate} />
+```
+
+#### Key Benefits
+
+-   Simplifies state management
+-   Automatically updates `myIndeterminate` when the checkbox changes (e.g., via clicking on the checkbox)
+-   Allows external control (e.g., checking via a separate button/programmatically)
+
+### 2. Change Handler
+
+For more granular control or to perform additional logic on state changes, use the `onIndeterminateChange` prop. This approach is useful when you need to execute custom logic alongside state updates.
+
+```svelte
+<script lang="ts">
+	import MyCheckbox from "$lib/components/MyCheckbox.svelte";
+	let myIndeterminate = $state(true);
+</script>
+
+<MyCheckbox
+	indeterminate={myIndeterminate}
+	onIndeterminateChange={(indeterminate) => {
+		myIndeterminate = indeterminate;
+		// additional logic here.
+	}}
+/>
+```
+
+#### Use Cases
+
+-   Implementing custom behaviors
+-   Integrating with external state management solutions
+-   Triggering side effects (e.g., logging, data fetching)
+
+### 3. Fully Controlled
+
+For complete control over the checkbox's checked state, use the `controlledIndeterminate` prop. This approach requires you to manually manage the `indeterminate` state, giving you full control over when and how the checkbox responds to change events.
+
+To implement controlled state:
+
+1. Set the `controlledIndeterminate` prop to `true` on the `Checkbox.Root` component.
+2. Provide a `indeterminate` prop to `Checkbox.Root`, which should be a variable holding the current state.
+3. Implement an `onIndeterminateChange` handler to update the state when the internal state changes.
+
+```svelte
+<script lang="ts">
+	import { Checkbox } from "bits-ui";
+	let myIndeterminate = $state(true);
+</script>
+
+<Checkbox.Root
+	controlledIndeterminate
+	indeterminate={myIndeterminate}
+	onIndeterminateChange={(i) => (myIndeterminate = i)}
+>
+	<!-- ... -->
+</Checkbox.Root>
+```
+
+#### When to Use
+
+-   Implementing complex indeterminate logic
 -   Coordinating multiple UI elements
 -   Debugging state-related issues
 

--- a/sites/docs/content/components/context-menu.md
+++ b/sites/docs/content/components/context-menu.md
@@ -242,8 +242,10 @@ You can use the `ContextMenu.CheckboxItem` component to create a `menuitemcheckb
 </script>
 
 <ContextMenu.CheckboxItem bind:checked={notifications}>
-	{#snippet children({ checked })}
-		{#if checked}
+	{#snippet children({ checked, indeterminate })}
+		{#if indeterminate}
+			-
+		{:else if checked}
 			✅
 		{/if}
 		Notifications

--- a/sites/docs/content/components/dropdown-menu.md
+++ b/sites/docs/content/components/dropdown-menu.md
@@ -256,8 +256,10 @@ You can use the `DropdownMenu.CheckboxItem` component to create a `menuitemcheck
 </script>
 
 <DropdownMenu.CheckboxItem bind:checked={notifications}>
-	{#snippet children({ checked })}
-		{#if checked}
+	{#snippet children({ checked, indeterminate })}
+		{#if indeterminate}
+			-
+		{:else if checked}
 			✅
 		{/if}
 		Notifications

--- a/sites/docs/content/components/menubar.md
+++ b/sites/docs/content/components/menubar.md
@@ -200,8 +200,10 @@ You can use the `Menubar.CheckboxItem` component to create a `menuitemcheckbox` 
 </script>
 
 <Menubar.CheckboxItem bind:checked={notifications}>
-	{#snippet children({ checked })}
-		{#if checked}
+	{#snippet children({ checked, indeterminate })}
+		{#if indeterminate}
+			-
+		{:else if checked}
 			✅
 		{/if}
 		Notifications

--- a/sites/docs/src/lib/components/demos/checkbox-demo-custom.svelte
+++ b/sites/docs/src/lib/components/demos/checkbox-demo-custom.svelte
@@ -26,12 +26,12 @@
 			name="hello"
 			{...restProps}
 		>
-			{#snippet children({ checked })}
+			{#snippet children({ checked, indeterminate })}
 				<div class="inline-flex items-center justify-center text-background">
-					{#if checked === true}
-						<Check class="size-[15px]" weight="bold" />
-					{:else if checked === "indeterminate"}
+					{#if indeterminate}
 						<Minus class="size-[15px]" weight="bold" />
+					{:else if checked}
+						<Check class="size-[15px]" weight="bold" />
 					{/if}
 				</div>
 			{/snippet}

--- a/sites/docs/src/lib/components/demos/checkbox-demo.svelte
+++ b/sites/docs/src/lib/components/demos/checkbox-demo.svelte
@@ -10,13 +10,14 @@
 		aria-labelledby="terms-label"
 		class="peer inline-flex size-[25px] items-center justify-center rounded-md border border-muted bg-foreground transition-all duration-150 ease-in-out active:scale-98 data-[state=unchecked]:border-border-input data-[state=unchecked]:bg-background data-[state=unchecked]:hover:border-dark-40"
 		name="hello"
+		indeterminate
 	>
-		{#snippet children({ checked })}
+		{#snippet children({ checked, indeterminate })}
 			<div class="inline-flex items-center justify-center text-background">
-				{#if checked === true}
-					<Check class="size-[15px]" weight="bold" />
-				{:else if checked === "indeterminate"}
+				{#if indeterminate}
 					<Minus class="size-[15px]" weight="bold" />
+				{:else if checked}
+					<Check class="size-[15px]" weight="bold" />
 				{/if}
 			</div>
 		{/snippet}

--- a/sites/docs/src/lib/components/demos/dropdown-menu-demo-transition.svelte
+++ b/sites/docs/src/lib/components/demos/dropdown-menu-demo-transition.svelte
@@ -11,7 +11,7 @@
 	import DotOutline from "phosphor-svelte/lib/DotOutline";
 	import { fly } from "svelte/transition";
 
-	let notifications = $state<"indeterminate" | boolean>(false);
+	let notifications = $state<boolean>(false);
 	let invited = $state("");
 </script>
 

--- a/sites/docs/src/lib/components/demos/dropdown-menu-demo.svelte
+++ b/sites/docs/src/lib/components/demos/dropdown-menu-demo.svelte
@@ -10,7 +10,7 @@
 	import Check from "phosphor-svelte/lib/Check";
 	import DotOutline from "phosphor-svelte/lib/DotOutline";
 
-	let notifications = $state<"indeterminate" | boolean>(false);
+	let notifications = $state<boolean>(false);
 	let invited = $state("");
 </script>
 

--- a/sites/docs/src/lib/components/demos/label-demo.svelte
+++ b/sites/docs/src/lib/components/demos/label-demo.svelte
@@ -11,12 +11,12 @@
 		class="peer inline-flex size-[25px] items-center justify-center rounded-md border border-muted bg-foreground transition-all duration-150 ease-in-out active:scale-98 data-[state=unchecked]:border-border-input data-[state=unchecked]:bg-background data-[state=unchecked]:hover:border-dark-40"
 		name="hello"
 	>
-		{#snippet children({ checked })}
+		{#snippet children({ checked, indeterminate })}
 			<div class="inline-flex items-center justify-center text-background">
-				{#if checked === true}
-					<Check class="size-[15px]" weight="bold" />
-				{:else if checked === "indeterminate"}
+				{#if indeterminate}
 					<Minus class="size-[15px]" weight="bold" />
+				{:else if checked}
+					<Check class="size-[15px]" weight="bold" />
 				{/if}
 			</div>
 		{/snippet}

--- a/sites/docs/src/lib/content/api-reference/checkbox.api.ts
+++ b/sites/docs/src/lib/content/api-reference/checkbox.api.ts
@@ -1,18 +1,20 @@
 import type { CheckboxRootPropsWithoutHTML } from "bits-ui";
 import {
 	controlledCheckedProp,
+	controlledIndeterminateProp,
 	createApiSchema,
 	createBooleanProp,
 	createDataAttrSchema,
 	createEnumDataAttr,
 	createFunctionProp,
 	createStringProp,
-	createUnionProp,
 	withChildProps,
 } from "./helpers.js";
 import {
-	CheckboxRootCheckedProp,
+	CheckboxRootChildSnippetProps,
+	CheckboxRootChildrenSnippetProps,
 	CheckboxRootOnCheckedChangeProp,
+	CheckboxRootOnIndeterminateChangeProp,
 	CheckboxRootStateDataAttr,
 } from "./extended-types/checkbox/index.js";
 import * as C from "$lib/content/constants.js";
@@ -21,13 +23,11 @@ export const root = createApiSchema<CheckboxRootPropsWithoutHTML>({
 	title: "Root",
 	description: "The button component used to toggle the state of the checkbox.",
 	props: {
-		checked: createUnionProp({
-			options: ["boolean", "'indeterminate'"],
+		checked: createBooleanProp({
 			default: C.FALSE,
 			description:
 				"The checkbox button's checked state. This can be a boolean or the string 'indeterminate', which would typically display a dash in the checkbox.",
 			bindable: true,
-			definition: CheckboxRootCheckedProp,
 		}),
 		onCheckedChange: createFunctionProp({
 			definition: CheckboxRootOnCheckedChangeProp,
@@ -35,6 +35,16 @@ export const root = createApiSchema<CheckboxRootPropsWithoutHTML>({
 				"A callback that is fired when the checkbox button's checked state changes.",
 		}),
 		controlledChecked: controlledCheckedProp,
+		indeterminate: createBooleanProp({
+			default: C.FALSE,
+			description: "Whether the checkbox is an indeterminate state or not.",
+			bindable: true,
+		}),
+		onIndeterminateChange: createFunctionProp({
+			definition: CheckboxRootOnIndeterminateChangeProp,
+			description: "A callback that is fired when the indeterminate state changes.",
+		}),
+		controlledIndeterminate: controlledIndeterminateProp,
 		disabled: createBooleanProp({
 			default: C.FALSE,
 			description:
@@ -52,7 +62,11 @@ export const root = createApiSchema<CheckboxRootPropsWithoutHTML>({
 			description:
 				"The value of the checkbox. This is what is submitted with the form when the checkbox is checked.",
 		}),
-		...withChildProps({ elType: "HTMLButtonElement" }),
+		...withChildProps({
+			elType: "HTMLButtonElement",
+			childDef: CheckboxRootChildSnippetProps,
+			childrenDef: CheckboxRootChildrenSnippetProps,
+		}),
 	},
 	dataAttributes: [
 		createEnumDataAttr({

--- a/sites/docs/src/lib/content/api-reference/extended-types/checkbox/checkbox-root-checked-prop.md
+++ b/sites/docs/src/lib/content/api-reference/extended-types/checkbox/checkbox-root-checked-prop.md
@@ -1,3 +1,0 @@
-```ts
-boolean | "indeterminate";
-```

--- a/sites/docs/src/lib/content/api-reference/extended-types/checkbox/checkbox-root-child-snippet-props.md
+++ b/sites/docs/src/lib/content/api-reference/extended-types/checkbox/checkbox-root-child-snippet-props.md
@@ -1,6 +1,7 @@
 ```ts
 type ChildSnippetProps = {
-	checked: boolean | "indeterminate";
+	checked: boolean;
+	indeterminate: boolean;
 	props: Record<string, unknown>;
-};
+}
 ```

--- a/sites/docs/src/lib/content/api-reference/extended-types/checkbox/checkbox-root-child-snippet-props.md
+++ b/sites/docs/src/lib/content/api-reference/extended-types/checkbox/checkbox-root-child-snippet-props.md
@@ -3,5 +3,5 @@ type ChildSnippetProps = {
 	checked: boolean;
 	indeterminate: boolean;
 	props: Record<string, unknown>;
-}
+};
 ```

--- a/sites/docs/src/lib/content/api-reference/extended-types/checkbox/checkbox-root-children-snippet-props.md
+++ b/sites/docs/src/lib/content/api-reference/extended-types/checkbox/checkbox-root-children-snippet-props.md
@@ -1,0 +1,6 @@
+```ts
+type ChildrenSnippetProps = {
+	checked: boolean;
+	indeterminate: boolean;
+}
+```

--- a/sites/docs/src/lib/content/api-reference/extended-types/checkbox/checkbox-root-children-snippet-props.md
+++ b/sites/docs/src/lib/content/api-reference/extended-types/checkbox/checkbox-root-children-snippet-props.md
@@ -2,5 +2,5 @@
 type ChildrenSnippetProps = {
 	checked: boolean;
 	indeterminate: boolean;
-}
+};
 ```

--- a/sites/docs/src/lib/content/api-reference/extended-types/checkbox/checkbox-root-on-checked-change-prop.md
+++ b/sites/docs/src/lib/content/api-reference/extended-types/checkbox/checkbox-root-on-checked-change-prop.md
@@ -1,3 +1,3 @@
 ```ts
-(checked: boolean | 'indeterminate') => void
+(checked: boolean) => void
 ```

--- a/sites/docs/src/lib/content/api-reference/extended-types/checkbox/checkbox-root-on-indeterminate-change.md
+++ b/sites/docs/src/lib/content/api-reference/extended-types/checkbox/checkbox-root-on-indeterminate-change.md
@@ -1,0 +1,3 @@
+```ts
+(indeterminate: boolean) => void
+```

--- a/sites/docs/src/lib/content/api-reference/extended-types/checkbox/checkbox-root-state-data-attr.md
+++ b/sites/docs/src/lib/content/api-reference/extended-types/checkbox/checkbox-root-state-data-attr.md
@@ -1,3 +1,3 @@
 ```ts
-"checked" | "unchecked" | "indeterminate"
+"checked" | "unchecked" | "indeterminate";
 ```

--- a/sites/docs/src/lib/content/api-reference/extended-types/checkbox/checkbox-root-state-data-attr.md
+++ b/sites/docs/src/lib/content/api-reference/extended-types/checkbox/checkbox-root-state-data-attr.md
@@ -1,3 +1,3 @@
 ```ts
-"checked" | "unchecked" | "indeterminate";
+"checked" | "unchecked" | "indeterminate"
 ```

--- a/sites/docs/src/lib/content/api-reference/extended-types/checkbox/index.ts
+++ b/sites/docs/src/lib/content/api-reference/extended-types/checkbox/index.ts
@@ -1,3 +1,5 @@
-export { default as CheckboxRootCheckedProp } from "./checkbox-root-checked-prop.md";
 export { default as CheckboxRootOnCheckedChangeProp } from "./checkbox-root-on-checked-change-prop.md";
 export { default as CheckboxRootStateDataAttr } from "./checkbox-root-state-data-attr.md";
+export { default as CheckboxRootOnIndeterminateChangeProp } from "./checkbox-root-on-indeterminate-change.md";
+export { default as CheckboxRootChildSnippetProps } from "./checkbox-root-child-snippet-props.md";
+export { default as CheckboxRootChildrenSnippetProps } from "./checkbox-root-children-snippet-props.md";

--- a/sites/docs/src/lib/content/api-reference/extended-types/shared/checked-children-snippet-props.md
+++ b/sites/docs/src/lib/content/api-reference/extended-types/shared/checked-children-snippet-props.md
@@ -1,5 +1,0 @@
-```ts
-type ChildrenSnippetProps = {
-	checked: boolean | "indeterminate";
-};
-```

--- a/sites/docs/src/lib/content/api-reference/extended-types/shared/checked-prop.md
+++ b/sites/docs/src/lib/content/api-reference/extended-types/shared/checked-prop.md
@@ -1,3 +1,0 @@
-```ts
-boolean | "indeterminate";
-```

--- a/sites/docs/src/lib/content/api-reference/extended-types/shared/date-on-placeholder-change-prop.md
+++ b/sites/docs/src/lib/content/api-reference/extended-types/shared/date-on-placeholder-change-prop.md
@@ -1,3 +1,0 @@
-```ts
-(date: DateValue) => void
-```

--- a/sites/docs/src/lib/content/api-reference/extended-types/shared/index.ts
+++ b/sites/docs/src/lib/content/api-reference/extended-types/shared/index.ts
@@ -1,13 +1,9 @@
 export { default as CalendarOnValueChangeProp } from "./calendar-on-value-change-prop.md";
 export { default as CalendarValueProp } from "./calendar-value-prop.md";
-export { default as CheckedChildSnippetProps } from "./checked-child-snippet-props.md";
-export { default as CheckedChildrenSnippetProps } from "./checked-children-snippet-props.md";
-export { default as CheckedProp } from "./checked-prop.md";
 export { default as ChildDefaultSnippetProps } from "./child-default-snippet-props.md";
 export { default as DateFieldInputChildSnippetProps } from "./date-field-input-child-snippet-props.md";
 export { default as DateFieldInputChildrenSnippetProps } from "./date-field-input-children-snippet-props.md";
 export { default as DateMatcherProp } from "./date-matcher-prop.md";
-export { default as DateOnPlaceholderChangeProp } from "./date-on-placeholder-change-prop.md";
 export { default as DateOnRangeChangeProp } from "./date-on-range-change-prop.md";
 export { default as DateRangeProp } from "./date-range-prop.md";
 export { default as DateValueProp } from "./date-value-prop.md";
@@ -22,7 +18,6 @@ export { default as InteractOutsideBehaviorProp } from "./interact-outside-behav
 export { default as MonthProp } from "./month-prop.md";
 export { default as NoopProp } from "./noop-prop.md";
 export { default as OnChangeStringOrArrayProp } from "./on-change-string-or-array-prop.md";
-export { default as OnCheckedChangeProp } from "./on-checked-change-prop.md";
 export { default as OnEscapeKeydownProp } from "./on-escape-keydown-prop.md";
 export { default as OnInteractOutsideProp } from "./on-interact-outside-prop.md";
 export { default as OnFocusOutsideProp } from "./on-focus-outside-prop.md";

--- a/sites/docs/src/lib/content/api-reference/extended-types/shared/on-checked-change-prop.md
+++ b/sites/docs/src/lib/content/api-reference/extended-types/shared/on-checked-change-prop.md
@@ -1,3 +1,0 @@
-```ts
-(checked: boolean | 'indeterminate') => void
-```

--- a/sites/docs/src/lib/content/api-reference/helpers.ts
+++ b/sites/docs/src/lib/content/api-reference/helpers.ts
@@ -576,35 +576,41 @@ export const valueDateRangeChangeFn: PropSchema = createFunctionProp({
 export const controlledValueProp = createBooleanProp({
 	default: C.FALSE,
 	description:
-		"Whether or not the value is controlled or not. If `true`, the component will not update the value state internally, instead it will call `onValueChange` when it would have otherwise, and it is up to you to update the `value` prop that is passed to the component.",
+		"Whether or not the `value` is controlled or not. If `true`, the component will not update the `value` state internally, instead it will call `onValueChange` when it would have otherwise, and it is up to you to update the `value` prop that is passed to the component.",
 });
 
 export const controlledPlaceholderProp = createBooleanProp({
 	default: C.FALSE,
 	description:
-		"Whether or not the placeholder is controlled or not. If `true`, the component will not update the placeholder state internally, instead it will call `onPlaceholderChange` when it would have otherwise, and it is up to you to update the `value` prop that is passed to the component.",
+		"Whether or not the `placeholder` is controlled or not. If `true`, the component will not update the `placeholder` state internally, instead it will call `onPlaceholderChange` when it would have otherwise, and it is up to you to update the `placeholder` prop that is passed to the component.",
 });
 
 export const controlledOpenProp = createBooleanProp({
 	default: C.FALSE,
 	description:
-		"Whether or not the open state is controlled or not. If `true`, the component will not update the open state internally, instead it will call `onOpenChange` when it would have otherwise, and it is up to you to update the `open` prop that is passed to the component.",
+		"Whether or not the `open` state is controlled or not. If `true`, the component will not update the `open` state internally, instead it will call `onOpenChange` when it would have otherwise, and it is up to you to update the `open` prop that is passed to the component.",
 });
 
 export const controlledCheckedProp = createBooleanProp({
 	default: C.FALSE,
 	description:
-		"Whether or not the checked state is controlled or not. If `true`, the component will not update the checked state internally, instead it will call `onCheckedChange` when it would have otherwise, and it is up to you to update the `checked` prop that is passed to the component.",
+		"Whether or not the `checked` state is controlled or not. If `true`, the component will not update the `checked` state internally, instead it will call `onCheckedChange` when it would have otherwise, and it is up to you to update the `checked` prop that is passed to the component.",
+});
+
+export const controlledIndeterminateProp = createBooleanProp({
+	default: C.FALSE,
+	description:
+		"Whether or not the `indeterminate` state is controlled or not. If `true`, the component will not update the `indeterminate` state internally, instead it will call `onIndeterminateChange` when it would have otherwise, and it is up to you to update the `indeterminate` prop that is passed to the component.",
 });
 
 export const controlledPressedProp = createBooleanProp({
 	default: C.FALSE,
 	description:
-		"Whether or not the pressed state is controlled or not. If `true`, the component will not update the pressed state internally, instead it will call `onPressedChange` when it would have otherwise, and it is up to you to update the `pressed` prop that is passed to the component.",
+		"Whether or not the `pressed` state is controlled or not. If `true`, the component will not update the `pressed` state internally, instead it will call `onPressedChange` when it would have otherwise, and it is up to you to update the `pressed` prop that is passed to the component.",
 });
 
 export const controlledPageProp = createBooleanProp({
 	default: C.FALSE,
 	description:
-		"Whether or not the page state is controlled or not. If `true`, the component will not update the page state internally, instead it will call `onPageChange` when it would have otherwise, and it is up to you to update the `page` prop that is passed to the component.",
+		"Whether or not the `page` state is controlled or not. If `true`, the component will not update the `page` state internally, instead it will call `onPageChange` when it would have otherwise, and it is up to you to update the `page` prop that is passed to the component.",
 });

--- a/sites/docs/src/lib/content/api-reference/menu.api.ts
+++ b/sites/docs/src/lib/content/api-reference/menu.api.ts
@@ -19,6 +19,7 @@ import {
 	arrowProps,
 	childrenSnippet,
 	controlledCheckedProp,
+	controlledIndeterminateProp,
 	controlledOpenProp,
 	controlledValueProp,
 	createBooleanProp,
@@ -38,11 +39,7 @@ import {
 	withChildProps,
 } from "./helpers.js";
 import {
-	CheckedChildSnippetProps,
-	CheckedChildrenSnippetProps,
-	CheckedProp,
 	NoopProp,
-	OnCheckedChangeProp,
 	OnOpenChangeProp,
 	OnStringValueChangeProp,
 	OpenChildSnippetProps,
@@ -53,6 +50,12 @@ import {
 } from "./extended-types/shared/index.js";
 import { MenuCheckedStateAttr } from "./extended-types/menu/index.js";
 import { RadioGroupStateAttr } from "./extended-types/radio-group/index.js";
+import {
+	CheckboxRootChildSnippetProps,
+	CheckboxRootChildrenSnippetProps,
+	CheckboxRootOnCheckedChangeProp,
+	CheckboxRootOnIndeterminateChangeProp,
+} from "./extended-types/checkbox/index.js";
 import type { APISchema, DataAttrSchema, PropObj } from "$lib/types/index.js";
 import * as C from "$lib/content/constants.js";
 import { enums } from "$lib/content/api-reference/helpers.js";
@@ -171,24 +174,32 @@ const checkboxItemProps = {
 		description:
 			"Whether or not the checkbox menu item is disabled. Disabled items cannot be interacted with and are skipped when navigating with the keyboard.",
 	}),
-	checked: createUnionProp({
-		options: ["boolean", "'indeterminate'"],
+	checked: createBooleanProp({
 		default: C.FALSE,
 		description: "The checkbox menu item's checked state.",
 		bindable: true,
-		definition: CheckedProp,
 	}),
 	onCheckedChange: createFunctionProp({
-		definition: OnCheckedChangeProp,
+		definition: CheckboxRootOnCheckedChangeProp,
 		description:
 			"A callback that is fired when the checkbox menu item's checked state changes.",
 	}),
 	controlledChecked: controlledCheckedProp,
+	indeterminate: createBooleanProp({
+		default: C.FALSE,
+		description: "Whether the checkbox menu item is in an indeterminate state or not.",
+		bindable: true,
+	}),
+	onIndeterminateChange: createFunctionProp({
+		definition: CheckboxRootOnIndeterminateChangeProp,
+		description: "A callback that is fired when the indeterminate state changes.",
+	}),
+	controlledIndeterminate: controlledIndeterminateProp,
 	...omit(sharedItemProps, "child", "children"),
 	...withChildProps({
 		elType: "HTMLDivElement",
-		childrenDef: CheckedChildrenSnippetProps,
-		childDef: CheckedChildSnippetProps,
+		childrenDef: CheckboxRootChildrenSnippetProps,
+		childDef: CheckboxRootChildSnippetProps,
 	}),
 } satisfies PropObj<DropdownMenuCheckboxItemPropsWithoutHTML>;
 


### PR DESCRIPTION
Having the `checked` state be `boolean | 'indeterminate'` is quite annoying, especially considering from a user's perspective, once you leave the `'indeterminate'` state, you can't toggle back to it.

This PR changes the `checked` props to be `boolean` and adds an `indeterminate` prop which is also of type `boolean`.

If you wish to have a checkbox in an indeterminate state, you can simply do the following:

```svelte
<Checkbox.Root indeterminate />
```

By default, when a user clicks an `indeterminate` checkbox, it will change `checked` to `true` and `indeterminate` to `false`.

`indeterminate` can be controlled, so you can programmatically put a checkbox back into the indeterminate state if you wish, using the normal state management strategies (`bind:indeterminate`, `onIndeterminateChange`, `controlledIndeterminate`).

I've wanted to make this change for some time and many others have expressed frustration with always having to conditionally check the type when working with things that expect a `boolean`.

Additionally, the snippet props for the `Checkbox` and `*Menu.CheckboxItem` components have been adjusted to expose both a `checked` and `indeterminate` prop:

```svelte
<Checkbox.Root>
	{#snippet children({ checked, indeterminate })}
		{#if indeterminate}
			-
		{:else if checked}
			✅
		{/if}	
	{/snippet}
</Checkbox.Root>
```

Closes #885 