### PR TITLE
feat: add `onStateChange` callback to Command component

### DIFF
--- a/.changeset/clever-terms-argue.md
+++ b/.changeset/clever-terms-argue.md
@@ -1,0 +1,5 @@
+---
+"bits-ui": patch
+---
+
+feat: add `onStateChange` callback to `Command` component

--- a/packages/bits-ui/src/lib/bits/command/components/command.svelte
+++ b/packages/bits-ui/src/lib/bits/command/components/command.svelte
@@ -11,6 +11,7 @@
 		ref = $bindable(null),
 		value = $bindable(""),
 		onValueChange = noop,
+		onStateChange = noop,
 		loop = false,
 		shouldFilter = true,
 		filter = defaultFilter,
@@ -45,6 +46,7 @@
 		),
 		vimBindings: box.with(() => vimBindings),
 		disablePointerSelection: box.with(() => disablePointerSelection),
+		onStateChange: box.with(() => onStateChange),
 	});
 
 	const mergedProps = $derived(mergeProps(restProps, rootState.props));

--- a/packages/bits-ui/src/lib/bits/command/types.ts
+++ b/packages/bits-ui/src/lib/bits/command/types.ts
@@ -47,6 +47,11 @@ export type CommandRootPropsWithoutHTML = WithChild<{
 	filter?: (value: string, search: string, keywords?: string[]) => number;
 
 	/**
+	 * A function that is called when the command state changes.
+	 */
+	onStateChange?: (state: Readonly<CommandState>) => void;
+
+	/**
 	 * Optionally provide or bind to the selected command menu item.
 	 */
 	value?: string;

--- a/sites/docs/src/lib/content/api-reference/command.api.ts
+++ b/sites/docs/src/lib/content/api-reference/command.api.ts
@@ -13,7 +13,7 @@ import type {
 	CommandViewportPropsWithoutHTML,
 } from "bits-ui";
 import { NoopProp, OnStringValueChangeProp } from "./extended-types/shared/index.js";
-import { CommandFilterProp } from "./extended-types/command/index.js";
+import { CommandFilterProp, CommandOnStateChangeProp } from "./extended-types/command/index.js";
 import {
 	controlledValueProp,
 	createApiSchema,
@@ -55,6 +55,11 @@ const root = createApiSchema<CommandRootPropsWithoutHTML>({
 			default: C.TRUE,
 			description:
 				"Whether or not the command menu should filter items. This is useful when you want to apply custom filtering logic outside of the Command component.",
+		}),
+		onStateChange: createFunctionProp({
+			definition: CommandOnStateChangeProp,
+			description: `A callback that fires when the command's internal state changes. This callback receives a readonly snapshot of the current state.
+			The callback is debounced and only fires once per batch of related updates (e.g., when typing triggers filtering and selection changes).`,
 		}),
 		loop: createBooleanProp({
 			default: C.FALSE,

--- a/sites/docs/src/lib/content/api-reference/extended-types/command/command-on-state-change-prop.md
+++ b/sites/docs/src/lib/content/api-reference/extended-types/command/command-on-state-change-prop.md
@@ -1,3 +1,19 @@
 ```ts
-(state: Readonly<CommandState>) => void;
+type CommandState = {
+	/** The value of the search query */
+	search: string;
+	/** The value of the selected command menu item */
+	value: string;
+	/** The filtered items */
+	filtered: {
+		/** The count of all visible items. */
+		count: number;
+		/** Map from visible item id to its search store. */
+		items: Map<string, number>;
+		/** Set of groups with at least one visible item. */
+		groups: Set<string>;
+	};
+};
+
+type onStateChange = (state: Readonly<CommandState>) => void;
 ```

--- a/sites/docs/src/lib/content/api-reference/extended-types/command/command-on-state-change-prop.md
+++ b/sites/docs/src/lib/content/api-reference/extended-types/command/command-on-state-change-prop.md
@@ -1,0 +1,3 @@
+```ts
+(state: Readonly<CommandState>) => void;
+```

--- a/sites/docs/src/lib/content/api-reference/extended-types/command/index.ts
+++ b/sites/docs/src/lib/content/api-reference/extended-types/command/index.ts
@@ -1,1 +1,2 @@
 export { default as CommandFilterProp } from "./command-filter-prop.md";
+export { default as CommandOnStateChangeProp } from "./command-on-state-change-prop.md";


### PR DESCRIPTION
As i was trying to reimplement [Multiple Selector](https://shadcnui-expansions.typeart.cc/docs/multiple-selector) for [Origin UI Svelte](https://github.com/max-got/originui-svelte/pull/25) i didn't found a way to access the current filtered items for select-{46|47}. [See Original](https://originui.com/selects) "Multiselect, Multiselect with placeholder and clear."

Initially i wanted to give the user something like [`useCommandState`](https://github.com/pacocoursey/cmdk#usecommandstatestate--stateselectedfield), but that felt wrong. But maybe there is a better solution. I just wanted to kickstart something like this! Feel free to close this, if you think that is the wrong approach!

This PR introduces a new `onStateChange` callback to the Command component, allowing consumers to track and react to internal state changes.

## Changes

- Added `onStateChange` prop to `CommandRootProps` that receives a readonly snapshot of the component's internal state
- Implemented state batching mechanism to prevent redundant callback triggers during related updates (e.g., when typing triggers both filtering and selection changes)
- Updated API documentation with the new `onStateChange` functionality

## Implementation Details

The state management system now:
- Batches related state updates to prevent multiple emissions
- Uses `afterTick` to ensure all related updates are processed before notifying
- Provides a readonly snapshot of the state to prevent unintended mutations
- Skips notifications during the initial mount phase to avoid unnecessary updates

## Example Usage
```svelte
<Command.Root
onStateChange={(state) => {
// Access current search query, selected value, and filtered items
console.log('Search:', state.search);
console.log('Selected:', state.value);
console.log('Filtered count:', state.filtered.count);
}}
>
<!-- Command components -->
</Command.Root>
```

## Testing
No test files found, tho i tested locally: 
- Verified that the callback fires only once per logical state change
- Tested with various interaction patterns (typing, selecting, hovering)