### PR TITLE
next(breaking): Floating Content `child` Snippet  

### DIFF
--- a/.changeset/fast-poems-tap.md
+++ b/.changeset/fast-poems-tap.md
@@ -1,0 +1,5 @@
+---
+"bits-ui": patch
+---
+
+BREAKING: Update `child` snippet behavior of Floating UI-based `Content` components

--- a/packages/bits-ui/src/lib/bits/context-menu/components/context-menu-content-static.svelte
+++ b/packages/bits-ui/src/lib/bits/context-menu/components/context-menu-content-static.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { box, mergeProps } from "svelte-toolbelt";
-	import type { ContextMenuContentProps } from "../types.js";
+	import type { ContextMenuContentStaticProps } from "../types.js";
 	import { CONTEXT_MENU_TRIGGER_ATTR, useMenuContent } from "$lib/bits/menu/menu.svelte.js";
 	import { useId } from "$lib/internal/use-id.js";
 	import { noop } from "$lib/internal/noop.js";
@@ -22,7 +22,7 @@
 		onEscapeKeydown = noop,
 		forceMount = false,
 		...restProps
-	}: ContextMenuContentProps = $props();
+	}: ContextMenuContentStaticProps = $props();
 
 	let isMounted = $state(false);
 

--- a/packages/bits-ui/src/lib/bits/context-menu/components/context-menu-content.svelte
+++ b/packages/bits-ui/src/lib/bits/context-menu/components/context-menu-content.svelte
@@ -78,15 +78,17 @@
 		{loop}
 		{id}
 	>
-		{#snippet popper({ props })}
+		{#snippet popper({ props, wrapperProps })}
 			{@const finalProps = mergeProps(props, {
 				style: getFloatingContentCSSVars("context-menu"),
 			})}
 			{#if child}
-				{@render child({ props: finalProps, ...contentState.snippetProps })}
+				{@render child({ props: finalProps, wrapperProps, ...contentState.snippetProps })}
 			{:else}
-				<div {...finalProps}>
-					{@render children?.()}
+				<div {...wrapperProps}>
+					<div {...finalProps}>
+						{@render children?.()}
+					</div>
 				</div>
 			{/if}
 			<Mounted bind:isMounted />
@@ -107,15 +109,17 @@
 		{loop}
 		{id}
 	>
-		{#snippet popper({ props })}
+		{#snippet popper({ props, wrapperProps })}
 			{@const finalProps = mergeProps(props, {
 				style: getFloatingContentCSSVars("context-menu"),
 			})}
 			{#if child}
-				{@render child({ props: finalProps, ...contentState.snippetProps })}
+				{@render child({ props: finalProps, wrapperProps, ...contentState.snippetProps })}
 			{:else}
-				<div {...finalProps}>
-					{@render children?.()}
+				<div {...wrapperProps}>
+					<div {...finalProps}>
+						{@render children?.()}
+					</div>
 				</div>
 			{/if}
 			<Mounted bind:isMounted />

--- a/packages/bits-ui/src/lib/bits/dropdown-menu/components/dropdown-menu-content-static.svelte
+++ b/packages/bits-ui/src/lib/bits/dropdown-menu/components/dropdown-menu-content-static.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { box, mergeProps } from "svelte-toolbelt";
-	import type { DropdownMenuContentProps } from "../types.js";
+	import type { DropdownMenuContentStaticProps } from "../types.js";
 	import { useMenuContent } from "$lib/bits/menu/menu.svelte.js";
 	import { useId } from "$lib/internal/use-id.js";
 	import { noop } from "$lib/internal/noop.js";
@@ -19,7 +19,7 @@
 		onEscapeKeydown = noop,
 		forceMount = false,
 		...restProps
-	}: DropdownMenuContentProps = $props();
+	}: DropdownMenuContentStaticProps = $props();
 
 	let isMounted = $state(false);
 

--- a/packages/bits-ui/src/lib/bits/dropdown-menu/components/dropdown-menu-content.svelte
+++ b/packages/bits-ui/src/lib/bits/dropdown-menu/components/dropdown-menu-content.svelte
@@ -60,15 +60,17 @@
 		forceMount={true}
 		{id}
 	>
-		{#snippet popper({ props })}
+		{#snippet popper({ props, wrapperProps })}
 			{@const finalProps = mergeProps(props, {
 				style: getFloatingContentCSSVars("dropdown-menu"),
 			})}
 			{#if child}
-				{@render child({ props: finalProps, ...contentState.snippetProps })}
+				{@render child({ props: finalProps, wrapperProps, ...contentState.snippetProps })}
 			{:else}
-				<div {...finalProps}>
-					{@render children?.()}
+				<div {...wrapperProps}>
+					<div {...finalProps}>
+						{@render children?.()}
+					</div>
 				</div>
 			{/if}
 			<Mounted bind:isMounted />
@@ -85,15 +87,17 @@
 		forceMount={false}
 		{id}
 	>
-		{#snippet popper({ props })}
+		{#snippet popper({ props, wrapperProps })}
 			{@const finalProps = mergeProps(props, {
 				style: getFloatingContentCSSVars("dropdown-menu"),
 			})}
 			{#if child}
-				{@render child({ props: finalProps, ...contentState.snippetProps })}
+				{@render child({ props: finalProps, wrapperProps, ...contentState.snippetProps })}
 			{:else}
-				<div {...finalProps}>
-					{@render children?.()}
+				<div {...wrapperProps}>
+					<div {...finalProps}>
+						{@render children?.()}
+					</div>
 				</div>
 			{/if}
 			<Mounted bind:isMounted />

--- a/packages/bits-ui/src/lib/bits/link-preview/components/link-preview-content-static.svelte
+++ b/packages/bits-ui/src/lib/bits/link-preview/components/link-preview-content-static.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { box, mergeProps } from "svelte-toolbelt";
-	import type { LinkPreviewContentProps } from "../types.js";
+	import type { LinkPreviewContentStaticProps } from "../types.js";
 	import { useLinkPreviewContent } from "../link-preview.svelte.js";
 	import { useId } from "$lib/internal/use-id.js";
 	import PopperLayer from "$lib/bits/utilities/popper-layer/popper-layer.svelte";
@@ -12,19 +12,11 @@
 		child,
 		id = useId(),
 		ref = $bindable(null),
-		side = "top",
-		sideOffset = 0,
-		align = "center",
-		avoidCollisions = true,
-		arrowPadding = 0,
-		sticky = "partial",
-		hideWhenDetached = false,
-		collisionPadding = 0,
 		onInteractOutside,
 		onEscapeKeydown,
 		forceMount = false,
 		...restProps
-	}: LinkPreviewContentProps = $props();
+	}: LinkPreviewContentStaticProps = $props();
 
 	const contentState = useLinkPreviewContent({
 		id: box.with(() => id),
@@ -34,18 +26,7 @@
 		),
 	});
 
-	const floatingProps = $derived({
-		side,
-		sideOffset,
-		align,
-		avoidCollisions,
-		arrowPadding,
-		sticky,
-		hideWhenDetached,
-		collisionPadding,
-	});
-
-	const mergedProps = $derived(mergeProps(restProps, floatingProps, contentState.props));
+	const mergedProps = $derived(mergeProps(restProps, contentState.props));
 
 	function handleInteractOutside(e: PointerEvent) {
 		onInteractOutside?.(e);

--- a/packages/bits-ui/src/lib/bits/link-preview/components/link-preview-content.svelte
+++ b/packages/bits-ui/src/lib/bits/link-preview/components/link-preview-content.svelte
@@ -75,15 +75,17 @@
 		preventScroll={false}
 		forceMount={true}
 	>
-		{#snippet popper({ props })}
+		{#snippet popper({ props, wrapperProps })}
 			{@const mergedProps = mergeProps(props, {
 				style: getFloatingContentCSSVars("link-preview"),
 			})}
 			{#if child}
-				{@render child({ props: mergedProps, ...contentState.snippetProps })}
+				{@render child({ props: mergedProps, wrapperProps, ...contentState.snippetProps })}
 			{:else}
-				<div {...mergedProps}>
-					{@render children?.()}
+				<div {...wrapperProps}>
+					<div {...mergedProps}>
+						{@render children?.()}
+					</div>
 				</div>
 			{/if}
 		{/snippet}
@@ -102,15 +104,17 @@
 		preventScroll={false}
 		forceMount={false}
 	>
-		{#snippet popper({ props })}
+		{#snippet popper({ props, wrapperProps })}
 			{@const mergedProps = mergeProps(props, {
 				style: getFloatingContentCSSVars("link-preview"),
 			})}
 			{#if child}
-				{@render child({ props: mergedProps, ...contentState.snippetProps })}
+				{@render child({ props: mergedProps, wrapperProps, ...contentState.snippetProps })}
 			{:else}
-				<div {...mergedProps}>
-					{@render children?.()}
+				<div {...wrapperProps}>
+					<div {...mergedProps}>
+						{@render children?.()}
+					</div>
 				</div>
 			{/if}
 			<Mounted onMountedChange={(m) => (contentState.root.contentMounted = m)} />

--- a/packages/bits-ui/src/lib/bits/link-preview/types.ts
+++ b/packages/bits-ui/src/lib/bits/link-preview/types.ts
@@ -14,6 +14,7 @@ import type {
 	WithChildren,
 	Without,
 } from "$lib/internal/types.js";
+import type { FloatingContentSnippetProps, StaticContentSnippetProps } from "$lib/shared/types.js";
 
 export type LinkPreviewRootPropsWithoutHTML = WithChildren<{
 	/**
@@ -69,14 +70,6 @@ export type LinkPreviewRootPropsWithoutHTML = WithChildren<{
 
 export type LinkPreviewRootProps = LinkPreviewRootPropsWithoutHTML;
 
-export type LinkPreviewContentSnippetProps = {
-	/**
-	 * Whether the content is open or closed. Used alongside the `forceMount` prop to
-	 * conditionally render the content using Svelte transitions.
-	 */
-	open: boolean;
-};
-
 export type LinkPreviewContentPropsWithoutHTML = WithChildNoChildrenSnippetProps<
 	Pick<
 		FloatingLayerContentProps,
@@ -101,13 +94,13 @@ export type LinkPreviewContentPropsWithoutHTML = WithChildNoChildrenSnippetProps
 			 */
 			forceMount?: boolean;
 		},
-	LinkPreviewContentSnippetProps
+	FloatingContentSnippetProps
 >;
 
 export type LinkPreviewContentProps = LinkPreviewContentPropsWithoutHTML &
 	Without<BitsPrimitiveDivAttributes, LinkPreviewContentPropsWithoutHTML>;
 
-export type LinkPreviewContentStaticPropsWithoutHTML = WithChild<
+export type LinkPreviewContentStaticPropsWithoutHTML = WithChildNoChildrenSnippetProps<
 	Pick<FloatingLayerContentProps, "dir"> &
 		Omit<DismissibleLayerProps, "onInteractOutsideStart"> &
 		EscapeLayerProps & {
@@ -118,7 +111,7 @@ export type LinkPreviewContentStaticPropsWithoutHTML = WithChild<
 			 */
 			forceMount?: boolean;
 		},
-	LinkPreviewContentSnippetProps
+	StaticContentSnippetProps
 >;
 
 export type LinkPreviewContentStaticProps = LinkPreviewContentStaticPropsWithoutHTML &

--- a/packages/bits-ui/src/lib/bits/menu/components/menu-content-static.svelte
+++ b/packages/bits-ui/src/lib/bits/menu/components/menu-content-static.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { box, mergeProps } from "svelte-toolbelt";
-	import type { MenuContentProps } from "../types.js";
+	import type { MenuContentStaticProps } from "../types.js";
 	import { useMenuContent } from "../menu.svelte.js";
 	import { useId } from "$lib/internal/use-id.js";
 	import { noop } from "$lib/internal/noop.js";
@@ -19,7 +19,7 @@
 		onEscapeKeydown = noop,
 		forceMount = false,
 		...restProps
-	}: MenuContentProps = $props();
+	}: MenuContentStaticProps = $props();
 
 	let isMounted = $state(false);
 

--- a/packages/bits-ui/src/lib/bits/menu/components/menu-content.svelte
+++ b/packages/bits-ui/src/lib/bits/menu/components/menu-content.svelte
@@ -63,7 +63,7 @@
 		forceMount={true}
 		{id}
 	>
-		{#snippet popper({ props })}
+		{#snippet popper({ props, wrapperProps })}
 			{@const finalProps = mergeProps(props, {
 				style: {
 					outline: "none",
@@ -71,10 +71,12 @@
 				},
 			})}
 			{#if child}
-				{@render child({ props: finalProps, ...contentState.snippetProps })}
+				{@render child({ props: finalProps, wrapperProps, ...contentState.snippetProps })}
 			{:else}
-				<div {...finalProps}>
-					{@render children?.()}
+				<div {...wrapperProps}>
+					<div {...finalProps}>
+						{@render children?.()}
+					</div>
 				</div>
 			{/if}
 			<Mounted bind:isMounted />
@@ -91,7 +93,7 @@
 		forceMount={false}
 		{id}
 	>
-		{#snippet popper({ props })}
+		{#snippet popper({ props, wrapperProps })}
 			{@const finalProps = mergeProps(props, {
 				style: {
 					outline: "none",
@@ -99,10 +101,12 @@
 				},
 			})}
 			{#if child}
-				{@render child({ props: finalProps, ...contentState.snippetProps })}
+				{@render child({ props: finalProps, wrapperProps, ...contentState.snippetProps })}
 			{:else}
-				<div {...finalProps}>
-					{@render children?.()}
+				<div {...wrapperProps}>
+					<div {...finalProps}>
+						{@render children?.()}
+					</div>
 				</div>
 			{/if}
 			<Mounted bind:isMounted />

--- a/packages/bits-ui/src/lib/bits/menu/components/menu-sub-content-static.svelte
+++ b/packages/bits-ui/src/lib/bits/menu/components/menu-sub-content-static.svelte
@@ -67,7 +67,7 @@
 		if (e.defaultPrevented) return;
 		afterTick(() => {
 			e.preventDefault();
-			if (subContentState.parentMenu.root.isUsingKeyboard.current) {
+			if (subContentState.parentMenu.root.isUsingKeyboard) {
 				const subContentEl = subContentState.parentMenu.contentNode;
 				subContentEl?.focus();
 			}

--- a/packages/bits-ui/src/lib/bits/menu/components/menu-sub-content-static.svelte
+++ b/packages/bits-ui/src/lib/bits/menu/components/menu-sub-content-static.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { afterTick, box, mergeProps } from "svelte-toolbelt";
-	import type { MenuSubContentProps } from "../types.js";
+	import type { MenuSubContentStaticProps } from "../types.js";
 	import { useMenuContent } from "../menu.svelte.js";
 	import { SUB_CLOSE_KEYS } from "../utils.js";
 	import { useId } from "$lib/internal/use-id.js";
@@ -25,9 +25,8 @@
 		onOpenAutoFocus: onOpenAutoFocusProp = noop,
 		onCloseAutoFocus: onCloseAutoFocusProp = noop,
 		onFocusOutside = noop,
-		side = "right",
 		...restProps
-	}: MenuSubContentProps = $props();
+	}: MenuSubContentStaticProps = $props();
 
 	let isMounted = $state(false);
 
@@ -58,7 +57,6 @@
 
 	const mergedProps = $derived(
 		mergeProps(restProps, subContentState.props, {
-			side,
 			onkeydown,
 			[dataAttr]: "",
 		})

--- a/packages/bits-ui/src/lib/bits/menu/components/menu-sub-content.svelte
+++ b/packages/bits-ui/src/lib/bits/menu/components/menu-sub-content.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
-	import { afterTick, box, mergeProps } from "svelte-toolbelt";
+	import { box, mergeProps } from "svelte-toolbelt";
 	import type { MenuSubContentProps } from "../types.js";
-	import { useMenuContent } from "../menu.svelte.js";
+	import { dispatchMenuOpen, useMenuContent } from "../menu.svelte.js";
 	import { SUB_CLOSE_KEYS } from "../utils.js";
 	import { useId } from "$lib/internal/use-id.js";
 	import PopperLayer from "$lib/bits/utilities/popper-layer/popper-layer.svelte";
@@ -67,13 +67,13 @@
 	function handleOpenAutoFocus(e: Event) {
 		onOpenAutoFocusProp(e);
 		if (e.defaultPrevented) return;
-		afterTick(() => {
-			e.preventDefault();
-			if (subContentState.parentMenu.root.isUsingKeyboard.current) {
-				const subContentEl = subContentState.parentMenu.contentNode;
-				subContentEl?.focus();
-			}
-		});
+		e.preventDefault();
+		if (
+			subContentState.parentMenu.root.isUsingKeyboard &&
+			subContentState.parentMenu.contentNode
+		) {
+			dispatchMenuOpen(subContentState.parentMenu.contentNode);
+		}
 	}
 
 	function handleCloseAutoFocus(e: Event) {

--- a/packages/bits-ui/src/lib/bits/menu/components/menu-sub-content.svelte
+++ b/packages/bits-ui/src/lib/bits/menu/components/menu-sub-content.svelte
@@ -121,15 +121,21 @@
 		{loop}
 		trapFocus={false}
 	>
-		{#snippet popper({ props })}
+		{#snippet popper({ props, wrapperProps })}
 			{@const finalProps = mergeProps(props, mergedProps, {
 				style: getFloatingContentCSSVars("menu"),
 			})}
 			{#if child}
-				{@render child({ props: finalProps, ...subContentState.snippetProps })}
+				{@render child({
+					props: finalProps,
+					wrapperProps,
+					...subContentState.snippetProps,
+				})}
 			{:else}
-				<div {...finalProps}>
-					{@render children?.()}
+				<div {...wrapperProps}>
+					<div {...finalProps}>
+						{@render children?.()}
+					</div>
 				</div>
 			{/if}
 			<Mounted bind:isMounted />
@@ -150,15 +156,21 @@
 		{loop}
 		trapFocus={false}
 	>
-		{#snippet popper({ props })}
+		{#snippet popper({ props, wrapperProps })}
 			{@const finalProps = mergeProps(props, mergedProps, {
 				style: getFloatingContentCSSVars("menu"),
 			})}
 			{#if child}
-				{@render child({ props: finalProps, ...subContentState.snippetProps })}
+				{@render child({
+					props: finalProps,
+					wrapperProps,
+					...subContentState.snippetProps,
+				})}
 			{:else}
-				<div {...finalProps}>
-					{@render children?.()}
+				<div {...wrapperProps}>
+					<div {...finalProps}>
+						{@render children?.()}
+					</div>
 				</div>
 			{/if}
 			<Mounted bind:isMounted />

--- a/packages/bits-ui/src/lib/bits/menu/types.ts
+++ b/packages/bits-ui/src/lib/bits/menu/types.ts
@@ -14,6 +14,7 @@ import type {
 } from "$lib/shared/attributes.js";
 import type { Direction } from "$lib/shared/index.js";
 import type { PortalProps } from "$lib/bits/utilities/portal/types.js";
+import type { FloatingContentSnippetProps, StaticContentSnippetProps } from "$lib/shared/types.js";
 
 export type MenuRootPropsWithoutHTML = WithChildren<{
 	/**
@@ -54,18 +55,10 @@ export type _SharedMenuContentProps = {
 	loop?: boolean;
 };
 
-export type MenuContentSnippetProps = {
-	/**
-	 * Whether the content is open or closed. Used alongside the `forceMount` prop to
-	 * conditionally render the content using Svelte transitions.
-	 */
-	open: boolean;
-};
-
 export type MenuContentPropsWithoutHTML = Expand<
 	WithChildNoChildrenSnippetProps<
 		Omit<PopperLayerProps, "content"> & _SharedMenuContentProps,
-		MenuContentSnippetProps
+		FloatingContentSnippetProps
 	>
 >;
 
@@ -75,7 +68,7 @@ export type MenuContentProps = MenuContentPropsWithoutHTML &
 export type MenuContentStaticPropsWithoutHTML = Expand<
 	WithChildNoChildrenSnippetProps<
 		Omit<PopperLayerStaticProps, "content"> & _SharedMenuContentProps,
-		MenuContentSnippetProps
+		StaticContentSnippetProps
 	>
 >;
 
@@ -219,7 +212,7 @@ export type MenuSubProps = MenuSubPropsWithoutHTML;
 export type MenuSubContentPropsWithoutHTML = Expand<
 	WithChildNoChildrenSnippetProps<
 		Omit<PopperLayerProps, "content" | "preventScroll"> & _SharedMenuContentProps,
-		MenuContentSnippetProps
+		FloatingContentSnippetProps
 	>
 >;
 
@@ -229,7 +222,7 @@ export type MenuSubContentProps = MenuSubContentPropsWithoutHTML &
 export type MenuSubContentStaticPropsWithoutHTML = Expand<
 	WithChildNoChildrenSnippetProps<
 		Omit<PopperLayerStaticProps, "content" | "preventScroll"> & _SharedMenuContentProps,
-		MenuContentSnippetProps
+		StaticContentSnippetProps
 	>
 >;
 

--- a/packages/bits-ui/src/lib/bits/popover/components/popover-content-static.svelte
+++ b/packages/bits-ui/src/lib/bits/popover/components/popover-content-static.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { box, mergeProps } from "svelte-toolbelt";
-	import type { PopoverContentProps } from "../types.js";
+	import type { PopoverContentStaticProps } from "../types.js";
 	import { usePopoverContent } from "../popover.svelte.js";
 	import PopperLayer from "$lib/bits/utilities/popper-layer/popper-layer.svelte";
 	import { noop } from "$lib/internal/noop.js";
@@ -20,7 +20,7 @@
 		trapFocus = true,
 		preventScroll = false,
 		...restProps
-	}: PopoverContentProps = $props();
+	}: PopoverContentStaticProps = $props();
 
 	const contentState = usePopoverContent({
 		id: box.with(() => id),

--- a/packages/bits-ui/src/lib/bits/popover/components/popover-content.svelte
+++ b/packages/bits-ui/src/lib/bits/popover/components/popover-content.svelte
@@ -65,15 +65,17 @@
 		loop
 		forceMount={true}
 	>
-		{#snippet popper({ props })}
+		{#snippet popper({ props, wrapperProps })}
 			{@const finalProps = mergeProps(props, {
 				style: getFloatingContentCSSVars("popover"),
 			})}
 			{#if child}
-				{@render child({ props: finalProps, ...contentState.snippetProps })}
+				{@render child({ props: finalProps, wrapperProps, ...contentState.snippetProps })}
 			{:else}
-				<div {...finalProps}>
-					{@render children?.()}
+				<div {...wrapperProps}>
+					<div {...finalProps}>
+						{@render children?.()}
+					</div>
 				</div>
 			{/if}
 		{/snippet}
@@ -91,15 +93,17 @@
 		loop
 		forceMount={false}
 	>
-		{#snippet popper({ props })}
+		{#snippet popper({ props, wrapperProps })}
 			{@const finalProps = mergeProps(props, {
 				style: getFloatingContentCSSVars("popover"),
 			})}
 			{#if child}
-				{@render child({ props: finalProps, ...contentState.snippetProps })}
+				{@render child({ props: finalProps, wrapperProps, ...contentState.snippetProps })}
 			{:else}
-				<div {...finalProps}>
-					{@render children?.()}
+				<div {...wrapperProps}>
+					<div {...finalProps}>
+						{@render children?.()}
+					</div>
 				</div>
 			{/if}
 		{/snippet}

--- a/packages/bits-ui/src/lib/bits/popover/types.ts
+++ b/packages/bits-ui/src/lib/bits/popover/types.ts
@@ -11,6 +11,7 @@ import type {
 	BitsPrimitiveButtonAttributes,
 	BitsPrimitiveDivAttributes,
 } from "$lib/shared/attributes.js";
+import type { FloatingContentSnippetProps, StaticContentSnippetProps } from "$lib/shared/types.js";
 
 export type PopoverRootPropsWithoutHTML = WithChildren<{
 	/**
@@ -35,17 +36,9 @@ export type PopoverRootPropsWithoutHTML = WithChildren<{
 
 export type PopoverRootProps = PopoverRootPropsWithoutHTML;
 
-export type PopoverContentSnippetProps = {
-	/**
-	 * Whether the content is open or closed. Used alongside the `forceMount` prop to
-	 * conditionally render the content using Svelte transitions.
-	 */
-	open: boolean;
-};
-
 export type PopoverContentPropsWithoutHTML = WithChildNoChildrenSnippetProps<
 	Omit<PopperLayerProps, "content" | "loop">,
-	PopoverContentSnippetProps
+	FloatingContentSnippetProps
 >;
 
 export type PopoverContentProps = PopoverContentPropsWithoutHTML &
@@ -53,7 +46,7 @@ export type PopoverContentProps = PopoverContentPropsWithoutHTML &
 
 export type PopoverContentStaticPropsWithoutHTML = WithChildNoChildrenSnippetProps<
 	Omit<PopperLayerStaticProps, "content" | "loop">,
-	PopoverContentSnippetProps
+	StaticContentSnippetProps
 >;
 
 export type PopoverContentStaticProps = PopoverContentStaticPropsWithoutHTML &

--- a/packages/bits-ui/src/lib/bits/select/components/select-content-static.svelte
+++ b/packages/bits-ui/src/lib/bits/select/components/select-content-static.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { box, mergeProps } from "svelte-toolbelt";
-	import type { SelectContentProps } from "../types.js";
+	import type { SelectContentStaticProps } from "../types.js";
 	import { useSelectContent } from "../select.svelte.js";
 	import PopperLayer from "$lib/bits/utilities/popper-layer/popper-layer.svelte";
 	import { useId } from "$lib/internal/use-id.js";
@@ -11,13 +11,12 @@
 		id = useId(),
 		ref = $bindable(null),
 		forceMount = false,
-		side = "bottom",
 		onInteractOutside = noop,
 		onEscapeKeydown = noop,
 		children,
 		child,
 		...restProps
-	}: SelectContentProps = $props();
+	}: SelectContentStaticProps = $props();
 
 	const contentState = useSelectContent({
 		id: box.with(() => id),
@@ -48,7 +47,6 @@
 	<PopperLayerForceMount
 		{...mergedProps}
 		isStatic
-		{side}
 		enabled={contentState.root.open.current}
 		{id}
 		onInteractOutside={handleInteractOutside}
@@ -76,7 +74,6 @@
 	<PopperLayer
 		{...mergedProps}
 		isStatic
-		{side}
 		present={contentState.root.open.current}
 		{id}
 		onInteractOutside={handleInteractOutside}

--- a/packages/bits-ui/src/lib/bits/select/components/select-content.svelte
+++ b/packages/bits-ui/src/lib/bits/select/components/select-content.svelte
@@ -61,13 +61,15 @@
 		onPlaced={() => (contentState.isPositioned = true)}
 		forceMount={true}
 	>
-		{#snippet popper({ props })}
+		{#snippet popper({ props, wrapperProps })}
 			{@const finalProps = mergeProps(props, { style: contentState.props.style })}
 			{#if child}
-				{@render child({ props: finalProps, ...contentState.snippetProps })}
+				{@render child({ props: finalProps, wrapperProps, ...contentState.snippetProps })}
 			{:else}
-				<div {...finalProps}>
-					{@render children?.()}
+				<div {...wrapperProps}>
+					<div {...finalProps}>
+						{@render children?.()}
+					</div>
 				</div>
 			{/if}
 		{/snippet}
@@ -88,13 +90,15 @@
 		onPlaced={() => (contentState.isPositioned = true)}
 		forceMount={false}
 	>
-		{#snippet popper({ props })}
+		{#snippet popper({ props, wrapperProps })}
 			{@const finalProps = mergeProps(props, { style: contentState.props.style })}
 			{#if child}
-				{@render child({ props: finalProps, ...contentState.snippetProps })}
+				{@render child({ props: finalProps, wrapperProps, ...contentState.snippetProps })}
 			{:else}
-				<div {...finalProps}>
-					{@render children?.()}
+				<div {...wrapperProps}>
+					<div {...finalProps}>
+						{@render children?.()}
+					</div>
 				</div>
 			{/if}
 		{/snippet}

--- a/packages/bits-ui/src/lib/bits/select/types.ts
+++ b/packages/bits-ui/src/lib/bits/select/types.ts
@@ -13,6 +13,7 @@ import type {
 	WithChildren,
 	Without,
 } from "$lib/internal/types.js";
+import type { FloatingContentSnippetProps, StaticContentSnippetProps } from "$lib/shared/types.js";
 
 export type SelectBaseRootPropsWithoutHTML = WithChildren<{
 	/**
@@ -177,19 +178,11 @@ export type _SharedSelectContentProps = {
 	loop?: boolean;
 };
 
-export type SelectContentSnippetProps = {
-	/**
-	 * Whether the content is open or closed. Used alongside the `forceMount` prop to conditionally
-	 * render the content using Svelte transitions.
-	 */
-	open: boolean;
-};
-
 export type SelectContentPropsWithoutHTML = Expand<
 	WithChildNoChildrenSnippetProps<
 		Omit<PopperLayerProps, "content" | "onOpenAutoFocus" | "trapFocus"> &
 			_SharedSelectContentProps,
-		SelectContentSnippetProps
+		FloatingContentSnippetProps
 	>
 >;
 
@@ -200,7 +193,7 @@ export type SelectContentStaticPropsWithoutHTML = Expand<
 	WithChildNoChildrenSnippetProps<
 		Omit<PopperLayerStaticProps, "content" | "onOpenAutoFocus" | "trapFocus"> &
 			_SharedSelectContentProps,
-		SelectContentSnippetProps
+		StaticContentSnippetProps
 	>
 >;
 

--- a/packages/bits-ui/src/lib/bits/tooltip/components/tooltip-content-static.svelte
+++ b/packages/bits-ui/src/lib/bits/tooltip/components/tooltip-content-static.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { box, mergeProps } from "svelte-toolbelt";
-	import type { TooltipContentProps } from "../types.js";
+	import type { TooltipContentStaticProps } from "../types.js";
 	import { useTooltipContent } from "../tooltip.svelte.js";
 	import { useId } from "$lib/internal/use-id.js";
 	import PopperLayer from "$lib/bits/utilities/popper-layer/popper-layer.svelte";
@@ -12,19 +12,12 @@
 		child,
 		id = useId(),
 		ref = $bindable(null),
-		side = "top",
-		sideOffset = 0,
-		align = "center",
-		avoidCollisions = true,
-		arrowPadding = 0,
-		sticky = "partial",
-		hideWhenDetached = false,
-		collisionPadding = 0,
+
 		onInteractOutside,
 		onEscapeKeydown,
 		forceMount = false,
 		...restProps
-	}: TooltipContentProps = $props();
+	}: TooltipContentStaticProps = $props();
 
 	const contentState = useTooltipContent({
 		id: box.with(() => id),
@@ -34,18 +27,7 @@
 		),
 	});
 
-	const floatingProps = $derived({
-		side,
-		sideOffset,
-		align,
-		avoidCollisions,
-		arrowPadding,
-		sticky,
-		hideWhenDetached,
-		collisionPadding,
-	});
-
-	const mergedProps = $derived(mergeProps(restProps, floatingProps, contentState.props));
+	const mergedProps = $derived(mergeProps(restProps, contentState.props));
 
 	function handleInteractOutside(e: PointerEvent) {
 		onInteractOutside?.(e);

--- a/packages/bits-ui/src/lib/bits/tooltip/components/tooltip-content.svelte
+++ b/packages/bits-ui/src/lib/bits/tooltip/components/tooltip-content.svelte
@@ -74,15 +74,17 @@
 		preventScroll={false}
 		forceMount={true}
 	>
-		{#snippet popper({ props })}
+		{#snippet popper({ props, wrapperProps })}
 			{@const mergedProps = mergeProps(props, {
 				style: getFloatingContentCSSVars("tooltip"),
 			})}
 			{#if child}
-				{@render child({ props: mergedProps, ...contentState.snippetProps })}
+				{@render child({ props: mergedProps, wrapperProps, ...contentState.snippetProps })}
 			{:else}
-				<div {...mergedProps}>
-					{@render children?.()}
+				<div {...wrapperProps}>
+					<div {...mergedProps}>
+						{@render children?.()}
+					</div>
 				</div>
 			{/if}
 		{/snippet}
@@ -101,15 +103,17 @@
 		preventScroll={false}
 		forceMount={false}
 	>
-		{#snippet popper({ props })}
+		{#snippet popper({ props, wrapperProps })}
 			{@const mergedProps = mergeProps(props, {
 				style: getFloatingContentCSSVars("tooltip"),
 			})}
 			{#if child}
-				{@render child({ props: mergedProps, ...contentState.snippetProps })}
+				{@render child({ props: mergedProps, wrapperProps, ...contentState.snippetProps })}
 			{:else}
-				<div {...mergedProps}>
-					{@render children?.()}
+				<div {...wrapperProps}>
+					<div {...mergedProps}>
+						{@render children?.()}
+					</div>
 				</div>
 			{/if}
 		{/snippet}

--- a/packages/bits-ui/src/lib/bits/tooltip/types.ts
+++ b/packages/bits-ui/src/lib/bits/tooltip/types.ts
@@ -14,6 +14,7 @@ import type {
 	BitsPrimitiveDivAttributes,
 } from "$lib/shared/attributes.js";
 import type { PortalProps } from "$lib/bits/utilities/portal/types.js";
+import type { FloatingContentSnippetProps, StaticContentSnippetProps } from "$lib/shared/types.js";
 
 export type TooltipProviderPropsWithoutHTML = WithChildren<{
 	/**
@@ -123,14 +124,6 @@ export type TooltipRootPropsWithoutHTML = WithChildren<{
 
 export type TooltipRootProps = TooltipRootPropsWithoutHTML;
 
-export type TooltipContentSnippetProps = {
-	/**
-	 * Whether the content is open or closed. Used alongside the `forceMount` prop to
-	 * conditionally render the content using Svelte transitions.
-	 */
-	open: boolean;
-};
-
 export type TooltipContentPropsWithoutHTML = WithChildNoChildrenSnippetProps<
 	Pick<
 		FloatingLayerContentProps,
@@ -155,7 +148,7 @@ export type TooltipContentPropsWithoutHTML = WithChildNoChildrenSnippetProps<
 			 */
 			forceMount?: boolean;
 		},
-	TooltipContentSnippetProps
+	FloatingContentSnippetProps
 >;
 
 export type TooltipContentProps = TooltipContentPropsWithoutHTML &
@@ -172,7 +165,7 @@ export type TooltipContentStaticPropsWithoutHTML = WithChildNoChildrenSnippetPro
 			 */
 			forceMount?: boolean;
 		},
-	TooltipContentSnippetProps
+	StaticContentSnippetProps
 >;
 
 export type TooltipContentStaticProps = TooltipContentStaticPropsWithoutHTML &

--- a/packages/bits-ui/src/lib/bits/utilities/floating-layer/components/floating-layer-content-static.svelte
+++ b/packages/bits-ui/src/lib/bits/utilities/floating-layer/components/floating-layer-content-static.svelte
@@ -5,7 +5,9 @@
 		content,
 		onPlaced,
 	}: {
-		content?: Snippet<[{ props: Record<string, unknown> }]>;
+		content?: Snippet<
+			[{ props: Record<string, unknown>; wrapperProps: Record<string, unknown> }]
+		>;
 		onPlaced?: () => void;
 	} = $props();
 
@@ -14,4 +16,4 @@
 	});
 </script>
 
-{@render content?.({ props: {} })}
+{@render content?.({ props: {}, wrapperProps: {} })}

--- a/packages/bits-ui/src/lib/bits/utilities/floating-layer/components/floating-layer-content.svelte
+++ b/packages/bits-ui/src/lib/bits/utilities/floating-layer/components/floating-layer-content.svelte
@@ -57,6 +57,4 @@
 	);
 </script>
 
-<div {...mergedProps}>
-	{@render content?.({ props: contentState.props })}
-</div>
+{@render content?.({ props: contentState.props, wrapperProps: mergedProps })}

--- a/packages/bits-ui/src/lib/bits/utilities/floating-layer/types.ts
+++ b/packages/bits-ui/src/lib/bits/utilities/floating-layer/types.ts
@@ -72,7 +72,7 @@ export type FloatingLayerContentProps = {
 
 	updatePositionStrategy?: "optimized" | "always";
 
-	content?: Snippet<[{ props: Record<string, unknown> }]>;
+	content?: Snippet<[{ props: Record<string, unknown>; wrapperProps: Record<string, unknown> }]>;
 
 	/**
 	 * The positioning strategy to use for the floating element.

--- a/packages/bits-ui/src/lib/bits/utilities/popper-layer/popper-layer-inner.svelte
+++ b/packages/bits-ui/src/lib/bits/utilities/popper-layer/popper-layer-inner.svelte
@@ -71,7 +71,7 @@
 	{onPlaced}
 	{customAnchor}
 >
-	{#snippet content({ props: floatingProps })}
+	{#snippet content({ props: floatingProps, wrapperProps })}
 		{#if restProps.forceMount && enabled}
 			<ScrollLock {preventScroll} />
 		{:else if !restProps.forceMount}
@@ -115,6 +115,7 @@
 											},
 										}
 									),
+									wrapperProps,
 								})}
 							</TextSelectionLayer>
 						{/snippet}

--- a/packages/bits-ui/src/lib/bits/utilities/popper-layer/types.ts
+++ b/packages/bits-ui/src/lib/bits/utilities/popper-layer/types.ts
@@ -42,7 +42,9 @@ export type PopperLayerImplProps = Omit<
 		Omit<PresenceLayerImplProps, "presence"> &
 		TextSelectionLayerImplProps &
 		FocusScopeImplProps & {
-			popper: Snippet<[{ props: Record<string, unknown> }]>;
+			popper: Snippet<
+				[{ props: Record<string, unknown>; wrapperProps: Record<string, unknown> }]
+			>;
 			isStatic?: boolean;
 		},
 	"enabled"

--- a/packages/bits-ui/src/lib/internal/events.ts
+++ b/packages/bits-ui/src/lib/internal/events.ts
@@ -48,3 +48,37 @@ export function addEventListener(
 		events.forEach((_event) => target.removeEventListener(_event, handler, options));
 	};
 }
+
+/**
+ * Creates a typed event dispatcher and listener pair for custom events
+ * @template T - The type of data that will be passed in the event detail
+ * @param eventName - The name of the custom event
+ * @param options - CustomEvent options (bubbles, cancelable, etc.)
+ * @returns A tuple containing dispatch and listen functions
+ */
+export function createCustomEvent<T = unknown>(
+	eventName: string,
+	options: Omit<CustomEventInit<T>, "detail"> = { bubbles: true, cancelable: true }
+) {
+	type CustomEventType = CustomEvent<T>;
+	type EventListener = (event: CustomEventType) => void;
+
+	function dispatch(element: HTMLElement, detail?: T) {
+		const event = new CustomEvent<T>(eventName, {
+			...options,
+			detail,
+		});
+		element.dispatchEvent(event);
+	}
+
+	function listen(element: EventTarget, callback: EventListener) {
+		const handler = (event: Event) => {
+			callback(event as CustomEventType);
+		};
+
+		// @ts-expect-error shh
+		return addEventListener(element, eventName, handler);
+	}
+
+	return [dispatch, listen] as const;
+}

--- a/packages/bits-ui/src/lib/shared/index.ts
+++ b/packages/bits-ui/src/lib/shared/index.ts
@@ -53,3 +53,4 @@ export type { WithChild, Without, WithChildren } from "$lib/internal/types.js";
 export { mergeProps } from "svelte-toolbelt";
 export { useId } from "$lib/internal/use-id.js";
 export * from "./attributes.js";
+export * from "./types.js";

--- a/packages/bits-ui/src/lib/shared/types.ts
+++ b/packages/bits-ui/src/lib/shared/types.ts
@@ -1,0 +1,15 @@
+export type FloatingContentSnippetProps = {
+	/**
+	 * Whether the content is open or closed. Used alongside the `forceMount` prop to
+	 * conditionally render the content using Svelte transitions.
+	 */
+	open: boolean;
+
+	/**
+	 * Attributes to spread onto a wrapper element around the content.
+	 * Do not style the wrapper element, its styles are computed by Floating UI.
+	 */
+	wrapperProps: Record<string, unknown>;
+};
+
+export type StaticContentSnippetProps = Omit<FloatingContentSnippetProps, "wrapperProps">;

--- a/packages/tests/src/tests/combobox/combobox-force-mount-test.svelte
+++ b/packages/tests/src/tests/combobox/combobox-force-mount-test.svelte
@@ -45,6 +45,32 @@
 	);
 </script>
 
+{#snippet Content({
+	props,
+	wrapperProps,
+}: {
+	props: Record<string, unknown>;
+	wrapperProps: Record<string, unknown>;
+})}
+	<div {...wrapperProps}>
+		<div {...props}>
+			<Combobox.Group data-testid="group">
+				<Combobox.GroupHeading data-testid="group-label">Options</Combobox.GroupHeading>
+				{#each filteredItems as { value, label, disabled }}
+					<Combobox.Item data-testid={value} {disabled} {value} {label}>
+						{#snippet children({ selected, highlighted: _highlighted })}
+							{#if selected}
+								<span data-testid="{value}-indicator">x</span>
+							{/if}
+							{label}
+						{/snippet}
+					</Combobox.Item>
+				{/each}
+			</Combobox.Group>
+		</div>
+	</div>
+{/snippet}
+
 <main data-testid="main">
 	<Combobox.Root
 		type="single"
@@ -66,56 +92,16 @@
 		<Combobox.Portal {...portalProps}>
 			{#if withOpenCheck}
 				<Combobox.Content data-testid="content" {...contentProps} forceMount>
-					{#snippet child({ props, open })}
-						{#if open}
-							<div {...props}>
-								<Combobox.Group data-testid="group">
-									<Combobox.GroupHeading data-testid="group-label"
-										>Options</Combobox.GroupHeading
-									>
-									{#each filteredItems as { value, label, disabled }}
-										<Combobox.Item
-											data-testid={value}
-											{disabled}
-											{value}
-											{label}
-										>
-											{#snippet children({
-												selected,
-												highlighted: _highlighted,
-											})}
-												{#if selected}
-													<span data-testid="{value}-indicator">x</span>
-												{/if}
-												{label}
-											{/snippet}
-										</Combobox.Item>
-									{/each}
-								</Combobox.Group>
-							</div>
+					{#snippet child(props)}
+						{#if props.open}
+							{@render Content(props)}
 						{/if}
 					{/snippet}
 				</Combobox.Content>
 			{:else}
 				<Combobox.Content data-testid="content" {...contentProps} forceMount>
-					{#snippet child({ props, open: _open })}
-						<div {...props}>
-							<Combobox.Group data-testid="group">
-								<Combobox.GroupHeading data-testid="group-label"
-									>Options</Combobox.GroupHeading
-								>
-								{#each filteredItems as { value, label, disabled }}
-									<Combobox.Item data-testid={value} {disabled} {value} {label}>
-										{#snippet children({ selected, highlighted: _highlighted })}
-											{#if selected}
-												<span data-testid="{value}-indicator">x</span>
-											{/if}
-											{label}
-										{/snippet}
-									</Combobox.Item>
-								{/each}
-							</Combobox.Group>
-						</div>
+					{#snippet child(props)}
+						{@render Content(props)}
 					{/snippet}
 				</Combobox.Content>
 			{/if}

--- a/packages/tests/src/tests/context-menu/context-menu-force-mount-test.svelte
+++ b/packages/tests/src/tests/context-menu/context-menu-force-mount-test.svelte
@@ -26,6 +26,81 @@
 	}: ContextMenuForceMountTestProps = $props();
 </script>
 
+{#snippet Content({
+	props,
+	wrapperProps,
+}: {
+	props: Record<string, unknown>;
+	wrapperProps: Record<string, unknown>;
+})}
+	<div {...wrapperProps}>
+		<div {...props}>
+			<ContextMenu.Separator data-testid="separator" />
+			<ContextMenu.Group data-testid="group">
+				<ContextMenu.GroupHeading data-testid="group-heading">
+					Stuff
+				</ContextMenu.GroupHeading>
+				<ContextMenu.Item data-testid="item">
+					<span>item</span>
+				</ContextMenu.Item>
+			</ContextMenu.Group>
+
+			<ContextMenu.Sub>
+				<ContextMenu.SubTrigger data-testid="sub-trigger">
+					<span>subtrigger</span>
+				</ContextMenu.SubTrigger>
+				<ContextMenu.SubContent data-testid="sub-content">
+					<ContextMenu.Item data-testid="sub-item">
+						<span>Email</span>
+					</ContextMenu.Item>
+					<ContextMenu.CheckboxItem
+						bind:checked={subChecked}
+						data-testid="sub-checkbox-item"
+					>
+						{#snippet children({ checked, indeterminate: _indeterminate })}
+							<span data-testid="sub-checkbox-indicator">
+								{checked}
+							</span>
+							sub checkbox
+						{/snippet}
+					</ContextMenu.CheckboxItem>
+				</ContextMenu.SubContent>
+			</ContextMenu.Sub>
+			<ContextMenu.Item disabled data-testid="disabled-item">disabled item</ContextMenu.Item>
+			<ContextMenu.Item disabled data-testid="disabled-item-2"
+				>disabled item 2</ContextMenu.Item
+			>
+			<ContextMenu.CheckboxItem bind:checked data-testid="checkbox-item">
+				{#snippet children({ checked, indeterminate: _indeterminate })}
+					<span data-testid="checkbox-indicator">
+						{checked}
+					</span>
+					Checkbox Item
+				{/snippet}
+			</ContextMenu.CheckboxItem>
+			<ContextMenu.Item data-testid="item-2">item 2</ContextMenu.Item>
+			<ContextMenu.RadioGroup bind:value={radio} data-testid="radio-group">
+				<ContextMenu.RadioItem value="1" data-testid="radio-item">
+					{#snippet children({ checked })}
+						<span data-testid="radio-indicator-1">
+							{checked}
+						</span>
+						<span>Radio Item 1</span>
+					{/snippet}
+				</ContextMenu.RadioItem>
+				<ContextMenu.RadioItem value="2" data-testid="radio-item-2">
+					{#snippet children({ checked })}
+						<span data-testid="radio-indicator-2">
+							{checked}
+						</span>
+						<span>Radio Item 2</span>
+					{/snippet}
+				</ContextMenu.RadioItem>
+			</ContextMenu.RadioGroup>
+		</div>
+	</div>
+{/snippet}
+
 <main>
 	<div data-testid="outside">outside</div>
 	<div data-testid="non-portal-container">
@@ -41,164 +116,16 @@
 			<ContextMenu.Portal {...portalProps}>
 				{#if withOpenCheck}
 					<ContextMenu.Content {...contentProps} data-testid="content" forceMount>
-						{#snippet child({ props, open })}
-							{#if open}
-								<div {...props}>
-									<ContextMenu.Separator data-testid="separator" />
-									<ContextMenu.Group data-testid="group">
-										<ContextMenu.GroupHeading data-testid="group-heading">
-											Stuff
-										</ContextMenu.GroupHeading>
-										<ContextMenu.Item data-testid="item">
-											<span>item</span>
-										</ContextMenu.Item>
-									</ContextMenu.Group>
-
-									<ContextMenu.Sub>
-										<ContextMenu.SubTrigger data-testid="sub-trigger">
-											<span>subtrigger</span>
-										</ContextMenu.SubTrigger>
-										<ContextMenu.SubContent data-testid="sub-content">
-											<ContextMenu.Item data-testid="sub-item">
-												<span>Email</span>
-											</ContextMenu.Item>
-											<ContextMenu.CheckboxItem
-												bind:checked={subChecked}
-												data-testid="sub-checkbox-item"
-											>
-												{#snippet children({
-													checked,
-													indeterminate: _indeterminate,
-												})}
-													<span data-testid="sub-checkbox-indicator">
-														{checked}
-													</span>
-													sub checkbox
-												{/snippet}
-											</ContextMenu.CheckboxItem>
-										</ContextMenu.SubContent>
-									</ContextMenu.Sub>
-									<ContextMenu.Item disabled data-testid="disabled-item"
-										>disabled item</ContextMenu.Item
-									>
-									<ContextMenu.Item disabled data-testid="disabled-item-2"
-										>disabled item 2</ContextMenu.Item
-									>
-									<ContextMenu.CheckboxItem
-										bind:checked
-										data-testid="checkbox-item"
-									>
-										{#snippet children({
-											checked,
-											indeterminate: _indeterminate,
-										})}
-											<span data-testid="checkbox-indicator">
-												{checked}
-											</span>
-											Checkbox Item
-										{/snippet}
-									</ContextMenu.CheckboxItem>
-									<ContextMenu.Item data-testid="item-2">item 2</ContextMenu.Item>
-									<ContextMenu.RadioGroup
-										bind:value={radio}
-										data-testid="radio-group"
-									>
-										<ContextMenu.RadioItem value="1" data-testid="radio-item">
-											{#snippet children({ checked })}
-												<span data-testid="radio-indicator-1">
-													{checked}
-												</span>
-												<span>Radio Item 1</span>
-											{/snippet}
-										</ContextMenu.RadioItem>
-										<ContextMenu.RadioItem value="2" data-testid="radio-item-2">
-											{#snippet children({ checked })}
-												<span data-testid="radio-indicator-2">
-													{checked}
-												</span>
-												<span>Radio Item 2</span>
-											{/snippet}
-										</ContextMenu.RadioItem>
-									</ContextMenu.RadioGroup>
-								</div>
+						{#snippet child(props)}
+							{#if props.open}
+								{@render Content(props)}
 							{/if}
 						{/snippet}
 					</ContextMenu.Content>
 				{:else}
 					<ContextMenu.Content {...contentProps} data-testid="content" forceMount>
-						{#snippet child({ props, open: _open })}
-							<div {...props}>
-								<ContextMenu.Separator data-testid="separator" />
-								<ContextMenu.Group data-testid="group">
-									<ContextMenu.GroupHeading data-testid="group-heading">
-										Stuff
-									</ContextMenu.GroupHeading>
-									<ContextMenu.Item data-testid="item">
-										<span>item</span>
-									</ContextMenu.Item>
-								</ContextMenu.Group>
-
-								<ContextMenu.Sub>
-									<ContextMenu.SubTrigger data-testid="sub-trigger">
-										<span>subtrigger</span>
-									</ContextMenu.SubTrigger>
-									<ContextMenu.SubContent data-testid="sub-content">
-										<ContextMenu.Item data-testid="sub-item">
-											<span>Email</span>
-										</ContextMenu.Item>
-										<ContextMenu.CheckboxItem
-											bind:checked={subChecked}
-											data-testid="sub-checkbox-item"
-										>
-											{#snippet children({
-												checked,
-												indeterminate: _indeterminate,
-											})}
-												<span data-testid="sub-checkbox-indicator">
-													{checked}
-												</span>
-												sub checkbox
-											{/snippet}
-										</ContextMenu.CheckboxItem>
-									</ContextMenu.SubContent>
-								</ContextMenu.Sub>
-								<ContextMenu.Item disabled data-testid="disabled-item"
-									>disabled item</ContextMenu.Item
-								>
-								<ContextMenu.Item disabled data-testid="disabled-item-2"
-									>disabled item 2</ContextMenu.Item
-								>
-								<ContextMenu.CheckboxItem bind:checked data-testid="checkbox-item">
-									{#snippet children({ checked, indeterminate: _indeterminate })}
-										<span data-testid="checkbox-indicator">
-											{checked}
-										</span>
-										Checkbox Item
-									{/snippet}
-								</ContextMenu.CheckboxItem>
-								<ContextMenu.Item data-testid="item-2">item 2</ContextMenu.Item>
-								<ContextMenu.RadioGroup
-									bind:value={radio}
-									data-testid="radio-group"
-								>
-									<ContextMenu.RadioItem value="1" data-testid="radio-item">
-										{#snippet children({ checked })}
-											<span data-testid="radio-indicator-1">
-												{checked}
-											</span>
-											<span>Radio Item 1</span>
-										{/snippet}
-									</ContextMenu.RadioItem>
-									<ContextMenu.RadioItem value="2" data-testid="radio-item-2">
-										{#snippet children({ checked })}
-											<span data-testid="radio-indicator-2">
-												{checked}
-											</span>
-											<span>Radio Item 2</span>
-										{/snippet}
-									</ContextMenu.RadioItem>
-								</ContextMenu.RadioGroup>
-							</div>
+						{#snippet child(props)}
+							{@render Content(props)}
 						{/snippet}
 					</ContextMenu.Content>
 				{/if}

--- a/packages/tests/src/tests/dropdown-menu/dropdown-menu-force-mount-test.svelte
+++ b/packages/tests/src/tests/dropdown-menu/dropdown-menu-force-mount-test.svelte
@@ -28,6 +28,82 @@
 	}: DropdownMenuForceMountTestProps = $props();
 </script>
 
+{#snippet Content({
+	props,
+	wrapperProps,
+}: {
+	props: Record<string, unknown>;
+	wrapperProps: Record<string, unknown>;
+})}
+	<div {...wrapperProps}>
+		<div {...props}>
+			<DropdownMenu.Separator data-testid="separator" />
+			<DropdownMenu.Group data-testid="group">
+				<DropdownMenu.GroupHeading data-testid="group-heading"
+					>Stuff</DropdownMenu.GroupHeading
+				>
+				<DropdownMenu.Item data-testid="item">
+					<span>item</span>
+				</DropdownMenu.Item>
+			</DropdownMenu.Group>
+
+			<DropdownMenu.Sub>
+				<DropdownMenu.SubTrigger data-testid="sub-trigger">
+					<span>subtrigger</span>
+				</DropdownMenu.SubTrigger>
+				<DropdownMenu.SubContent data-testid="sub-content" {...subContentProps}>
+					<DropdownMenu.Item data-testid="sub-item">
+						<span>Email</span>
+					</DropdownMenu.Item>
+					<DropdownMenu.CheckboxItem
+						bind:checked={subChecked}
+						data-testid="sub-checkbox-item"
+					>
+						{#snippet children({ checked, indeterminate: _indeterminate })}
+							<span data-testid="sub-checkbox-indicator">
+								{checked}
+							</span>
+							sub checkbox
+						{/snippet}
+					</DropdownMenu.CheckboxItem>
+				</DropdownMenu.SubContent>
+			</DropdownMenu.Sub>
+			<DropdownMenu.Item disabled data-testid="disabled-item">disabled item</DropdownMenu.Item
+			>
+			<DropdownMenu.Item disabled data-testid="disabled-item-2"
+				>disabled item 2</DropdownMenu.Item
+			>
+			<DropdownMenu.CheckboxItem bind:checked data-testid="checkbox-item">
+				{#snippet children({ checked, indeterminate: _indeterminate })}
+					<span data-testid="checkbox-indicator">
+						{checked}
+					</span>
+					Checkbox Item
+				{/snippet}
+			</DropdownMenu.CheckboxItem>
+			<DropdownMenu.Item data-testid="item-2">item 2</DropdownMenu.Item>
+			<DropdownMenu.RadioGroup bind:value={radio} data-testid="radio-group">
+				<DropdownMenu.RadioItem value="1" data-testid="radio-item">
+					{#snippet children({ checked })}
+						<span data-testid="radio-indicator-1">
+							{checked}
+						</span>
+						<span>Radio Item 1</span>
+					{/snippet}
+				</DropdownMenu.RadioItem>
+				<DropdownMenu.RadioItem value="2" data-testid="radio-item-2">
+					{#snippet children({ checked })}
+						<span data-testid="radio-indicator-2">
+							{checked}
+						</span>
+						<span>Radio Item 2</span>
+					{/snippet}
+				</DropdownMenu.RadioItem>
+			</DropdownMenu.RadioGroup>
+		</div>
+	</div>
+{/snippet}
+
 <main>
 	<div data-testid="outside">outside</div>
 	<div data-testid="non-portal-container">
@@ -36,175 +112,16 @@
 			<DropdownMenu.Portal {...portalProps}>
 				{#if withOpenCheck}
 					<DropdownMenu.Content data-testid="content" {...contentProps} forceMount>
-						{#snippet child({ props, open })}
-							{#if open}
-								<div {...props}>
-									<DropdownMenu.Separator data-testid="separator" />
-									<DropdownMenu.Group data-testid="group">
-										<DropdownMenu.GroupHeading data-testid="group-heading"
-											>Stuff</DropdownMenu.GroupHeading
-										>
-										<DropdownMenu.Item data-testid="item">
-											<span>item</span>
-										</DropdownMenu.Item>
-									</DropdownMenu.Group>
-
-									<DropdownMenu.Sub>
-										<DropdownMenu.SubTrigger data-testid="sub-trigger">
-											<span>subtrigger</span>
-										</DropdownMenu.SubTrigger>
-										<DropdownMenu.SubContent
-											data-testid="sub-content"
-											{...subContentProps}
-										>
-											<DropdownMenu.Item data-testid="sub-item">
-												<span>Email</span>
-											</DropdownMenu.Item>
-											<DropdownMenu.CheckboxItem
-												bind:checked={subChecked}
-												data-testid="sub-checkbox-item"
-											>
-												{#snippet children({
-													checked,
-													indeterminate: _indeterminate,
-												})}
-													<span data-testid="sub-checkbox-indicator">
-														{checked}
-													</span>
-													sub checkbox
-												{/snippet}
-											</DropdownMenu.CheckboxItem>
-										</DropdownMenu.SubContent>
-									</DropdownMenu.Sub>
-									<DropdownMenu.Item disabled data-testid="disabled-item"
-										>disabled item</DropdownMenu.Item
-									>
-									<DropdownMenu.Item disabled data-testid="disabled-item-2"
-										>disabled item 2</DropdownMenu.Item
-									>
-									<DropdownMenu.CheckboxItem
-										bind:checked
-										data-testid="checkbox-item"
-									>
-										{#snippet children({
-											checked,
-											indeterminate: _indeterminate,
-										})}
-											<span data-testid="checkbox-indicator">
-												{checked}
-											</span>
-											Checkbox Item
-										{/snippet}
-									</DropdownMenu.CheckboxItem>
-									<DropdownMenu.Item data-testid="item-2"
-										>item 2</DropdownMenu.Item
-									>
-									<DropdownMenu.RadioGroup
-										bind:value={radio}
-										data-testid="radio-group"
-									>
-										<DropdownMenu.RadioItem value="1" data-testid="radio-item">
-											{#snippet children({ checked })}
-												<span data-testid="radio-indicator-1">
-													{checked}
-												</span>
-												<span>Radio Item 1</span>
-											{/snippet}
-										</DropdownMenu.RadioItem>
-										<DropdownMenu.RadioItem
-											value="2"
-											data-testid="radio-item-2"
-										>
-											{#snippet children({ checked })}
-												<span data-testid="radio-indicator-2">
-													{checked}
-												</span>
-												<span>Radio Item 2</span>
-											{/snippet}
-										</DropdownMenu.RadioItem>
-									</DropdownMenu.RadioGroup>
-								</div>
+						{#snippet child(props)}
+							{#if props.open}
+								{@render Content(props)}
 							{/if}
 						{/snippet}
 					</DropdownMenu.Content>
 				{:else}
 					<DropdownMenu.Content data-testid="content" {...contentProps} forceMount>
-						{#snippet child({ props, open: _open })}
-							<div {...props}>
-								<DropdownMenu.Separator data-testid="separator" />
-								<DropdownMenu.Group data-testid="group">
-									<DropdownMenu.GroupHeading data-testid="group-heading"
-										>Stuff</DropdownMenu.GroupHeading
-									>
-									<DropdownMenu.Item data-testid="item">
-										<span>item</span>
-									</DropdownMenu.Item>
-								</DropdownMenu.Group>
-
-								<DropdownMenu.Sub>
-									<DropdownMenu.SubTrigger data-testid="sub-trigger">
-										<span>subtrigger</span>
-									</DropdownMenu.SubTrigger>
-									<DropdownMenu.SubContent
-										data-testid="sub-content"
-										{...subContentProps}
-									>
-										<DropdownMenu.Item data-testid="sub-item">
-											<span>Email</span>
-										</DropdownMenu.Item>
-										<DropdownMenu.CheckboxItem
-											bind:checked={subChecked}
-											data-testid="sub-checkbox-item"
-										>
-											{#snippet children({
-												checked,
-												indeterminate: _indeterminate,
-											})}
-												<span data-testid="sub-checkbox-indicator">
-													{checked}
-												</span>
-												sub checkbox
-											{/snippet}
-										</DropdownMenu.CheckboxItem>
-									</DropdownMenu.SubContent>
-								</DropdownMenu.Sub>
-								<DropdownMenu.Item disabled data-testid="disabled-item"
-									>disabled item</DropdownMenu.Item
-								>
-								<DropdownMenu.Item disabled data-testid="disabled-item-2"
-									>disabled item 2</DropdownMenu.Item
-								>
-								<DropdownMenu.CheckboxItem bind:checked data-testid="checkbox-item">
-									{#snippet children({ checked, indeterminate: _indeterminate })}
-										<span data-testid="checkbox-indicator">
-											{checked}
-										</span>
-										Checkbox Item
-									{/snippet}
-								</DropdownMenu.CheckboxItem>
-								<DropdownMenu.Item data-testid="item-2">item 2</DropdownMenu.Item>
-								<DropdownMenu.RadioGroup
-									bind:value={radio}
-									data-testid="radio-group"
-								>
-									<DropdownMenu.RadioItem value="1" data-testid="radio-item">
-										{#snippet children({ checked })}
-											<span data-testid="radio-indicator-1">
-												{checked}
-											</span>
-											<span>Radio Item 1</span>
-										{/snippet}
-									</DropdownMenu.RadioItem>
-									<DropdownMenu.RadioItem value="2" data-testid="radio-item-2">
-										{#snippet children({ checked })}
-											<span data-testid="radio-indicator-2">
-												{checked}
-											</span>
-											<span>Radio Item 2</span>
-										{/snippet}
-									</DropdownMenu.RadioItem>
-								</DropdownMenu.RadioGroup>
-							</div>
+						{#snippet child(props)}
+							{@render Content(props)}
 						{/snippet}
 					</DropdownMenu.Content>
 				{/if}

--- a/packages/tests/src/tests/link-preview/link-preview-force-mount-test.svelte
+++ b/packages/tests/src/tests/link-preview/link-preview-force-mount-test.svelte
@@ -17,6 +17,18 @@
 	}: LinkPreviewForceMountTestProps = $props();
 </script>
 
+{#snippet Content({
+	props,
+	wrapperProps,
+}: {
+	props: Record<string, unknown>;
+	wrapperProps: Record<string, unknown>;
+})}
+	<div {...wrapperProps}>
+		<div {...props}>Content</div>
+	</div>
+{/snippet}
+
 <main data-testid="main">
 	<LinkPreview.Root bind:open {...restProps} openDelay={50} closeDelay={50}>
 		<LinkPreview.Trigger
@@ -35,9 +47,9 @@
 					{...contentProps}
 					forceMount
 				>
-					{#snippet child({ props, open })}
-						{#if open}
-							<div {...props}>Content</div>
+					{#snippet child(props)}
+						{#if props.open}
+							{@render Content(props)}
 						{/if}
 					{/snippet}
 				</LinkPreview.Content>
@@ -48,8 +60,8 @@
 					{...contentProps}
 					forceMount
 				>
-					{#snippet child({ props, open: _open })}
-						<div {...props}>Content</div>
+					{#snippet child(props)}
+						{@render Content(props)}
 					{/snippet}
 				</LinkPreview.Content>
 			{/if}

--- a/packages/tests/src/tests/popover/popover-force-mount-test.svelte
+++ b/packages/tests/src/tests/popover/popover-force-mount-test.svelte
@@ -17,30 +17,38 @@
 	}: PopoverForceMountTestProps = $props();
 </script>
 
+{#snippet Content({
+	props,
+	wrapperProps,
+}: {
+	props: Record<string, unknown>;
+	wrapperProps: Record<string, unknown>;
+})}
+	<div {...wrapperProps}>
+		<div {...props}>
+			content
+			<Popover.Close data-testid="close">close</Popover.Close>
+			<Popover.Arrow data-testid="arrow" />
+		</div>
+	</div>
+{/snippet}
+
 <main data-testid="main">
 	<Popover.Root bind:open {...restProps}>
 		<Popover.Trigger data-testid="trigger">trigger</Popover.Trigger>
 		<Popover.Portal {...portalProps}>
 			{#if withOpenCheck}
 				<Popover.Content {...contentProps} data-testid="content" forceMount>
-					{#snippet child({ props, open })}
-						{#if open}
-							<div {...props}>
-								content
-								<Popover.Close data-testid="close">close</Popover.Close>
-								<Popover.Arrow data-testid="arrow" />
-							</div>
+					{#snippet child(props)}
+						{#if props.open}
+							{@render Content(props)}
 						{/if}
 					{/snippet}
 				</Popover.Content>
 			{:else}
 				<Popover.Content {...contentProps} data-testid="content" forceMount>
-					{#snippet child({ props, open: _open })}
-						<div {...props}>
-							content
-							<Popover.Close data-testid="close">close</Popover.Close>
-							<Popover.Arrow data-testid="arrow" />
-						</div>
+					{#snippet child(props)}
+						{@render Content(props)}
 					{/snippet}
 				</Popover.Content>
 			{/if}

--- a/packages/tests/src/tests/select/select-force-mount-test.svelte
+++ b/packages/tests/src/tests/select/select-force-mount-test.svelte
@@ -42,6 +42,33 @@
 	const selectedLabel = $derived(filteredItems.find((item) => item.value === value)?.label);
 </script>
 
+{#snippet Content({
+	props,
+	wrapperProps,
+}: {
+	props: Record<string, unknown>;
+	wrapperProps: Record<string, unknown>;
+})}
+	<div {...wrapperProps}>
+		<div {...props}>
+			<Select.Group data-testid="group">
+				<Select.GroupHeading data-testid="group-label">Options</Select.GroupHeading>
+				{#each filteredItems as { value, label, disabled }}
+					{@const testId = generateTestId(value)}
+					<Select.Item data-testid={testId} {disabled} {value} {label}>
+						{#snippet children({ selected, highlighted: _highlighted })}
+							{#if selected}
+								<span data-testid="{testId}-indicator">x</span>
+							{/if}
+							{label}
+						{/snippet}
+					</Select.Item>
+				{/each}
+			</Select.Group>
+		</div>
+	</div>
+{/snippet}
+
 <main data-testid="main">
 	<Select.Root bind:value bind:open {...restProps}>
 		<Select.Trigger data-testid="trigger">
@@ -54,58 +81,16 @@
 		<Select.Portal {...portalProps}>
 			{#if withOpenCheck}
 				<Select.Content data-testid="content" {...contentProps} forceMount>
-					{#snippet child({ props, open })}
-						{#if open}
-							<div {...props}>
-								<Select.Group data-testid="group">
-									<Select.GroupHeading data-testid="group-label"
-										>Options</Select.GroupHeading
-									>
-									{#each filteredItems as { value, label, disabled }}
-										{@const testId = generateTestId(value)}
-										<Select.Item
-											data-testid={testId}
-											{disabled}
-											{value}
-											{label}
-										>
-											{#snippet children({
-												selected,
-												highlighted: _highlighted,
-											})}
-												{#if selected}
-													<span data-testid="{testId}-indicator">x</span>
-												{/if}
-												{label}
-											{/snippet}
-										</Select.Item>
-									{/each}
-								</Select.Group>
-							</div>
+					{#snippet child(props)}
+						{#if props.open}
+							{@render Content(props)}
 						{/if}
 					{/snippet}
 				</Select.Content>
 			{:else}
 				<Select.Content data-testid="content" {...contentProps} forceMount>
-					{#snippet child({ props, open: _open })}
-						<div {...props}>
-							<Select.Group data-testid="group">
-								<Select.GroupHeading data-testid="group-label"
-									>Options</Select.GroupHeading
-								>
-								{#each filteredItems as { value, label, disabled }}
-									{@const testId = generateTestId(value)}
-									<Select.Item data-testid={testId} {disabled} {value} {label}>
-										{#snippet children({ selected, highlighted: _highlighted })}
-											{#if selected}
-												<span data-testid="{testId}-indicator">x</span>
-											{/if}
-											{label}
-										{/snippet}
-									</Select.Item>
-								{/each}
-							</Select.Group>
-						</div>
+					{#snippet child(props)}
+						{@render Content(props)}
 					{/snippet}
 				</Select.Content>
 			{/if}

--- a/packages/tests/src/tests/tooltip/tooltip-force-mount-test.svelte
+++ b/packages/tests/src/tests/tooltip/tooltip-force-mount-test.svelte
@@ -18,6 +18,18 @@
 	}: TooltipForceMountTestProps = $props();
 </script>
 
+{#snippet Content({
+	props,
+	wrapperProps,
+}: {
+	props: Record<string, unknown>;
+	wrapperProps: Record<string, unknown>;
+})}
+	<div {...wrapperProps}>
+		<div {...props}>Content</div>
+	</div>
+{/snippet}
+
 <main data-testid="main">
 	<Tooltip.Provider delayDuration={0}>
 		<Tooltip.Root bind:open {...restProps}>
@@ -30,9 +42,9 @@
 						class="w-80"
 						forceMount
 					>
-						{#snippet child({ props, open })}
-							{#if open}
-								<div {...props}>Content</div>
+						{#snippet child(props)}
+							{#if props.open}
+								{@render Content(props)}
 							{/if}
 						{/snippet}
 					</Tooltip.Content>
@@ -43,8 +55,8 @@
 						class="w-80"
 						forceMount
 					>
-						{#snippet child({ props, open: _open })}
-							<div {...props}>Content</div>
+						{#snippet child(props)}
+							{@render Content(props)}
 						{/snippet}
 					</Tooltip.Content>
 				{/if}

--- a/sites/docs/content/child-snippet.md
+++ b/sites/docs/content/child-snippet.md
@@ -74,3 +74,49 @@ Behind the scenes, components using the child prop typically implement logic sim
 	</button>
 {/if}
 ```
+
+## Floating Content Components
+
+Floating content components (tooltips, popovers, dropdowns, etc.) require special handling when used with the `child` snippet due to their positioning requirements with Floating UI.
+
+### Implementation Details
+
+When implementing floating content, you must:
+
+-   Include a wrapper element within the `child` snippet
+-   Spread the `wrapperProps` prop to this wrapper element
+-   Place your floating content inside this wrapper
+
+```svelte {4,8} /wrapperProps/
+<Popover.Content>
+	{#snippet child({ wrapperProps, props, open })}
+		{#if open}
+			<div {...wrapperProps}>
+				<div {...props}>
+					<!-- ... -->
+				</div>
+			</div>
+		{/if}
+	{/snippet}
+</Popover.Content>
+```
+
+### Important Considerations
+
+-   The wrapper element must remain unstyled as its positioning is managed internally by Floating UI
+-   The `wrapperProps` contain computed positioning data essential for proper floating behavior
+-   Modifying the wrapper element's styles or structure may break positioning calculations
+
+### Affected Components
+
+The following components require a wrapper element:
+
+-   `Combobox.Content`
+-   `DatePicker.Content`
+-   `DateRangePicker.Content`
+-   `DropdownMenu.Content`
+-   `LinkPreview.Content`
+-   `Menubar.Content`
+-   `Popover.Content`
+-   `Select.Content`
+-   `Tooltip.Content`

--- a/sites/docs/content/components/combobox.md
+++ b/sites/docs/content/components/combobox.md
@@ -433,10 +433,12 @@ You can use the `forceMount` prop along with the `child` snippet to forcefully m
 </script>
 
 <Combobox.Content forceMount>
-	{#snippet child({ props, open })}
+	{#snippet child({ wrapperProps, props, open })}
 		{#if open}
-			<div {...props} transition:fly>
-				<!-- ... -->
+			<div {...wrapperProps}>
+				<div {...props} transition:fly>
+					<!-- ... -->
+				</div>
 			</div>
 		{/if}
 	{/snippet}

--- a/sites/docs/content/components/context-menu.md
+++ b/sites/docs/content/components/context-menu.md
@@ -305,8 +305,6 @@ You can create nested menus using the `ContextMenu.Sub` component to create comp
 </ContextMenu.Content>
 ```
 
-<!-- <ContextMenuDemoNested /> -->
-
 ## Svelte Transitions
 
 You can use the `forceMount` prop along with the `child` snippet to forcefully mount the `ContextMenu.Content` component to use Svelte Transitions or another animation library that requires more control.
@@ -318,11 +316,13 @@ You can use the `forceMount` prop along with the `child` snippet to forcefully m
 </script>
 
 <ContextMenu.Content forceMount>
-	{#snippet child({ props, open })}
+	{#snippet child({ wrapperProps, props, open })}
 		{#if open}
-			<div {...props} transition:fly>
-				<ContextMenu.Item>Item 1</ContextMenu.Item>
-				<ContextMenu.Item>Item 2</ContextMenu.Item>
+			<div {...wrapperProps}>
+				<div {...props} transition:fly>
+					<ContextMenu.Item>Item 1</ContextMenu.Item>
+					<ContextMenu.Item>Item 2</ContextMenu.Item>
+				</div>
 			</div>
 		{/if}
 	{/snippet}

--- a/sites/docs/content/components/dropdown-menu.md
+++ b/sites/docs/content/components/dropdown-menu.md
@@ -333,11 +333,13 @@ You can use the `forceMount` prop along with the `child` snippet to forcefully m
 </script>
 
 <DropdownMenu.Content forceMount>
-	{#snippet child({ props, open })}
+	{#snippet child({ wrapperProps, props, open })}
 		{#if open}
-			<div {...props} transition:fly>
-				<DropdownMenu.Item>Item 1</DropdownMenu.Item>
-				<DropdownMenu.Item>Item 2</DropdownMenu.Item>
+			<div {...wrapperProps}>
+				<div {...props} transition:fly>
+					<DropdownMenu.Item>Item 1</DropdownMenu.Item>
+					<DropdownMenu.Item>Item 2</DropdownMenu.Item>
+				</div>
 			</div>
 		{/if}
 	{/snippet}

--- a/sites/docs/content/components/link-preview.md
+++ b/sites/docs/content/components/link-preview.md
@@ -182,10 +182,12 @@ You can use the `forceMount` prop along with the `child` snippet to forcefully m
 </script>
 
 <LinkPreview.Content forceMount>
-	{#snippet child({ props, open })}
+	{#snippet child({ wrapperProps, props, open })}
 		{#if open}
-			<div {...props} transition:fly>
-				<!-- ... -->
+			<div {...wrapperProps}>
+				<div {...props} transition:fly>
+					<!-- ... -->
+				</div>
 			</div>
 		{/if}
 	{/snippet}

--- a/sites/docs/content/components/menubar.md
+++ b/sites/docs/content/components/menubar.md
@@ -272,11 +272,13 @@ You can use the `forceMount` prop along with the `child` snippet to forcefully m
 </script>
 
 <Menubar.Content forceMount>
-	{#snippet child({ props, open })}
+	{#snippet child({ wrapperProps, props, open })}
 		{#if open}
-			<div {...props} transition:fly>
-				<Menubar.Item>Item 1</Menubar.Item>
-				<Menubar.Item>Item 2</Menubar.Item>
+			<div {...wrapperProps}>
+				<div {...props} transition:fly>
+					<Menubar.Item>Item 1</Menubar.Item>
+					<Menubar.Item>Item 2</Menubar.Item>
+				</div>
 			</div>
 		{/if}
 	{/snippet}

--- a/sites/docs/content/components/popover.md
+++ b/sites/docs/content/components/popover.md
@@ -278,10 +278,12 @@ You can use the `forceMount` prop along with the `child` snippet to forcefully m
 </script>
 
 <Popover.Content forceMount>
-	{#snippet child({ props, open })}
+	{#snippet child({ wrapperProps, props, open })}
 		{#if open}
-			<div {...props} transition:fly>
-				<!-- ... -->
+			<div {...wrapperProps}>
+				<div {...props} transition:fly>
+					<!-- ... -->
+				</div>
 			</div>
 		{/if}
 	{/snippet}

--- a/sites/docs/content/components/select.md
+++ b/sites/docs/content/components/select.md
@@ -449,10 +449,12 @@ You can use the `forceMount` prop along with the `child` snippet to forcefully m
 </script>
 
 <Select.Content forceMount>
-	{#snippet child({ props, open })}
+	{#snippet child({ wrapperProps, props, open })}
 		{#if open}
-			<div {...props} transition:fly>
-				<!-- ... -->
+			<div {...wrapperProps}>
+				<div {...props} transition:fly>
+					<!-- ... -->
+				</div>
 			</div>
 		{/if}
 	{/snippet}

--- a/sites/docs/content/components/tooltip.md
+++ b/sites/docs/content/components/tooltip.md
@@ -302,10 +302,12 @@ You can use the `forceMount` prop along with the `child` snippet to forcefully m
 <Tooltip.Root>
 	<!-- ... other tooltip components -->
 	<Tooltip.Content forceMount>
-		{#snippet child({ props, open })}
+		{#snippet child({ wrapperProps, props, open })}
 			{#if open}
-				<div {...props} transition:fly>
-					<!-- ... -->
+				<div {...wrapperProps}>
+					<div {...props} transition:fly>
+						<!-- ... -->
+					</div>
 				</div>
 			{/if}
 		{/snippet}

--- a/sites/docs/content/transitions.md
+++ b/sites/docs/content/transitions.md
@@ -4,7 +4,7 @@ description: Learn how to use transitions with Bits UI components.
 ---
 
 <script>
-	import Callout from '$lib/components/Callout.svelte';
+	import Callout from '$lib/components/callout.svelte';
 </script>
 
 Svelte Transitions are one of the awesome features of Svelte. Unfortunately, they don't play very nicely with components, due to the fact that they rely on various directives like `in:`, `out:`, and `transition:`, which aren't supported by components.

--- a/sites/docs/content/transitions.md
+++ b/sites/docs/content/transitions.md
@@ -3,6 +3,10 @@ title: Transitions
 description: Learn how to use transitions with Bits UI components.
 ---
 
+<script>
+	import Callout from '$lib/components/Callout.svelte';
+</script>
+
 Svelte Transitions are one of the awesome features of Svelte. Unfortunately, they don't play very nicely with components, due to the fact that they rely on various directives like `in:`, `out:`, and `transition:`, which aren't supported by components.
 
 In previous version of Bits UI, we had a workaround for this by exposing a ton of `transition*` props on the components that we felt were most likely to be used with transitions. However, this was a bit of a hack and limited us to _only_ Svelte Transitions, and users who wanted to use other libraries or just CSS were left out.
@@ -91,4 +95,34 @@ Which can then be used alongside the other `Dialog.*` components:
 		</MyDialogContent>
 	</Dialog.Portal>
 </Dialog.Root>
+```
+
+### Floating Content Components
+
+`Content` components that rely on Floating UI require a slight modification to how the `child` snippet is used.
+
+For example, if we were to use the `Popover.Content` component, we need to add a wrapper element within the `child` snippet, and spread the `wrapperProps` snippet prop to it.
+
+```svelte {12,16} /wrapperProps,/
+<script lang="ts">
+	import { Popover } from "bits-ui";
+	import { fly } from "svelte/transition";
+</script>
+
+<Popover.Root>
+	<Popover.Trigger>Open Popover</Popover.Trigger>
+	<Popover.Portal>
+		<Popover.Content forceMount>
+			{#snippet child({ wrapperProps, props, open })}
+				{#if open}
+					<div {...wrapperProps}>
+						<div {...props} transition:fly>
+							<!-- ... -->
+						</div>
+					</div>
+				{/if}
+			{/snippet}
+		</Popover.Content>
+	</Popover.Portal>
+</Popover.Root>
 ```

--- a/sites/docs/src/lib/components/demos/combobox-demo-transition.svelte
+++ b/sites/docs/src/lib/components/demos/combobox-demo-transition.svelte
@@ -66,37 +66,43 @@
 			sideOffset={10}
 			forceMount
 		>
-			{#snippet child({ props, open })}
+			{#snippet child({ wrapperProps, props, open })}
 				{#if open}
-					<div {...props} transition:fly={{ duration: 300 }}>
-						<Combobox.ScrollUpButton class="flex w-full items-center justify-center">
-							<CaretDoubleUp class="size-3" />
-						</Combobox.ScrollUpButton>
-						<Combobox.Viewport class="p-1">
-							{#each filteredFruits as fruit, i (i + fruit.value)}
-								<Combobox.Item
-									class="flex h-10 w-full select-none items-center rounded-button py-3 pl-5 pr-1.5 text-sm capitalize outline-none  data-[highlighted]:bg-muted"
-									value={fruit.value}
-									label={fruit.label}
-								>
-									{#snippet children({ selected })}
-										{fruit.label}
-										{#if selected}
-											<div class="ml-auto">
-												<Check />
-											</div>
-										{/if}
-									{/snippet}
-								</Combobox.Item>
-							{:else}
-								<span class="block px-5 py-2 text-sm text-muted-foreground">
-									No results found, try again.
-								</span>
-							{/each}
-						</Combobox.Viewport>
-						<Combobox.ScrollDownButton class="flex w-full items-center justify-center">
-							<CaretDoubleDown class="size-3" />
-						</Combobox.ScrollDownButton>
+					<div {...wrapperProps}>
+						<div {...props} transition:fly={{ duration: 300 }}>
+							<Combobox.ScrollUpButton
+								class="flex w-full items-center justify-center"
+							>
+								<CaretDoubleUp class="size-3" />
+							</Combobox.ScrollUpButton>
+							<Combobox.Viewport class="p-1">
+								{#each filteredFruits as fruit, i (i + fruit.value)}
+									<Combobox.Item
+										class="flex h-10 w-full select-none items-center rounded-button py-3 pl-5 pr-1.5 text-sm capitalize outline-none  data-[highlighted]:bg-muted"
+										value={fruit.value}
+										label={fruit.label}
+									>
+										{#snippet children({ selected })}
+											{fruit.label}
+											{#if selected}
+												<div class="ml-auto">
+													<Check />
+												</div>
+											{/if}
+										{/snippet}
+									</Combobox.Item>
+								{:else}
+									<span class="block px-5 py-2 text-sm text-muted-foreground">
+										No results found, try again.
+									</span>
+								{/each}
+							</Combobox.Viewport>
+							<Combobox.ScrollDownButton
+								class="flex w-full items-center justify-center"
+							>
+								<CaretDoubleDown class="size-3" />
+							</Combobox.ScrollDownButton>
+						</div>
 					</div>
 				{/if}
 			{/snippet}

--- a/sites/docs/src/lib/components/demos/context-menu-demo-transition.svelte
+++ b/sites/docs/src/lib/components/demos/context-menu-demo-transition.svelte
@@ -22,36 +22,16 @@
 			class="focus-override w-[229px] rounded-xl border border-muted bg-background px-1 py-1.5 shadow-popover outline-none focus-visible:outline-none"
 			forceMount
 		>
-			{#snippet child({ props, open })}
+			{#snippet child({ wrapperProps, props, open })}
 				{#if open}
-					<div {...props} transition:fly={{ duration: 300 }}>
-						<ContextMenu.Item
-							class="flex h-10 select-none items-center rounded-button py-3 pl-3 pr-1.5 text-sm font-medium outline-none !ring-0 !ring-transparent data-[highlighted]:bg-muted"
-						>
-							<div class="flex items-center">
-								<PencilSimpleLine class="mr-2 size-5 text-foreground-alt" />
-								Edit
-							</div>
-							<div class="ml-auto flex items-center gap-px">
-								<kbd
-									class="inline-flex size-5 items-center justify-center rounded-button border border-dark-10 bg-background-alt text-[13px] text-muted-foreground shadow-kbd"
-								>
-									⌘
-								</kbd>
-								<kbd
-									class="inline-flex size-5 items-center justify-center rounded-button border border-dark-10 bg-background-alt text-[11px] text-muted-foreground shadow-kbd"
-								>
-									E
-								</kbd>
-							</div>
-						</ContextMenu.Item>
-						<ContextMenu.Sub>
-							<ContextMenu.SubTrigger
-								class="flex h-10 select-none items-center rounded-button py-3 pl-3 pr-1.5 text-sm font-medium outline-none !ring-0 !ring-transparent data-[highlighted]:bg-muted data-[state=open]:bg-muted"
+					<div {...wrapperProps}>
+						<div {...props} transition:fly={{ duration: 300 }}>
+							<ContextMenu.Item
+								class="flex h-10 select-none items-center rounded-button py-3 pl-3 pr-1.5 text-sm font-medium outline-none !ring-0 !ring-transparent data-[highlighted]:bg-muted"
 							>
 								<div class="flex items-center">
-									<PlusCircle class="mr-2 size-5 text-foreground-alt" />
-									Add
+									<PencilSimpleLine class="mr-2 size-5 text-foreground-alt" />
+									Edit
 								</div>
 								<div class="ml-auto flex items-center gap-px">
 									<kbd
@@ -62,70 +42,92 @@
 									<kbd
 										class="inline-flex size-5 items-center justify-center rounded-button border border-dark-10 bg-background-alt text-[11px] text-muted-foreground shadow-kbd"
 									>
-										N
+										E
 									</kbd>
 								</div>
-							</ContextMenu.SubTrigger>
-							<ContextMenu.SubContent
-								class="z-[100] w-[209px] rounded-xl border border-muted bg-background px-1 py-1.5 shadow-popover !ring-0 !ring-transparent"
-								sideOffset={10}
+							</ContextMenu.Item>
+							<ContextMenu.Sub>
+								<ContextMenu.SubTrigger
+									class="flex h-10 select-none items-center rounded-button py-3 pl-3 pr-1.5 text-sm font-medium outline-none !ring-0 !ring-transparent data-[highlighted]:bg-muted data-[state=open]:bg-muted"
+								>
+									<div class="flex items-center">
+										<PlusCircle class="mr-2 size-5 text-foreground-alt" />
+										Add
+									</div>
+									<div class="ml-auto flex items-center gap-px">
+										<kbd
+											class="inline-flex size-5 items-center justify-center rounded-button border border-dark-10 bg-background-alt text-[13px] text-muted-foreground shadow-kbd"
+										>
+											⌘
+										</kbd>
+										<kbd
+											class="inline-flex size-5 items-center justify-center rounded-button border border-dark-10 bg-background-alt text-[11px] text-muted-foreground shadow-kbd"
+										>
+											N
+										</kbd>
+									</div>
+								</ContextMenu.SubTrigger>
+								<ContextMenu.SubContent
+									class="z-[100] w-[209px] rounded-xl border border-muted bg-background px-1 py-1.5 shadow-popover !ring-0 !ring-transparent"
+									sideOffset={10}
+								>
+									<ContextMenu.Item
+										class="flex h-10 select-none items-center rounded-button py-3 pl-3 pr-1.5 text-sm font-normal outline-none !ring-0 !ring-transparent data-[highlighted]:bg-muted"
+									>
+										Header
+									</ContextMenu.Item>
+									<ContextMenu.Item
+										class="flex h-10 select-none items-center rounded-button py-3 pl-3 pr-1.5 text-sm font-normal outline-none !ring-0 !ring-transparent data-[highlighted]:bg-muted"
+									>
+										Paragraph
+									</ContextMenu.Item>
+									<ContextMenu.Item
+										class="flex h-10 select-none items-center rounded-button py-3 pl-3 pr-1.5 text-sm font-normal outline-none !ring-0 !ring-transparent data-[highlighted]:bg-muted"
+									>
+										Codeblock
+									</ContextMenu.Item>
+									<ContextMenu.Item
+										class="flex h-10 select-none items-center rounded-button py-3 pl-3 pr-1.5 text-sm font-normal outline-none !ring-0 !ring-transparent data-[highlighted]:bg-muted"
+									>
+										List
+									</ContextMenu.Item>
+									<ContextMenu.Item
+										class="flex h-10 select-none items-center rounded-button py-3 pl-3 pr-1.5 text-sm font-normal outline-none !ring-0 !ring-transparent data-[highlighted]:bg-muted"
+									>
+										Task
+									</ContextMenu.Item>
+								</ContextMenu.SubContent>
+							</ContextMenu.Sub>
+							<ContextMenu.Item
+								class="flex h-10 select-none items-center rounded-button py-3 pl-3 pr-1.5 text-sm font-medium outline-none !ring-0 !ring-transparent data-[highlighted]:bg-muted"
 							>
-								<ContextMenu.Item
-									class="flex h-10 select-none items-center rounded-button py-3 pl-3 pr-1.5 text-sm font-normal outline-none !ring-0 !ring-transparent data-[highlighted]:bg-muted"
-								>
-									Header
-								</ContextMenu.Item>
-								<ContextMenu.Item
-									class="flex h-10 select-none items-center rounded-button py-3 pl-3 pr-1.5 text-sm font-normal outline-none !ring-0 !ring-transparent data-[highlighted]:bg-muted"
-								>
-									Paragraph
-								</ContextMenu.Item>
-								<ContextMenu.Item
-									class="flex h-10 select-none items-center rounded-button py-3 pl-3 pr-1.5 text-sm font-normal outline-none !ring-0 !ring-transparent data-[highlighted]:bg-muted"
-								>
-									Codeblock
-								</ContextMenu.Item>
-								<ContextMenu.Item
-									class="flex h-10 select-none items-center rounded-button py-3 pl-3 pr-1.5 text-sm font-normal outline-none !ring-0 !ring-transparent data-[highlighted]:bg-muted"
-								>
-									List
-								</ContextMenu.Item>
-								<ContextMenu.Item
-									class="flex h-10 select-none items-center rounded-button py-3 pl-3 pr-1.5 text-sm font-normal outline-none !ring-0 !ring-transparent data-[highlighted]:bg-muted"
-								>
-									Task
-								</ContextMenu.Item>
-							</ContextMenu.SubContent>
-						</ContextMenu.Sub>
-						<ContextMenu.Item
-							class="flex h-10 select-none items-center rounded-button py-3 pl-3 pr-1.5 text-sm font-medium outline-none !ring-0 !ring-transparent data-[highlighted]:bg-muted"
-						>
-							<div class="flex items-center">
-								<CopySimple class="mr-2 size-5 text-foreground-alt" />
-								Duplicate
-							</div>
-							<div class="ml-auto flex items-center gap-px">
-								<kbd
-									class="inline-flex size-5 items-center justify-center rounded-button border border-dark-10 bg-background-alt text-[13px] text-muted-foreground shadow-kbd"
-								>
-									⌘
-								</kbd>
-								<kbd
-									class="inline-flex size-5 items-center justify-center rounded-button border border-dark-10 bg-background-alt text-[11px] text-muted-foreground shadow-kbd"
-								>
-									D
-								</kbd>
-							</div>
-						</ContextMenu.Item>
-						<ContextMenu.Separator class="-mx-1 my-1 block h-px bg-muted" />
-						<ContextMenu.Item
-							class="flex h-10 select-none items-center rounded-button py-3 pl-3 pr-1.5 text-sm font-medium outline-none !ring-0 !ring-transparent data-[highlighted]:bg-muted"
-						>
-							<div class="flex items-center">
-								<Trash class="mr-2 size-5 text-foreground-alt" />
-								Delete
-							</div>
-						</ContextMenu.Item>
+								<div class="flex items-center">
+									<CopySimple class="mr-2 size-5 text-foreground-alt" />
+									Duplicate
+								</div>
+								<div class="ml-auto flex items-center gap-px">
+									<kbd
+										class="inline-flex size-5 items-center justify-center rounded-button border border-dark-10 bg-background-alt text-[13px] text-muted-foreground shadow-kbd"
+									>
+										⌘
+									</kbd>
+									<kbd
+										class="inline-flex size-5 items-center justify-center rounded-button border border-dark-10 bg-background-alt text-[11px] text-muted-foreground shadow-kbd"
+									>
+										D
+									</kbd>
+								</div>
+							</ContextMenu.Item>
+							<ContextMenu.Separator class="-mx-1 my-1 block h-px bg-muted" />
+							<ContextMenu.Item
+								class="flex h-10 select-none items-center rounded-button py-3 pl-3 pr-1.5 text-sm font-medium outline-none !ring-0 !ring-transparent data-[highlighted]:bg-muted"
+							>
+								<div class="flex items-center">
+									<Trash class="mr-2 size-5 text-foreground-alt" />
+									Delete
+								</div>
+							</ContextMenu.Item>
+						</div>
 					</div>
 				{/if}
 			{/snippet}

--- a/sites/docs/src/lib/components/demos/dropdown-menu-demo-transition.svelte
+++ b/sites/docs/src/lib/components/demos/dropdown-menu-demo-transition.svelte
@@ -27,203 +27,205 @@
 			sideOffset={8}
 			forceMount
 		>
-			{#snippet child({ props, open })}
+			{#snippet child({ wrapperProps, props, open })}
 				{#if open}
-					<div {...props} transition:fly={{ duration: 300 }}>
-						<DropdownMenu.Item
-							class="flex h-10 select-none items-center rounded-button py-3 pl-3 pr-1.5 text-sm font-medium !ring-0 !ring-transparent data-[highlighted]:bg-muted"
-						>
-							<div class="flex items-center">
-								<UserCircle class="mr-2 size-5 text-foreground-alt" />
-								Profile
-							</div>
-							<div class="ml-auto flex items-center gap-px">
-								<kbd
-									class="inline-flex size-5 items-center justify-center rounded-button border border-dark-10 bg-background-alt text-xs text-muted-foreground shadow-kbd"
-								>
-									⌘
-								</kbd>
-								<kbd
-									class="inline-flex size-5 items-center justify-center rounded-button border border-dark-10 bg-background-alt text-[10px] text-muted-foreground shadow-kbd"
-								>
-									P
-								</kbd>
-							</div>
-						</DropdownMenu.Item>
-						<DropdownMenu.Item
-							class="flex h-10 select-none items-center rounded-button py-3 pl-3 pr-1.5 text-sm font-medium !ring-0 !ring-transparent data-[highlighted]:bg-muted"
-						>
-							<div class="flex items-center">
-								<Cardholder class="mr-2 size-5 text-foreground-alt" />
-								Billing
-							</div>
-							<div class="ml-auto flex items-center gap-px">
-								<kbd
-									class="inline-flex size-5 items-center justify-center rounded-button border border-dark-10 bg-background-alt text-xs text-muted-foreground shadow-kbd"
-								>
-									⌘
-								</kbd>
-								<kbd
-									class="inline-flex size-5 items-center justify-center rounded-button border border-dark-10 bg-background-alt text-[10px] text-muted-foreground shadow-kbd"
-								>
-									B
-								</kbd>
-							</div>
-						</DropdownMenu.Item>
-						<DropdownMenu.Item
-							class="flex h-10 select-none items-center rounded-button py-3 pl-3 pr-1.5 text-sm font-medium !ring-0 !ring-transparent data-[highlighted]:bg-muted"
-						>
-							<div class="flex items-center">
-								<GearSix class="mr-2 size-5 text-foreground-alt" />
-								Settings
-							</div>
-							<div class="ml-auto flex items-center gap-px">
-								<kbd
-									class="inline-flex size-5 items-center justify-center rounded-button border border-dark-10 bg-background-alt text-xs text-muted-foreground shadow-kbd"
-								>
-									⌘
-								</kbd>
-								<kbd
-									class="inline-flex size-5 items-center justify-center rounded-button border border-dark-10 bg-background-alt text-[10px] text-muted-foreground shadow-kbd"
-								>
-									S
-								</kbd>
-							</div>
-						</DropdownMenu.Item>
-						<DropdownMenu.CheckboxItem
-							bind:checked={notifications}
-							class="flex h-10 select-none items-center rounded-button py-3 pl-3 pr-1.5 text-sm font-medium !ring-0 !ring-transparent data-[highlighted]:bg-muted"
-						>
-							{#snippet children({ checked })}
-								<div class="flex items-center pr-4">
-									<Bell class="mr-2 size-5 text-foreground-alt" />
-									Notifications
-								</div>
-								<div class="ml-auto flex items-center gap-px">
-									{#if checked}
-										<Check class="size-4" />
-									{/if}
-								</div>
-							{/snippet}
-						</DropdownMenu.CheckboxItem>
-						<DropdownMenu.Sub>
-							<DropdownMenu.SubTrigger
-								class="flex h-10 select-none items-center rounded-button py-3 pl-3 pr-1.5 text-sm font-medium !ring-0 !ring-transparent data-[highlighted]:bg-muted data-[state=open]:bg-muted"
+					<div {...wrapperProps}>
+						<div {...props} transition:fly={{ duration: 300 }}>
+							<DropdownMenu.Item
+								class="flex h-10 select-none items-center rounded-button py-3 pl-3 pr-1.5 text-sm font-medium !ring-0 !ring-transparent data-[highlighted]:bg-muted"
 							>
 								<div class="flex items-center">
-									<UserCirclePlus class="mr-2 size-5 text-foreground-alt" />
-									Workspace
+									<UserCircle class="mr-2 size-5 text-foreground-alt" />
+									Profile
 								</div>
 								<div class="ml-auto flex items-center gap-px">
-									<CaretRight class="size-5 text-foreground-alt" />
+									<kbd
+										class="inline-flex size-5 items-center justify-center rounded-button border border-dark-10 bg-background-alt text-xs text-muted-foreground shadow-kbd"
+									>
+										⌘
+									</kbd>
+									<kbd
+										class="inline-flex size-5 items-center justify-center rounded-button border border-dark-10 bg-background-alt text-[10px] text-muted-foreground shadow-kbd"
+									>
+										P
+									</kbd>
 								</div>
-							</DropdownMenu.SubTrigger>
-							<DropdownMenu.SubContent
-								id="subcontent"
-								class="w-[209px] rounded-xl border border-muted bg-background px-1 py-1.5 shadow-popover !ring-0 !ring-transparent"
-								sideOffset={10}
+							</DropdownMenu.Item>
+							<DropdownMenu.Item
+								class="flex h-10 select-none items-center rounded-button py-3 pl-3 pr-1.5 text-sm font-medium !ring-0 !ring-transparent data-[highlighted]:bg-muted"
 							>
-								<DropdownMenu.RadioGroup bind:value={invited}>
-									<DropdownMenu.RadioItem
-										value="huntabyte"
-										class="flex h-10 select-none items-center rounded-button py-3 pl-3 pr-1.5 text-sm font-medium !ring-0 !ring-transparent data-[highlighted]:bg-muted"
+								<div class="flex items-center">
+									<Cardholder class="mr-2 size-5 text-foreground-alt" />
+									Billing
+								</div>
+								<div class="ml-auto flex items-center gap-px">
+									<kbd
+										class="inline-flex size-5 items-center justify-center rounded-button border border-dark-10 bg-background-alt text-xs text-muted-foreground shadow-kbd"
 									>
-										{#snippet children({ checked })}
-											<Avatar.Root
-												class="relative mr-3 flex size-5 shrink-0 overflow-hidden rounded-full border border-foreground/50"
-											>
-												<Avatar.Image
-													src="https://github.com/huntabyte.png"
-													alt="@huntabyte"
-													class="aspect-square h-full w-full"
-												/>
-												<Avatar.Fallback
-													class="flex h-full w-full items-center justify-center rounded-full bg-muted text-xxs"
-													>HJ</Avatar.Fallback
-												>
-											</Avatar.Root>
-											@huntabyte
-											{#if checked}
-												<DotOutline class="ml-auto size-4" />
-											{/if}
-										{/snippet}
-									</DropdownMenu.RadioItem>
-									<DropdownMenu.RadioItem
-										value="pavel"
-										class="flex h-10 select-none items-center rounded-button py-3 pl-3 pr-1.5 text-sm font-medium !ring-0 !ring-transparent data-[highlighted]:bg-muted"
+										⌘
+									</kbd>
+									<kbd
+										class="inline-flex size-5 items-center justify-center rounded-button border border-dark-10 bg-background-alt text-[10px] text-muted-foreground shadow-kbd"
 									>
-										{#snippet children({ checked })}
-											<Avatar.Root
-												class="relative mr-3 flex size-5 shrink-0 overflow-hidden rounded-full border border-foreground/50"
-											>
-												<Avatar.Image
-													src="https://github.com/pavelstianko.png"
-													alt="@pavel_stianko"
-													class="aspect-square h-full w-full"
-												/>
-												<Avatar.Fallback
-													class="flex h-full w-full items-center justify-center rounded-full bg-muted text-xs"
-													>PS</Avatar.Fallback
-												>
-											</Avatar.Root>
-											@pavel_stianko
-											{#if checked}
-												<DotOutline class="ml-auto size-4" />
-											{/if}
-										{/snippet}
-									</DropdownMenu.RadioItem>
-									<DropdownMenu.RadioItem
-										value="cokakoala"
-										class="flex h-10 select-none items-center rounded-button py-3 pl-3 pr-1.5 text-sm font-medium !ring-0 !ring-transparent data-[highlighted]:bg-muted"
+										B
+									</kbd>
+								</div>
+							</DropdownMenu.Item>
+							<DropdownMenu.Item
+								class="flex h-10 select-none items-center rounded-button py-3 pl-3 pr-1.5 text-sm font-medium !ring-0 !ring-transparent data-[highlighted]:bg-muted"
+							>
+								<div class="flex items-center">
+									<GearSix class="mr-2 size-5 text-foreground-alt" />
+									Settings
+								</div>
+								<div class="ml-auto flex items-center gap-px">
+									<kbd
+										class="inline-flex size-5 items-center justify-center rounded-button border border-dark-10 bg-background-alt text-xs text-muted-foreground shadow-kbd"
 									>
-										{#snippet children({ checked })}
-											<Avatar.Root
-												class="relative mr-3 flex size-5 shrink-0 overflow-hidden rounded-full border border-foreground/50"
-											>
-												<Avatar.Image
-													src="https://github.com/adriangonz97.png"
-													alt="@cokakoala_"
-													class="aspect-square h-full w-full"
-												/>
-												<Avatar.Fallback
-													class="flex h-full w-full items-center justify-center rounded-full bg-muted text-xs"
-													>CK</Avatar.Fallback
-												>
-											</Avatar.Root>
-											@cokakoala_
-											{#if checked}
-												<DotOutline class="ml-auto size-4" />
-											{/if}
-										{/snippet}
-									</DropdownMenu.RadioItem>
-									<DropdownMenu.RadioItem
-										value="tglide"
-										class="flex h-10 select-none items-center rounded-button py-3 pl-3 pr-1.5 text-sm font-medium !ring-0 !ring-transparent data-[highlighted]:bg-muted"
+										⌘
+									</kbd>
+									<kbd
+										class="inline-flex size-5 items-center justify-center rounded-button border border-dark-10 bg-background-alt text-[10px] text-muted-foreground shadow-kbd"
 									>
-										{#snippet children({ checked })}
-											<Avatar.Root
-												class="relative mr-3 flex size-5 shrink-0 overflow-hidden rounded-full border border-foreground/50"
-											>
-												<Avatar.Image
-													src="https://github.com/tglide.png"
-													alt="@tglide"
-													class="aspect-square h-full w-full"
-												/>
-												<Avatar.Fallback
-													class="flex h-full w-full items-center justify-center rounded-full bg-muted text-xs"
+										S
+									</kbd>
+								</div>
+							</DropdownMenu.Item>
+							<DropdownMenu.CheckboxItem
+								bind:checked={notifications}
+								class="flex h-10 select-none items-center rounded-button py-3 pl-3 pr-1.5 text-sm font-medium !ring-0 !ring-transparent data-[highlighted]:bg-muted"
+							>
+								{#snippet children({ checked })}
+									<div class="flex items-center pr-4">
+										<Bell class="mr-2 size-5 text-foreground-alt" />
+										Notifications
+									</div>
+									<div class="ml-auto flex items-center gap-px">
+										{#if checked}
+											<Check class="size-4" />
+										{/if}
+									</div>
+								{/snippet}
+							</DropdownMenu.CheckboxItem>
+							<DropdownMenu.Sub>
+								<DropdownMenu.SubTrigger
+									class="flex h-10 select-none items-center rounded-button py-3 pl-3 pr-1.5 text-sm font-medium !ring-0 !ring-transparent data-[highlighted]:bg-muted data-[state=open]:bg-muted"
+								>
+									<div class="flex items-center">
+										<UserCirclePlus class="mr-2 size-5 text-foreground-alt" />
+										Workspace
+									</div>
+									<div class="ml-auto flex items-center gap-px">
+										<CaretRight class="size-5 text-foreground-alt" />
+									</div>
+								</DropdownMenu.SubTrigger>
+								<DropdownMenu.SubContent
+									id="subcontent"
+									class="w-[209px] rounded-xl border border-muted bg-background px-1 py-1.5 shadow-popover !ring-0 !ring-transparent"
+									sideOffset={10}
+								>
+									<DropdownMenu.RadioGroup bind:value={invited}>
+										<DropdownMenu.RadioItem
+											value="huntabyte"
+											class="flex h-10 select-none items-center rounded-button py-3 pl-3 pr-1.5 text-sm font-medium !ring-0 !ring-transparent data-[highlighted]:bg-muted"
+										>
+											{#snippet children({ checked })}
+												<Avatar.Root
+													class="relative mr-3 flex size-5 shrink-0 overflow-hidden rounded-full border border-foreground/50"
 												>
-													TL
-												</Avatar.Fallback>
-											</Avatar.Root>
-											@thomasglopes
-											{#if checked}
-												<DotOutline class="ml-auto size-4" />
-											{/if}
-										{/snippet}
-									</DropdownMenu.RadioItem>
-								</DropdownMenu.RadioGroup>
-							</DropdownMenu.SubContent>
-						</DropdownMenu.Sub>
+													<Avatar.Image
+														src="https://github.com/huntabyte.png"
+														alt="@huntabyte"
+														class="aspect-square h-full w-full"
+													/>
+													<Avatar.Fallback
+														class="flex h-full w-full items-center justify-center rounded-full bg-muted text-xxs"
+														>HJ</Avatar.Fallback
+													>
+												</Avatar.Root>
+												@huntabyte
+												{#if checked}
+													<DotOutline class="ml-auto size-4" />
+												{/if}
+											{/snippet}
+										</DropdownMenu.RadioItem>
+										<DropdownMenu.RadioItem
+											value="pavel"
+											class="flex h-10 select-none items-center rounded-button py-3 pl-3 pr-1.5 text-sm font-medium !ring-0 !ring-transparent data-[highlighted]:bg-muted"
+										>
+											{#snippet children({ checked })}
+												<Avatar.Root
+													class="relative mr-3 flex size-5 shrink-0 overflow-hidden rounded-full border border-foreground/50"
+												>
+													<Avatar.Image
+														src="https://github.com/pavelstianko.png"
+														alt="@pavel_stianko"
+														class="aspect-square h-full w-full"
+													/>
+													<Avatar.Fallback
+														class="flex h-full w-full items-center justify-center rounded-full bg-muted text-xs"
+														>PS</Avatar.Fallback
+													>
+												</Avatar.Root>
+												@pavel_stianko
+												{#if checked}
+													<DotOutline class="ml-auto size-4" />
+												{/if}
+											{/snippet}
+										</DropdownMenu.RadioItem>
+										<DropdownMenu.RadioItem
+											value="cokakoala"
+											class="flex h-10 select-none items-center rounded-button py-3 pl-3 pr-1.5 text-sm font-medium !ring-0 !ring-transparent data-[highlighted]:bg-muted"
+										>
+											{#snippet children({ checked })}
+												<Avatar.Root
+													class="relative mr-3 flex size-5 shrink-0 overflow-hidden rounded-full border border-foreground/50"
+												>
+													<Avatar.Image
+														src="https://github.com/adriangonz97.png"
+														alt="@cokakoala_"
+														class="aspect-square h-full w-full"
+													/>
+													<Avatar.Fallback
+														class="flex h-full w-full items-center justify-center rounded-full bg-muted text-xs"
+														>CK</Avatar.Fallback
+													>
+												</Avatar.Root>
+												@cokakoala_
+												{#if checked}
+													<DotOutline class="ml-auto size-4" />
+												{/if}
+											{/snippet}
+										</DropdownMenu.RadioItem>
+										<DropdownMenu.RadioItem
+											value="tglide"
+											class="flex h-10 select-none items-center rounded-button py-3 pl-3 pr-1.5 text-sm font-medium !ring-0 !ring-transparent data-[highlighted]:bg-muted"
+										>
+											{#snippet children({ checked })}
+												<Avatar.Root
+													class="relative mr-3 flex size-5 shrink-0 overflow-hidden rounded-full border border-foreground/50"
+												>
+													<Avatar.Image
+														src="https://github.com/tglide.png"
+														alt="@tglide"
+														class="aspect-square h-full w-full"
+													/>
+													<Avatar.Fallback
+														class="flex h-full w-full items-center justify-center rounded-full bg-muted text-xs"
+													>
+														TL
+													</Avatar.Fallback>
+												</Avatar.Root>
+												@thomasglopes
+												{#if checked}
+													<DotOutline class="ml-auto size-4" />
+												{/if}
+											{/snippet}
+										</DropdownMenu.RadioItem>
+									</DropdownMenu.RadioGroup>
+								</DropdownMenu.SubContent>
+							</DropdownMenu.Sub>
+						</div>
 					</div>
 				{/if}
 			{/snippet}

--- a/sites/docs/src/lib/components/demos/link-preview-demo-transition.svelte
+++ b/sites/docs/src/lib/components/demos/link-preview-demo-transition.svelte
@@ -34,36 +34,40 @@
 		sideOffset={8}
 		forceMount
 	>
-		{#snippet child({ open, props })}
+		{#snippet child({ open, props, wrapperProps })}
 			{#if open}
-				<div {...props} transition:fly={{ duration: 300 }}>
-					<div class="flex space-x-4">
-						<Avatar.Root
-							bind:loadingStatus={loadingStatusContent}
-							class="h-12 w-12 rounded-full border {loadingStatusContent === 'loaded'
-								? 'border-foreground'
-								: 'border-transparent'} bg-muted text-[17px] font-medium uppercase text-muted-foreground"
-						>
-							<div
-								class="flex h-full w-full items-center justify-center overflow-hidden rounded-full border-2 border-transparent"
+				<div {...wrapperProps}>
+					<div {...props} transition:fly={{ duration: 300 }}>
+						<div class="flex space-x-4">
+							<Avatar.Root
+								bind:loadingStatus={loadingStatusContent}
+								class="h-12 w-12 rounded-full border {loadingStatusContent ===
+								'loaded'
+									? 'border-foreground'
+									: 'border-transparent'} bg-muted text-[17px] font-medium uppercase text-muted-foreground"
 							>
-								<Avatar.Image src="/avatar-1.png" alt="@huntabyte" />
-								<Avatar.Fallback class="border border-muted">HB</Avatar.Fallback>
-							</div>
-						</Avatar.Root>
-						<div class="space-y-1 text-sm">
-							<h4 class="font-medium">@huntabyte</h4>
-							<p>I do things on the internet.</p>
-							<div
-								class="flex items-center gap-[21px] pt-2 text-xs text-muted-foreground"
-							>
-								<div class="flex items-center text-xs">
-									<MapPin class="mr-1 size-4" />
-									<span> FL, USA </span>
+								<div
+									class="flex h-full w-full items-center justify-center overflow-hidden rounded-full border-2 border-transparent"
+								>
+									<Avatar.Image src="/avatar-1.png" alt="@huntabyte" />
+									<Avatar.Fallback class="border border-muted">HB</Avatar.Fallback
+									>
 								</div>
-								<div class="flex items-center text-xs">
-									<CalendarBlank class="mr-1 size-4" />
-									<span> Joined May 2020</span>
+							</Avatar.Root>
+							<div class="space-y-1 text-sm">
+								<h4 class="font-medium">@huntabyte</h4>
+								<p>I do things on the internet.</p>
+								<div
+									class="flex items-center gap-[21px] pt-2 text-xs text-muted-foreground"
+								>
+									<div class="flex items-center text-xs">
+										<MapPin class="mr-1 size-4" />
+										<span> FL, USA </span>
+									</div>
+									<div class="flex items-center text-xs">
+										<CalendarBlank class="mr-1 size-4" />
+										<span> Joined May 2020</span>
+									</div>
 								</div>
 							</div>
 						</div>

--- a/sites/docs/src/lib/components/demos/popover-demo-transition.svelte
+++ b/sites/docs/src/lib/components/demos/popover-demo-transition.svelte
@@ -21,60 +21,64 @@
 			sideOffset={8}
 			forceMount
 		>
-			{#snippet child({ props, open })}
+			{#snippet child({ wrapperProps, props, open })}
 				{#if open}
-					<div {...props} transition:fly={{ duration: 300 }}>
-						<div class="flex items-center">
-							<div
-								class="mr-3 flex size-12 items-center justify-center rounded-full bg-muted"
-							>
-								<ImageSquare class="size-6" />
-							</div>
-							<div class="flex flex-col">
-								<h4 class="text-[17px] font-semibold leading-5 tracking-[-0.01em]">
-									Resize image
-								</h4>
-								<p class="text-sm font-medium text-muted-foreground">
-									Resize your photos easily
-								</p>
-							</div>
-						</div>
-						<Separator.Root class="-mx-4 mb-6 mt-[17px] block h-px bg-dark-10" />
-						<div class="flex items-center pb-2">
-							<div class="mr-2 flex items-center">
-								<div class="relative mr-2">
-									<span class="sr-only">Width</span>
-									<span
-										aria-hidden="true"
-										class="absolute left-5 top-4 text-xxs text-muted-foreground"
-										>W</span
-									>
-									<input
-										type="number"
-										class="h-input w-[119px] rounded-10px border border-border-input bg-background pl-10 pr-2 text-sm text-foreground"
-										bind:value={width}
-									/>
+					<div {...wrapperProps}>
+						<div {...props} transition:fly={{ duration: 300 }}>
+							<div class="flex items-center">
+								<div
+									class="mr-3 flex size-12 items-center justify-center rounded-full bg-muted"
+								>
+									<ImageSquare class="size-6" />
 								</div>
-								<div class="relative">
-									<span class="sr-only">Height</span>
-									<span
-										aria-hidden="true"
-										class="absolute left-5 top-4 text-xxs text-muted-foreground"
-										>H</span
+								<div class="flex flex-col">
+									<h4
+										class="text-[17px] font-semibold leading-5 tracking-[-0.01em]"
 									>
-									<input
-										type="number"
-										class="h-input w-[119px] rounded-10px border border-border-input bg-background pl-10 pr-2 text-sm text-foreground"
-										bind:value={height}
-									/>
+										Resize image
+									</h4>
+									<p class="text-sm font-medium text-muted-foreground">
+										Resize your photos easily
+									</p>
 								</div>
 							</div>
-							<Toggle.Root
-								aria-label="toggle constrain portions"
-								class="inline-flex size-10 items-center justify-center rounded-[9px] bg-background transition-all hover:bg-muted active:scale-98 data-[state=on]:bg-muted"
-							>
-								<LinkSimpleHorizontalBreak class="size-6" />
-							</Toggle.Root>
+							<Separator.Root class="-mx-4 mb-6 mt-[17px] block h-px bg-dark-10" />
+							<div class="flex items-center pb-2">
+								<div class="mr-2 flex items-center">
+									<div class="relative mr-2">
+										<span class="sr-only">Width</span>
+										<span
+											aria-hidden="true"
+											class="absolute left-5 top-4 text-xxs text-muted-foreground"
+											>W</span
+										>
+										<input
+											type="number"
+											class="h-input w-[119px] rounded-10px border border-border-input bg-background pl-10 pr-2 text-sm text-foreground"
+											bind:value={width}
+										/>
+									</div>
+									<div class="relative">
+										<span class="sr-only">Height</span>
+										<span
+											aria-hidden="true"
+											class="absolute left-5 top-4 text-xxs text-muted-foreground"
+											>H</span
+										>
+										<input
+											type="number"
+											class="h-input w-[119px] rounded-10px border border-border-input bg-background pl-10 pr-2 text-sm text-foreground"
+											bind:value={height}
+										/>
+									</div>
+								</div>
+								<Toggle.Root
+									aria-label="toggle constrain portions"
+									class="inline-flex size-10 items-center justify-center rounded-[9px] bg-background transition-all hover:bg-muted active:scale-98 data-[state=on]:bg-muted"
+								>
+									<LinkSimpleHorizontalBreak class="size-6" />
+								</Toggle.Root>
+							</div>
 						</div>
 					</div>
 				{/if}

--- a/sites/docs/src/lib/components/demos/select-demo-transition.svelte
+++ b/sites/docs/src/lib/components/demos/select-demo-transition.svelte
@@ -51,33 +51,37 @@
 			sideOffset={10}
 			forceMount
 		>
-			{#snippet child({ props, open })}
+			{#snippet child({ wrapperProps, props, open })}
 				{#if open}
-					<div {...props} transition:fly={{ duration: 300 }}>
-						<Select.ScrollUpButton class="flex w-full items-center justify-center">
-							<CaretDoubleUp class="size-3" />
-						</Select.ScrollUpButton>
-						<Select.Viewport class="p-1">
-							{#each themes as theme, i (i + theme.value)}
-								<Select.Item
-									class="flex h-10 w-full select-none items-center rounded-button py-3 pl-5 pr-1.5 text-sm capitalize outline-none duration-75 data-[highlighted]:bg-muted"
-									value={theme.value}
-									label={theme.label}
-								>
-									{#snippet children({ selected })}
-										{theme.label}
-										{#if selected}
-											<div class="ml-auto">
-												<Check />
-											</div>
-										{/if}
-									{/snippet}
-								</Select.Item>
-							{/each}
-						</Select.Viewport>
-						<Select.ScrollDownButton class="flex w-full items-center justify-center">
-							<CaretDoubleDown class="size-3" />
-						</Select.ScrollDownButton>
+					<div {...wrapperProps}>
+						<div {...props} transition:fly={{ duration: 300 }}>
+							<Select.ScrollUpButton class="flex w-full items-center justify-center">
+								<CaretDoubleUp class="size-3" />
+							</Select.ScrollUpButton>
+							<Select.Viewport class="p-1">
+								{#each themes as theme, i (i + theme.value)}
+									<Select.Item
+										class="flex h-10 w-full select-none items-center rounded-button py-3 pl-5 pr-1.5 text-sm capitalize outline-none duration-75 data-[highlighted]:bg-muted"
+										value={theme.value}
+										label={theme.label}
+									>
+										{#snippet children({ selected })}
+											{theme.label}
+											{#if selected}
+												<div class="ml-auto">
+													<Check />
+												</div>
+											{/if}
+										{/snippet}
+									</Select.Item>
+								{/each}
+							</Select.Viewport>
+							<Select.ScrollDownButton
+								class="flex w-full items-center justify-center"
+							>
+								<CaretDoubleDown class="size-3" />
+							</Select.ScrollDownButton>
+						</div>
 					</div>
 				{/if}
 			{/snippet}

--- a/sites/docs/src/lib/components/demos/tooltip-demo-transition.svelte
+++ b/sites/docs/src/lib/components/demos/tooltip-demo-transition.svelte
@@ -13,13 +13,15 @@
 			<MagicWand class="size-5" />
 		</Tooltip.Trigger>
 		<Tooltip.Content sideOffset={8} forceMount>
-			{#snippet child({ props, open })}
+			{#snippet child({ wrapperProps, props, open })}
 				{#if open}
-					<div {...props} transition:fly={{ duration: 300 }}>
-						<div
-							class="z-0 flex items-center justify-center rounded-input border border-dark-10 bg-background p-3 text-sm font-medium shadow-popover outline-none"
-						>
-							Make some magic!
+					<div {...wrapperProps}>
+						<div {...props} transition:fly={{ duration: 300 }}>
+							<div
+								class="z-0 flex items-center justify-center rounded-input border border-dark-10 bg-background p-3 text-sm font-medium shadow-popover outline-none"
+							>
+								Make some magic!
+							</div>
 						</div>
 					</div>
 				{/if}

--- a/sites/docs/src/lib/content/api-reference/combobox.api.ts
+++ b/sites/docs/src/lib/content/api-reference/combobox.api.ts
@@ -21,6 +21,7 @@ import {
 } from "./extended-types/shared/index.js";
 import { ComboboxScrollAlignmentProp } from "./extended-types/combobox/index.js";
 import { ItemsProp } from "./extended-types/select/index.js";
+import { FloatingContentChildSnippetProps } from "./extended-types/floating/index.js";
 import {
 	arrowProps,
 	childrenSnippet,
@@ -152,7 +153,7 @@ export const content = createApiSchema<ComboboxContentPropsWithoutHTML>({
 		...withChildProps({
 			elType: "HTMLDivElement",
 			childrenDef: OpenChildrenSnippetProps,
-			childDef: OpenChildSnippetProps,
+			childDef: FloatingContentChildSnippetProps,
 		}),
 	},
 	dataAttributes: [

--- a/sites/docs/src/lib/content/api-reference/context-menu.api.ts
+++ b/sites/docs/src/lib/content/api-reference/context-menu.api.ts
@@ -33,6 +33,7 @@ import {
 	withChildProps,
 } from "./helpers.js";
 import { menu } from "./menu.api.js";
+import { FloatingContentChildSnippetProps } from "./extended-types/floating/index.js";
 import * as C from "$lib/content/constants.js";
 import { omit } from "$lib/utils/omit.js";
 
@@ -75,7 +76,7 @@ export const content = createApiSchema<ContextMenuContentPropsWithoutHTML>({
 			description:
 				"Whether or not the context menu should loop through items when reaching the end.",
 		}),
-		...withChildProps({ elType: "HTMLDivElement" }),
+		...withChildProps({ elType: "HTMLDivElement", childDef: FloatingContentChildSnippetProps }),
 	},
 	dataAttributes: menu.content.dataAttributes,
 	cssVars: [

--- a/sites/docs/src/lib/content/api-reference/extended-types/floating/floating-content-child-snippet-props.md
+++ b/sites/docs/src/lib/content/api-reference/extended-types/floating/floating-content-child-snippet-props.md
@@ -1,0 +1,17 @@
+```ts
+type ChildSnippetProps = {
+	// Props for the positioning wrapper
+	// Do not style this element -
+	// styling should be applied to the content element
+	wrapperProps: Record<string, unknown>;
+
+	// Props for your content element
+	// Apply your custom styles here
+	props: Record<string, unknown>;
+
+	// Content visibility state
+	// Use this for conditional rendering with
+	// Svelte transitions
+	open: boolean;
+};
+```

--- a/sites/docs/src/lib/content/api-reference/extended-types/floating/index.ts
+++ b/sites/docs/src/lib/content/api-reference/extended-types/floating/index.ts
@@ -6,3 +6,4 @@ export { default as FloatingStickyProp } from "./sticky-prop.md";
 export { default as FloatingStrategyProp } from "./strategy-prop.md";
 export { default as FloatingUpdatePositionStrategyProp } from "./update-position-strategy-prop.md";
 export { default as FloatingCustomAnchorProp } from "./custom-anchor-prop.md";
+export { default as FloatingContentChildSnippetProps } from "./floating-content-child-snippet-props.md";

--- a/sites/docs/src/lib/content/api-reference/menu.api.ts
+++ b/sites/docs/src/lib/content/api-reference/menu.api.ts
@@ -56,6 +56,7 @@ import {
 	CheckboxRootOnCheckedChangeProp,
 	CheckboxRootOnIndeterminateChangeProp,
 } from "./extended-types/checkbox/index.js";
+import { FloatingContentChildSnippetProps } from "./extended-types/floating/index.js";
 import type { APISchema, DataAttrSchema, PropObj } from "$lib/types/index.js";
 import * as C from "$lib/content/constants.js";
 import { enums } from "$lib/content/api-reference/helpers.js";
@@ -121,7 +122,7 @@ const contentProps = {
 	...withChildProps({
 		elType: "HTMLDivElement",
 		childrenDef: OpenChildrenSnippetProps,
-		childDef: OpenChildSnippetProps,
+		childDef: FloatingContentChildSnippetProps,
 	}),
 } satisfies PropObj<DropdownMenuContentPropsWithoutHTML>;
 

--- a/sites/docs/src/lib/content/api-reference/popover.api.ts
+++ b/sites/docs/src/lib/content/api-reference/popover.api.ts
@@ -7,6 +7,7 @@ import type {
 	PopoverTriggerPropsWithoutHTML,
 } from "bits-ui";
 import { OnOpenChangeProp, OpenClosedProp } from "./extended-types/shared/index.js";
+import { FloatingContentChildSnippetProps } from "./extended-types/floating/index.js";
 import {
 	arrowProps,
 	childrenSnippet,
@@ -81,7 +82,7 @@ export const content = createApiSchema<PopoverContentPropsWithoutHTML>({
 		},
 		forceMount: forceMountProp,
 		dir: dirProp,
-		...withChildProps({ elType: "HTMLDivElement" }),
+		...withChildProps({ elType: "HTMLDivElement", childDef: FloatingContentChildSnippetProps }),
 	},
 	dataAttributes: [
 		openClosedDataAttr,

--- a/sites/docs/src/lib/content/api-reference/select.api.ts
+++ b/sites/docs/src/lib/content/api-reference/select.api.ts
@@ -23,6 +23,7 @@ import {
 } from "./extended-types/shared/index.js";
 import { ComboboxScrollAlignmentProp } from "./extended-types/combobox/index.js";
 import { ItemsProp } from "./extended-types/select/index.js";
+import { FloatingContentChildSnippetProps } from "./extended-types/floating/index.js";
 import {
 	arrowProps,
 	childrenSnippet,
@@ -151,7 +152,7 @@ export const content = createApiSchema<SelectContentPropsWithoutHTML>({
 		...withChildProps({
 			elType: "HTMLDivElement",
 			childrenDef: OpenChildrenSnippetProps,
-			childDef: OpenChildSnippetProps,
+			childDef: FloatingContentChildSnippetProps,
 		}),
 	},
 	dataAttributes: [

--- a/sites/docs/src/lib/content/api-reference/tooltip.api.ts
+++ b/sites/docs/src/lib/content/api-reference/tooltip.api.ts
@@ -11,6 +11,7 @@ import {
 	OpenChildSnippetProps,
 	OpenChildrenSnippetProps,
 } from "./extended-types/shared/index.js";
+import { FloatingContentChildSnippetProps } from "./extended-types/floating/index.js";
 import {
 	arrowProps,
 	childrenSnippet,
@@ -143,7 +144,7 @@ export const content = createApiSchema<TooltipContentPropsWithoutHTML>({
 		...withChildProps({
 			elType: "HTMLDivElement",
 			childrenDef: OpenChildrenSnippetProps,
-			childDef: OpenChildSnippetProps,
+			childDef: FloatingContentChildSnippetProps,
 		}),
 	},
 	dataAttributes: [


### PR DESCRIPTION
We're introducing a breaking change to improve performance and fix issues with floating content components that use Svelte transitions.

## Current Behavior & Issue

Our floating `<X.Content>` components currently wrap user content in a positioning div. While this simplifies styling by separating positioning logic from content styles, it creates performance issues when used with Svelte transitions or conditional rendering.

The current internal implementation:

```svelte
<div {...wrapperProps}>
    {@render child({ props })}
</div>
```

When using transitions, this results in:

```svelte
<div {...wrapperProps}>
    {#if open} 
        <div transition:fade>
            <!-- content -->
        </div>
    {/if}
</div>
```

The key issue is that the wrapper `div` remains in the DOM even when content is hidden, continuously recalculating positions on viewport changes. This creates unnecessary performance overhead, especially with multiple floating components (see [Issue #877](https://github.com/huntabyte/bits-ui/issues/877)).

## New Implementation

To resolve this, we're updating the `child` snippet API for all Floating UI-based `Content` components. The new API provides more granular control over wrapper and content elements:

```ts
type ChildSnippetProps = {
    // Props for the positioning wrapper
    // Do not style this element - styling should be applied to the content element
    wrapperProps: Record<string, unknown>
    
    // Props for your content element
    // Apply your custom styles here
    props: Record<string, unknown>
    
    // Content visibility state
    // Use this for conditional rendering with Svelte transitions
    open: boolean
}
```

## Migration Impact

This is a breaking change that will affect applications using the `child` snippet with Floating UI-based `Content` components in `bits-ui@1.0.0-next` . While we understand this may require updates to your code, we're making this change early to minimize the long-term impact as adoption grows beyond `bits-ui@0.X`.

We recommend encapsulating these components in your own reusable components to minimize the impact of such changes across your application.

Before:

```svelte
<DropdownMenu.Content>
	{#snippet child({ props, open })}
		{#if open}
			<div {...props} transition:slide>
				<!-- ... -->
			</div> 
		{/if}
	{/snippet}
</DropdownMenu.Content>
```

After:

```svelte
<DropdownMenu.Content>
	{#snippet child({ wrapperProps, props, open })}
		{#if open}
			<div {...wrapperProps>
				<div {...props} transition:slide>
					<!-- ... -->
				</div>
			</div> 
		{/if}
	{/snippet}
</DropdownMenu.Content>
```

### Components Impacted
- `Combobox`
- `ContextMenu`
- `DatePicker`
- `DateRangePicker`
- `DropdownMenu`
- `LinkPreview`
- `Menubar`
- `Popover`
- `Select`
- `Tooltip`