### PR TITLE
fix: command arrow navigation after empty state

### DIFF
--- a/.changeset/clever-singers-wait.md
+++ b/.changeset/clever-singers-wait.md
@@ -1,0 +1,5 @@
+---
+"bits-ui": patch
+---
+
+fix: `Command` arrow navigation after empty state displayed

--- a/packages/bits-ui/src/lib/bits/command/command.svelte.ts
+++ b/packages/bits-ui/src/lib/bits/command/command.svelte.ts
@@ -810,7 +810,6 @@ class CommandItemState {
 	#ref: CommandItemStateProps["ref"];
 	id: CommandItemStateProps["id"];
 	root: CommandRootState;
-
 	#value: CommandItemStateProps["value"];
 	#disabled: CommandItemStateProps["disabled"];
 	#onSelectProp: CommandItemStateProps["onSelect"];
@@ -916,6 +915,7 @@ class CommandItemState {
 				"aria-selected": getAriaSelected(this.isSelected),
 				"data-disabled": getDataDisabled(this.#disabled.current),
 				"data-selected": getDataSelected(this.isSelected),
+				"data-value": this.trueValue,
 				[ITEM_ATTR]: "",
 				role: "option",
 				onpointermove: this.onpointermove,


### PR DESCRIPTION
Closes #996 