### PR TITLE
next: `Checkbox.Group`

### DIFF
--- a/.changeset/grumpy-clouds-remember.md
+++ b/.changeset/grumpy-clouds-remember.md
@@ -1,0 +1,5 @@
+---
+"bits-ui": minor
+---
+
+feat: `Checkbox.Group` and `Checkbox.GroupLabel` components

--- a/packages/bits-ui/src/lib/app.d.ts
+++ b/packages/bits-ui/src/lib/app.d.ts
@@ -12,4 +12,6 @@ declare global {
 	var bitsEscapeLayers: Map<EscapeLayerState, ReadableBox<EscapeBehaviorType>>;
 	// eslint-disable-next-line vars-on-top, no-var
 	var bitsTextSelectionLayers: Map<TextSelectionLayerState, ReadableBox<boolean>>;
+	// eslint-disable-next-line vars-on-top, no-var
+	var bitsIdCounter: { current: number };
 }

--- a/packages/bits-ui/src/lib/bits/checkbox/checkbox.svelte.ts
+++ b/packages/bits-ui/src/lib/bits/checkbox/checkbox.svelte.ts
@@ -65,6 +65,7 @@ class CheckboxGroupState {
 				id: this.id.current,
 				role: "group",
 				"aria-labelledby": this.labelId,
+				"data-disabled": getDataDisabled(this.disabled.current),
 				[CHECKBOX_GROUP_ATTR]: "",
 			}) as const
 	);
@@ -99,6 +100,7 @@ class CheckboxGroupLabelState {
 		() =>
 			({
 				id: this.id.current,
+				"data-disabled": getDataDisabled(this.group.disabled.current),
 				[CHECKBOX_GROUP_LABEL_ATTR]: "",
 			}) as const
 	);

--- a/packages/bits-ui/src/lib/bits/checkbox/checkbox.svelte.ts
+++ b/packages/bits-ui/src/lib/bits/checkbox/checkbox.svelte.ts
@@ -1,5 +1,6 @@
 import { srOnlyStyles, styleToString, useRefById } from "svelte-toolbelt";
 import type { HTMLButtonAttributes } from "svelte/elements";
+import { watch } from "runed";
 import type { ReadableBoxedValues, WritableBoxedValues } from "$lib/internal/box.svelte.js";
 import type { BitsKeyboardEvent, BitsMouseEvent, WithRefProps } from "$lib/internal/types.js";
 import { getAriaChecked, getAriaRequired, getDataDisabled } from "$lib/internal/attrs.js";
@@ -7,6 +8,101 @@ import { kbd } from "$lib/internal/kbd.js";
 import { createContext } from "$lib/internal/create-context.js";
 
 const CHECKBOX_ROOT_ATTR = "data-checkbox-root";
+const CHECKBOX_GROUP_ATTR = "data-checkbox-group";
+const CHECKBOX_GROUP_LABEL_ATTR = "data-checkbox-group-label";
+
+type CheckboxGroupStateProps = WithRefProps<
+	ReadableBoxedValues<{
+		name: string | undefined;
+		disabled: boolean;
+		required: boolean;
+	}> &
+		WritableBoxedValues<{
+			value: string[];
+		}>
+>;
+
+class CheckboxGroupState {
+	id: CheckboxGroupStateProps["id"];
+	ref: CheckboxGroupStateProps["ref"];
+	value: CheckboxGroupStateProps["value"];
+	disabled: CheckboxGroupStateProps["disabled"];
+	required: CheckboxGroupStateProps["required"];
+	name: CheckboxGroupStateProps["name"];
+	labelId = $state<string | undefined>(undefined);
+
+	constructor(props: CheckboxGroupStateProps) {
+		this.id = props.id;
+		this.ref = props.ref;
+		this.value = props.value;
+		this.disabled = props.disabled;
+		this.required = props.required;
+		this.name = props.name;
+
+		useRefById({
+			id: this.id,
+			ref: this.ref,
+		});
+	}
+
+	addValue(checkboxValue: string | undefined) {
+		if (!checkboxValue) return;
+		if (!this.value.current.includes(checkboxValue)) {
+			this.value.current.push(checkboxValue);
+		}
+	}
+
+	removeValue(checkboxValue: string | undefined) {
+		if (!checkboxValue) return;
+		const index = this.value.current.indexOf(checkboxValue);
+		if (index === -1) return;
+		this.value.current.splice(index, 1);
+	}
+
+	props = $derived.by(
+		() =>
+			({
+				id: this.id.current,
+				role: "group",
+				"aria-labelledby": this.labelId,
+				[CHECKBOX_GROUP_ATTR]: "",
+			}) as const
+	);
+}
+
+type CheckboxGroupLabelStateProps = WithRefProps;
+
+class CheckboxGroupLabelState {
+	id: CheckboxGroupLabelStateProps["id"];
+	ref: CheckboxGroupLabelStateProps["ref"];
+	group: CheckboxGroupState;
+
+	constructor(props: CheckboxGroupLabelStateProps, group: CheckboxGroupState) {
+		this.id = props.id;
+		this.ref = props.ref;
+		this.group = group;
+
+		useRefById({
+			id: this.id,
+			ref: this.ref,
+			onRefChange: (node) => {
+				if (node) {
+					group.labelId = node.id;
+				} else {
+					group.labelId = undefined;
+				}
+			},
+		});
+	}
+
+	props = $derived.by(
+		() =>
+			({
+				id: this.id.current,
+				[CHECKBOX_GROUP_LABEL_ATTR]: "",
+			}) as const
+	);
+}
 
 type CheckboxRootStateProps = WithRefProps<
 	ReadableBoxedValues<{
@@ -27,22 +123,44 @@ class CheckboxRootState {
 	#ref: CheckboxRootStateProps["ref"];
 	#type: CheckboxRootStateProps["type"];
 	checked: CheckboxRootStateProps["checked"];
-	disabled: CheckboxRootStateProps["disabled"];
-	required: CheckboxRootStateProps["required"];
-	name: CheckboxRootStateProps["name"];
+	#disabled: CheckboxRootStateProps["disabled"];
+	#required: CheckboxRootStateProps["required"];
+	#name: CheckboxRootStateProps["name"];
 	value: CheckboxRootStateProps["value"];
 	indeterminate: CheckboxRootStateProps["indeterminate"];
+	group: CheckboxGroupState | null = null;
 
-	constructor(props: CheckboxRootStateProps) {
+	trueName = $derived.by(() => {
+		if (this.group && this.group.name.current) {
+			return this.group.name.current;
+		} else {
+			return this.#name.current;
+		}
+	});
+	trueRequired = $derived.by(() => {
+		if (this.group && this.group.required.current) {
+			return true;
+		}
+		return this.#required.current;
+	});
+	trueDisabled = $derived.by(() => {
+		if (this.group && this.group.disabled.current) {
+			return true;
+		}
+		return this.#disabled.current;
+	});
+
+	constructor(props: CheckboxRootStateProps, group: CheckboxGroupState | null = null) {
 		this.checked = props.checked;
-		this.disabled = props.disabled;
-		this.required = props.required;
-		this.name = props.name;
+		this.#disabled = props.disabled;
+		this.#required = props.required;
+		this.#name = props.name;
 		this.value = props.value;
 		this.#ref = props.ref;
 		this.#id = props.id;
 		this.indeterminate = props.indeterminate;
 		this.#type = props.type;
+		this.group = group;
 		this.onkeydown = this.onkeydown.bind(this);
 		this.onclick = this.onclick.bind(this);
 
@@ -50,10 +168,30 @@ class CheckboxRootState {
 			id: this.#id,
 			ref: this.#ref,
 		});
+
+		watch(
+			[() => $state.snapshot(this.group?.value.current), () => this.value.current],
+			([groupValue, value]) => {
+				if (!groupValue || !value) return;
+				this.checked.current = groupValue.includes(value);
+			}
+		);
+
+		watch(
+			() => this.checked.current,
+			(checked) => {
+				if (!this.group) return;
+				if (checked) {
+					this.group?.addValue(this.value.current);
+				} else {
+					this.group?.removeValue(this.value.current);
+				}
+			}
+		);
 	}
 
 	onkeydown(e: BitsKeyboardEvent) {
-		if (this.disabled.current) return;
+		if (this.#disabled.current) return;
 		if (e.key === kbd.ENTER) e.preventDefault();
 		if (e.key === kbd.SPACE) {
 			e.preventDefault();
@@ -71,9 +209,14 @@ class CheckboxRootState {
 	}
 
 	onclick(_: BitsMouseEvent) {
-		if (this.disabled.current) return;
+		if (this.#disabled.current) return;
 		this.#toggle();
 	}
+
+	snippetProps = $derived.by(() => ({
+		checked: this.checked.current,
+		indeterminate: this.indeterminate.current,
+	}));
 
 	props = $derived.by(
 		() =>
@@ -81,10 +224,10 @@ class CheckboxRootState {
 				id: this.#id.current,
 				role: "checkbox",
 				type: this.#type.current,
-				disabled: this.disabled.current,
+				disabled: this.trueDisabled,
 				"aria-checked": getAriaChecked(this.checked.current, this.indeterminate.current),
-				"aria-required": getAriaRequired(this.required.current),
-				"data-disabled": getDataDisabled(this.disabled.current),
+				"aria-required": getAriaRequired(this.trueRequired),
+				"data-disabled": getDataDisabled(this.trueDisabled),
 				"data-state": getCheckboxDataState(
 					this.checked.current,
 					this.indeterminate.current
@@ -103,7 +246,20 @@ class CheckboxRootState {
 
 class CheckboxInputState {
 	root: CheckboxRootState;
-	shouldRender = $derived.by(() => Boolean(this.root.name.current));
+	trueChecked = $derived.by(() => {
+		if (this.root.group) {
+			if (
+				this.root.value.current !== undefined &&
+				this.root.group.value.current.includes(this.root.value.current)
+			) {
+				return true;
+			}
+			return false;
+		}
+		return this.root.checked.current;
+	});
+
+	shouldRender = $derived.by(() => Boolean(this.root.trueName));
 
 	constructor(root: CheckboxRootState) {
 		this.root = root;
@@ -114,9 +270,9 @@ class CheckboxInputState {
 			({
 				type: "checkbox",
 				checked: this.root.checked.current === true,
-				disabled: this.root.disabled.current,
-				required: this.root.required.current,
-				name: this.root.name.current,
+				disabled: this.root.trueDisabled,
+				required: this.root.trueRequired,
+				name: this.root.trueName,
 				value: this.root.value.current,
 				"aria-hidden": "true",
 				style: styleToString(srOnlyStyles),
@@ -139,11 +295,22 @@ function getCheckboxDataState(checked: boolean, indeterminate: boolean) {
 // CONTEXT METHODS
 //
 
+const [setCheckboxGroupContext, getCheckboxGroupContext] =
+	createContext<CheckboxGroupState>("Checkbox.Group");
+
 const [setCheckboxRootContext, getCheckboxRootContext] =
 	createContext<CheckboxRootState>("Checkbox.Root");
 
+export function useCheckboxGroup(props: CheckboxGroupStateProps) {
+	return setCheckboxGroupContext(new CheckboxGroupState(props));
+}
+
 export function useCheckboxRoot(props: CheckboxRootStateProps) {
-	return setCheckboxRootContext(new CheckboxRootState(props));
+	return setCheckboxRootContext(new CheckboxRootState(props, getCheckboxGroupContext(null)));
+}
+
+export function useCheckboxGroupLabel(props: CheckboxGroupLabelStateProps) {
+	return new CheckboxGroupLabelState(props, getCheckboxGroupContext());
 }
 
 export function useCheckboxInput(): CheckboxInputState {

--- a/packages/bits-ui/src/lib/bits/checkbox/components/checkbox-group-label.svelte
+++ b/packages/bits-ui/src/lib/bits/checkbox/components/checkbox-group-label.svelte
@@ -1,0 +1,32 @@
+<script lang="ts">
+	import { box, mergeProps } from "svelte-toolbelt";
+	import type { CheckboxGroupLabelProps } from "../types.js";
+	import { useCheckboxGroupLabel } from "../checkbox.svelte.js";
+	import { useId } from "$lib/internal/use-id.js";
+
+	let {
+		ref = $bindable(null),
+		id = useId(),
+		child,
+		children,
+		...restProps
+	}: CheckboxGroupLabelProps = $props();
+
+	const labelState = useCheckboxGroupLabel({
+		id: box.with(() => id),
+		ref: box.with(
+			() => ref,
+			(v) => (ref = v)
+		),
+	});
+
+	const mergedProps = $derived(mergeProps(restProps, labelState.props));
+</script>
+
+{#if child}
+	{@render child({ props: mergedProps })}
+{:else}
+	<span {...mergedProps}>
+		{@render children?.()}
+	</span>
+{/if}

--- a/packages/bits-ui/src/lib/bits/checkbox/components/checkbox-group.svelte
+++ b/packages/bits-ui/src/lib/bits/checkbox/components/checkbox-group.svelte
@@ -1,0 +1,45 @@
+<script lang="ts">
+	import { box, mergeProps } from "svelte-toolbelt";
+	import type { CheckboxGroupProps } from "../types.js";
+	import { useCheckboxGroup } from "../checkbox.svelte.js";
+	import { noop } from "$lib/internal/noop.js";
+	import { useId } from "$lib/internal/use-id.js";
+
+	let {
+		ref = $bindable(null),
+		id = useId(),
+		value = $bindable([]),
+		onValueChange = noop,
+		name,
+		required,
+		disabled,
+		children,
+		child,
+		...restProps
+	}: CheckboxGroupProps = $props();
+
+	const groupState = useCheckboxGroup({
+		id: box.with(() => id),
+		ref: box.with(
+			() => ref,
+			(v) => (ref = v)
+		),
+		disabled: box.with(() => Boolean(disabled)),
+		required: box.with(() => Boolean(required)),
+		name: box.with(() => name),
+		value: box.with(
+			() => value,
+			(v) => onValueChange(v)
+		),
+	});
+
+	const mergedProps = $derived(mergeProps(restProps, groupState.props));
+</script>
+
+{#if child}
+	{@render child({ props: mergedProps })}
+{:else}
+	<div {...mergedProps}>
+		{@render children?.()}
+	</div>
+{/if}

--- a/packages/bits-ui/src/lib/bits/checkbox/components/checkbox.svelte
+++ b/packages/bits-ui/src/lib/bits/checkbox/components/checkbox.svelte
@@ -65,15 +65,11 @@
 {#if child}
 	{@render child({
 		props: mergedProps,
-		checked: rootState.checked.current,
-		indeterminate: rootState.indeterminate.current,
+		...rootState.snippetProps,
 	})}
 {:else}
 	<button {...mergedProps}>
-		{@render children?.({
-			checked: rootState.checked.current,
-			indeterminate: rootState.indeterminate.current,
-		})}
+		{@render children?.(rootState.snippetProps)}
 	</button>
 {/if}
 

--- a/packages/bits-ui/src/lib/bits/checkbox/exports.ts
+++ b/packages/bits-ui/src/lib/bits/checkbox/exports.ts
@@ -1,2 +1,8 @@
 export { default as Root } from "./components/checkbox.svelte";
-export type { CheckboxRootProps as RootProps } from "./types.js";
+export { default as Group } from "./components/checkbox-group.svelte";
+export { default as GroupLabel } from "./components/checkbox-group-label.svelte";
+export type {
+	CheckboxRootProps as RootProps,
+	CheckboxGroupProps as GroupProps,
+	CheckboxGroupLabelProps as GroupLabelProps,
+} from "./types.js";

--- a/packages/bits-ui/src/lib/bits/checkbox/types.ts
+++ b/packages/bits-ui/src/lib/bits/checkbox/types.ts
@@ -1,5 +1,9 @@
 import type { OnChangeFn, WithChild, Without } from "$lib/internal/types.js";
-import type { BitsPrimitiveButtonAttributes } from "$lib/shared/attributes.js";
+import type {
+	BitsPrimitiveButtonAttributes,
+	BitsPrimitiveDivAttributes,
+	BitsPrimitiveSpanAttributes,
+} from "$lib/shared/attributes.js";
 
 export type CheckboxRootSnippetProps = { checked: boolean; indeterminate: boolean };
 
@@ -29,7 +33,9 @@ export type CheckboxRootPropsWithoutHTML = WithChild<
 		name?: any;
 
 		/**
-		 * The value of the checkbox used in form submission.
+		 * The value of the checkbox used in form submission and to identify
+		 * the checkbox when in a `Checkbox.Group`. If not provided while in a
+		 * `Checkbox.Group`, the checkbox will use a random identifier.
 		 *
 		 * @defaultValue undefined
 		 */
@@ -86,3 +92,63 @@ export type CheckboxRootPropsWithoutHTML = WithChild<
 
 export type CheckboxRootProps = CheckboxRootPropsWithoutHTML &
 	Without<BitsPrimitiveButtonAttributes, CheckboxRootPropsWithoutHTML>;
+
+export type CheckboxGroupPropsWithoutHTML = WithChild<{
+	/**
+	 * Whether the checkbox group is disabled.
+	 * This will disable all checkboxes in the group.
+	 *
+	 * @defaultValue false
+	 */
+	disabled?: boolean | null | undefined;
+
+	/**
+	 * Whether the checkbox group is required (for form validation).
+	 * This will mark all checkboxes in the group as required.
+	 *
+	 * @defaultValue false
+	 */
+	required?: boolean;
+
+	/**
+	 * The name of the checkbox used in form submission.
+	 * If not provided, the hidden input will not be rendered.
+	 * This will be used as the name for all checkboxes in the group.
+	 *
+	 * @defaultValue undefined
+	 */
+	// eslint-disable-next-line ts/no-explicit-any
+	name?: any;
+
+	/**
+	 * The value of the checkbox group, indicating which
+	 * of the checkboxes in the group are checked.
+	 *
+	 * @bindable
+	 * @defaultValue []
+	 */
+	value?: string[];
+
+	/**
+	 * A callback function called when the value changes.
+	 */
+	onValueChange?: OnChangeFn<string[]>;
+
+	/**
+	 * Whether or not the checkbox group value is controlled or not. If `true`, the
+	 * checkbox group will not update the value internally, instead it will call
+	 * `onValueChange` when it would have otherwise, and it is up to you to update
+	 * the `value` prop that is passed to the component.
+	 *
+	 * @defaultValue false
+	 */
+	controlledValue?: boolean;
+}>;
+
+export type CheckboxGroupProps = CheckboxGroupPropsWithoutHTML &
+	Without<BitsPrimitiveDivAttributes, CheckboxGroupPropsWithoutHTML>;
+
+export type CheckboxGroupLabelPropsWithoutHTML = WithChild;
+
+export type CheckboxGroupLabelProps = CheckboxGroupLabelPropsWithoutHTML &
+	Without<BitsPrimitiveSpanAttributes, CheckboxGroupLabelPropsWithoutHTML>;

--- a/packages/bits-ui/src/lib/internal/use-id.ts
+++ b/packages/bits-ui/src/lib/internal/use-id.ts
@@ -1,9 +1,9 @@
-let count = 0;
+globalThis.bitsIdCounter ??= { current: 0 };
 
 /**
  * Generates a unique ID based on a global counter.
  */
 export function useId(prefix = "bits") {
-	count++;
-	return `${prefix}-${count}`;
+	globalThis.bitsIdCounter.current++;
+	return `${prefix}-${globalThis.bitsIdCounter.current}`;
 }

--- a/packages/tests/src/tests/checkbox/checkbox-group-test.svelte
+++ b/packages/tests/src/tests/checkbox/checkbox-group-test.svelte
@@ -1,0 +1,57 @@
+<script lang="ts">
+	import { Checkbox } from "bits-ui";
+
+	let {
+		value = $bindable([]),
+		items = [],
+		disabledItems = [],
+		onFormSubmit,
+		...restProps
+	}: Checkbox.GroupProps & {
+		/**
+		 * The individual checkbox items.
+		 */
+		items?: string[];
+		disabledItems?: string[];
+		onFormSubmit?: (fd: FormData) => void;
+	} = $props();
+</script>
+
+{#snippet MyCheckbox({ itemValue }: { itemValue: string })}
+	<Checkbox.Root
+		data-testid="{itemValue}-checkbox"
+		value={itemValue}
+		disabled={disabledItems?.includes(itemValue)}
+	>
+		{#snippet children({ checked, indeterminate })}
+			<span data-testid="{itemValue}-indicator">
+				{#if indeterminate}
+					indeterminate
+				{:else}
+					{checked}
+				{/if}
+			</span>
+		{/snippet}
+	</Checkbox.Root>
+{/snippet}
+
+<main>
+	<form
+		method="POST"
+		onsubmit={(e) => {
+			e.preventDefault();
+			const formData = new FormData(e.currentTarget);
+			onFormSubmit?.(formData);
+		}}
+	>
+		<p data-testid="binding">{value}</p>
+		<Checkbox.Group data-testid="group" bind:value {...restProps}>
+			<Checkbox.GroupLabel data-testid="group-label">My Group</Checkbox.GroupLabel>
+			{#each items as itemValue}
+				{@render MyCheckbox({ itemValue })}
+			{/each}
+		</Checkbox.Group>
+		<button type="submit" data-testid="submit"> Submit </button>
+	</form>
+	<button data-testid="update" onclick={() => (value = ["c", "d"])}> Programmatic update </button>
+</main>

--- a/packages/tests/src/tests/checkbox/checkbox.test.ts
+++ b/packages/tests/src/tests/checkbox/checkbox.test.ts
@@ -174,7 +174,7 @@ describe("checkbox", () => {
 	});
 });
 
-describe.only("checkbox group", () => {
+describe("checkbox group", () => {
 	it("should have no accessibility violations", async () => {
 		const { container } = render(CheckboxGroupTest);
 		expect(await axe(container)).toHaveNoViolations();

--- a/packages/tests/src/tests/checkbox/checkbox.test.ts
+++ b/packages/tests/src/tests/checkbox/checkbox.test.ts
@@ -1,12 +1,15 @@
 import { render } from "@testing-library/svelte/svelte5";
 import { axe } from "jest-axe";
-import { describe, it } from "vitest";
-import { tick } from "svelte";
+import { describe, it, vi } from "vitest";
+import { type ComponentProps, tick } from "svelte";
 import type { Checkbox } from "bits-ui";
 import { getTestKbd, setupUserEvents } from "../utils.js";
 import CheckboxTest from "./checkbox-test.svelte";
+import CheckboxGroupTest from "./checkbox-group-test.svelte";
 
 const kbd = getTestKbd();
+
+const groupItems = ["a", "b", "c", "d"];
 
 function setup(props?: Checkbox.RootProps) {
 	const user = setupUserEvents();
@@ -21,6 +24,39 @@ function setup(props?: Checkbox.RootProps) {
 	};
 }
 
+function setupGroup(props: ComponentProps<typeof CheckboxGroupTest> = {}) {
+	const items = props.items ?? groupItems;
+	const user = setupUserEvents();
+	const returned = render(CheckboxGroupTest, {
+		...props,
+		items,
+	});
+	const group = returned.getByTestId("group");
+	const groupLabel = returned.getByTestId("group-label");
+	const submit = returned.getByTestId("submit");
+	const binding = returned.getByTestId("binding");
+	const updateBtn = returned.getByTestId("update");
+
+	const getCheckbox = (v: string) => returned.getByTestId(`${v}-checkbox`);
+	const getIndicator = (v: string) => returned.getByTestId(`${v}-indicator`);
+	const checkboxes = items.map((v) => getCheckbox(v));
+	const indicators = items.map((v) => returned.getByTestId(`${v}-indicator`));
+
+	return {
+		...returned,
+		group,
+		groupLabel,
+		getCheckbox,
+		getIndicator,
+		checkboxes,
+		indicators,
+		user,
+		submit,
+		binding,
+		updateBtn,
+	};
+}
+
 describe("checkbox", () => {
 	it("should have no accessibility violations", async () => {
 		const { container } = render(CheckboxTest);
@@ -32,7 +68,7 @@ describe("checkbox", () => {
 		expect(root).toHaveAttribute("data-checkbox-root");
 	});
 
-	it("should not render the checkbox input if a name prop isnt passed", async () => {
+	it("should not render the checkbox input if a name prop isn't passed", async () => {
 		const { input } = setup({ name: "" });
 		expect(input).not.toBeInTheDocument();
 	});
@@ -61,15 +97,13 @@ describe("checkbox", () => {
 	it("should toggle when clicked", async () => {
 		const { getByTestId, root, input, user } = setup();
 		const indicator = getByTestId("indicator");
-		expect(root).toHaveAttribute("data-state", "unchecked");
-		expect(root).toHaveAttribute("aria-checked", "false");
+		expectUnchecked(root);
 		expect(input.checked).toBe(false);
 		expect(indicator).toHaveTextContent("false");
 		expect(indicator).not.toHaveTextContent("true");
 		expect(indicator).not.toHaveTextContent("indeterminate");
 		await user.click(root);
-		expect(root).toHaveAttribute("data-state", "checked");
-		expect(root).toHaveAttribute("aria-checked", "true");
+		expectChecked(root);
 		expect(input.checked).toBe(true);
 		expect(indicator).toHaveTextContent("true");
 		expect(indicator).not.toHaveTextContent("false");
@@ -78,29 +112,25 @@ describe("checkbox", () => {
 
 	it("should toggle when the `Space` key is pressed", async () => {
 		const { root, input, user } = setup();
-		expect(root).toHaveAttribute("data-state", "unchecked");
-		expect(root).toHaveAttribute("aria-checked", "false");
+		expectUnchecked(root);
 		expect(input.checked).toBe(false);
 		root.focus();
 		await user.keyboard(kbd.SPACE);
-		expect(root).toHaveAttribute("data-state", "checked");
-		expect(root).toHaveAttribute("aria-checked", "true");
+		expectChecked(root);
 		expect(input.checked).toBe(true);
 	});
 
 	it("should not toggle when the `Enter` key is pressed", async () => {
 		const { getByTestId, root, input, user } = setup();
 		const indicator = getByTestId("indicator");
-		expect(root).toHaveAttribute("data-state", "unchecked");
-		expect(root).toHaveAttribute("aria-checked", "false");
+		expectUnchecked(root);
 		expect(input.checked).toBe(false);
 		expect(indicator).toHaveTextContent("false");
 		expect(indicator).not.toHaveTextContent("true");
 		expect(indicator).not.toHaveTextContent("indeterminate");
 		root.focus();
 		await user.keyboard(kbd.ENTER);
-		expect(root).not.toHaveAttribute("data-state", "checked");
-		expect(root).not.toHaveAttribute("aria-checked", "true");
+		expectUnchecked(root);
 		expect(indicator).toHaveTextContent("false");
 		expect(indicator).not.toHaveTextContent("true");
 		expect(indicator).not.toHaveTextContent("indeterminate");
@@ -109,13 +139,11 @@ describe("checkbox", () => {
 
 	it("should be disabled when the `disabled` prop is passed", async () => {
 		const { root, input, user } = setup({ disabled: true });
-		expect(root).toHaveAttribute("data-state", "unchecked");
-		expect(root).toHaveAttribute("aria-checked", "false");
+		expectUnchecked(root);
 		expect(input.checked).toBe(false);
 		expect(input.disabled).toBe(true);
 		await user.click(root);
-		expect(root).toHaveAttribute("data-state", "unchecked");
-		expect(root).toHaveAttribute("aria-checked", "false");
+		expectChecked(root);
 		expect(root).toBeDisabled();
 		expect(input.checked).toBe(false);
 	});
@@ -145,3 +173,116 @@ describe("checkbox", () => {
 		expect(binding).toHaveTextContent("true");
 	});
 });
+
+describe.only("checkbox group", () => {
+	it("should have no accessibility violations", async () => {
+		const { container } = render(CheckboxGroupTest);
+		expect(await axe(container)).toHaveNoViolations();
+	});
+
+	it("should have bits data attrs", async () => {
+		const { group, groupLabel } = setupGroup();
+		expect(group).toHaveAttribute("data-checkbox-group");
+		expect(groupLabel).toHaveAttribute("data-checkbox-group-label");
+	});
+
+	it("should handle default values appropriately", async () => {
+		const t = setupGroup({
+			value: ["a", "b"],
+		});
+
+		const [a, b, c, d] = t.checkboxes;
+		expectChecked(a, b);
+		expectUnchecked(c, d);
+
+		await t.user.click(a);
+		expectUnchecked(a);
+		await t.user.click(d);
+		expectChecked(d);
+	});
+
+	it("should submit the form data correctly using the checkbox values and group name", async () => {
+		let submittedValues: string[] | undefined;
+		const t = setupGroup({
+			name: "myGroup",
+			onFormSubmit: (fd) => {
+				submittedValues = fd.getAll("myGroup") as string[];
+			},
+		});
+		const [a, b] = t.checkboxes;
+		await t.user.click(a);
+		expectChecked(a);
+		await t.user.click(t.submit);
+		expect(submittedValues).toEqual(["a"]);
+		await t.user.click(b);
+		await t.user.click(t.submit);
+		expect(submittedValues).toEqual(["a", "b"]);
+	});
+
+	it("should handle binding value", async () => {
+		const t = setupGroup();
+
+		const [a, b, _, d] = t.checkboxes;
+		expect(t.binding).toHaveTextContent("");
+		await t.user.click(a);
+		expect(t.binding).toHaveTextContent("a");
+		await t.user.click(b);
+		expect(t.binding).toHaveTextContent("a,b");
+		await t.user.click(a);
+		expect(t.binding).toHaveTextContent("b");
+		await t.user.click(d);
+		expect(t.binding).toHaveTextContent("b,d");
+	});
+
+	it("should handle programmatic value changes", async () => {
+		const t = setupGroup({
+			value: ["a", "b"],
+		});
+
+		const [a, b, c, d] = t.checkboxes;
+		expectChecked(a, b);
+		await t.user.click(t.updateBtn);
+		expectUnchecked(a, b);
+		expectChecked(c, d);
+	});
+
+	it("should propagate disabled state to children checkboxes", async () => {
+		const t = setupGroup({
+			disabled: true,
+			required: true,
+		});
+
+		for (const checkbox of t.checkboxes) {
+			expect(checkbox).toBeDisabled();
+			expect(checkbox).toHaveAttribute("aria-required", "true");
+		}
+	});
+
+	it("should allow disabling a single item in the group", async () => {
+		const t = setupGroup({
+			disabledItems: ["a"],
+		});
+
+		const [a, ...rest] = t.checkboxes;
+
+		expect(a).toBeDisabled();
+
+		for (const checkbox of rest) {
+			expect(checkbox).not.toBeDisabled();
+		}
+	});
+});
+
+function expectChecked(...nodes: HTMLElement[]) {
+	for (const n of nodes) {
+		expect(n).toHaveAttribute("data-state", "checked");
+		expect(n).toHaveAttribute("aria-checked", "true");
+	}
+}
+
+function expectUnchecked(...nodes: HTMLElement[]) {
+	for (const n of nodes) {
+		expect(n).toHaveAttribute("data-state", "unchecked");
+		expect(n).toHaveAttribute("aria-checked", "false");
+	}
+}

--- a/packages/tests/src/tests/checkbox/checkbox.test.ts
+++ b/packages/tests/src/tests/checkbox/checkbox.test.ts
@@ -143,7 +143,7 @@ describe("checkbox", () => {
 		expect(input.checked).toBe(false);
 		expect(input.disabled).toBe(true);
 		await user.click(root);
-		expectChecked(root);
+		expectUnchecked(root);
 		expect(root).toBeDisabled();
 		expect(input.checked).toBe(false);
 	});

--- a/sites/docs/content/components/checkbox.md
+++ b/sites/docs/content/components/checkbox.md
@@ -4,7 +4,7 @@ description: Allow users to switch between checked, unchecked, and indeterminate
 ---
 
 <script>
-	import { APISection, ComponentPreviewV2, CheckboxDemo, CheckboxDemoCustom, Callout } from '$lib/components/index.js'
+	import { APISection, ComponentPreviewV2, CheckboxDemo, CheckboxDemoCustom, CheckboxDemoGroup, Callout } from '$lib/components/index.js'
 	export let schemas;
 </script>
 
@@ -320,5 +320,143 @@ If you want to make the checkbox required, you can use the `required` prop.
 ```
 
 This will apply the `required` attribute to the hidden input element, ensuring that proper form submission is enforced.
+
+## Checkbox Groups
+
+You can use the `Checkbox.Group` component to create a checkbox group.
+
+```svelte
+<script lang="ts">
+	import { Checkbox } from "bits-ui";
+</script>
+
+<Checkbox.Group name="notifications">
+	<Checkbox.GroupLabel>Notifications</Checkbox.GroupLabel>
+	<Checkbox.Root value="marketing" />
+	<Checkbox.Root value="promotions" />
+	<Checkbox.Root value="news" />
+</Checkbox.Group>
+```
+
+<ComponentPreviewV2 name="checkbox-demo-group" comp="Checkbox" containerClass="mt-6">
+
+{#snippet preview()}
+<CheckboxDemoGroup />
+{/snippet}
+
+</ComponentPreviewV2>
+
+### Managing Value State
+
+Bits UI offers several approaches to manage and synchronize a Checkbox Group's value state, catering to different levels of control and integration needs.
+
+#### 1. Two-Way Binding
+
+For seamless state synchronization, use Svelte's `bind:value` directive. This method automatically keeps your local state in sync with the group's internal state.
+
+```svelte
+<script lang="ts">
+	import { Checkbox } from "bits-ui";
+	let myValue = $state<string[]>([]);
+</script>
+
+<button
+	onclick={() => {
+		myValue = ["item-1", "item-2"];
+	}}
+>
+	Open Items 1 and 2
+</button>
+
+<Checkbox.Group name="myItems" bind:value={myValue}>
+	<Checkbox.GroupLabel>Items</Checkbox.GroupLabel>
+	<Checkbox.Root value="item-1" />
+	<Checkbox.Root value="item-2" />
+	<Checkbox.Root value="item-3" />
+</Checkbox.Group>
+```
+
+##### Key Benefits
+
+-   Simplifies state management
+-   Automatically updates `myValue` when the accordion changes (e.g., via clicking on an item's trigger)
+-   Allows external control (e.g., opening an item via a separate button)
+
+#### 2. Change Handler
+
+For more granular control or to perform additional logic on state changes, use the `onValueChange` prop. This approach is useful when you need to execute custom logic alongside state updates.
+
+```svelte
+<script lang="ts">
+	import { Checkbox } from "bits-ui";
+	let myValue = $state<string[]>([]);
+</script>
+
+<Checkbox.Group
+	value={myValue}
+	onValueChange={(value) => {
+		myValue = value;
+		// additional logic here.
+	}}
+>
+	<Checkbox.GroupLabel>Items</Checkbox.GroupLabel>
+	<Checkbox.Root value="item-1" />
+	<Checkbox.Root value="item-2" />
+	<Checkbox.Root value="item-3" />
+</Accordion.Root>
+```
+
+#### Use Cases
+
+-   Implementing custom behaviors on value change
+-   Integrating with external state management solutions
+-   Triggering side effects (e.g., logging, data fetching)
+
+#### 3. Fully Controlled
+
+For complete control over the Checkbox Group's value state, use the `controlledValue` prop. This approach requires you to manually manage the value state, giving you full control over when and how the group responds to value change events.
+
+To implement controlled state:
+
+1. Set the `controlledValue` prop to `true` on the `Checkbox.Group` component.
+2. Provide a `value` prop to `Checkbox.Group`, which should be a variable holding the current state.
+3. Implement an `onValueChange` handler to update the state when the internal state changes.
+
+```svelte
+<script lang="ts">
+	import { Checkbox } from "bits-ui";
+	let myValue = $state("");
+</script>
+
+<Checkbox.Group controlledValue value={myValue} onValueChange={(v) => (myValue = v)}>
+	<!-- ... -->
+</Checkbox.Group>
+```
+
+##### When to Use
+
+-   Implementing complex logic
+-   Coordinating multiple UI elements
+-   Debugging state-related issues
+
+<Callout>
+
+While powerful, fully controlled state should be used judiciously as it increases complexity and can cause unexpected behaviors if not handled carefully.
+
+For more in-depth information on controlled components and advanced state management techniques, refer to our [Controlled State](/docs/controlled-state) documentation.
+
+</Callout>
+
+### HTML Forms
+
+To render hidden `<input />` elements for the various checkboxes within a group, pass a `name` to `Checkbox.Group`. All descendent checkboxes will then render hidden inputs with the same name.
+
+```svelte /name="notifications"/
+<Checkbox.Group name="notifications">
+	<!-- ... -->
+</Checkbox.Group>
+```
+
+When a `Checkbox.Group` component is used, its descendent `Checkbox.Root` components will use certain properties from the group, such as the `name`, `required`, and `disabled`.
 
 <APISection {schemas} />

--- a/sites/docs/src/lib/components/demos/checkbox-demo-group.svelte
+++ b/sites/docs/src/lib/components/demos/checkbox-demo-group.svelte
@@ -1,0 +1,47 @@
+<script lang="ts">
+	import { Checkbox, Label, useId } from "bits-ui";
+	import Check from "phosphor-svelte/lib/Check";
+	import Minus from "phosphor-svelte/lib/Minus";
+</script>
+
+<Checkbox.Group class="flex flex-col gap-3">
+	<Checkbox.GroupLabel class="text-sm font-medium text-foreground-alt">
+		Notifications
+	</Checkbox.GroupLabel>
+	<div class="flex flex-col gap-4">
+		{@render MyCheckbox({ label: "Marketing", value: "marketing" })}
+		{@render MyCheckbox({ label: "Promotions", value: "promotions" })}
+		{@render MyCheckbox({ label: "News", value: "news" })}
+		{@render MyCheckbox({ label: "Updates", value: "updates" })}
+	</div>
+</Checkbox.Group>
+
+{#snippet MyCheckbox({ value, label }: { value: string; label: string })}
+	{@const id = useId()}
+	<div class="flex items-center">
+		<Checkbox.Root
+			{id}
+			aria-labelledby="{id}-label"
+			class="peer inline-flex size-[25px] items-center justify-center rounded-md border border-muted bg-foreground transition-all duration-150 ease-in-out active:scale-98 data-[state=unchecked]:border-border-input data-[state=unchecked]:bg-background data-[state=unchecked]:hover:border-dark-40"
+			name="hello"
+			{value}
+		>
+			{#snippet children({ checked, indeterminate })}
+				<div class="inline-flex items-center justify-center text-background">
+					{#if indeterminate}
+						<Minus class="size-[15px]" weight="bold" />
+					{:else if checked}
+						<Check class="size-[15px]" weight="bold" />
+					{/if}
+				</div>
+			{/snippet}
+		</Checkbox.Root>
+		<Label.Root
+			id="{id}-label"
+			for={id}
+			class="pl-3 text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+		>
+			{label}
+		</Label.Root>
+	</div>
+{/snippet}

--- a/sites/docs/src/lib/components/demos/checkbox-demo-group.svelte
+++ b/sites/docs/src/lib/components/demos/checkbox-demo-group.svelte
@@ -2,9 +2,11 @@
 	import { Checkbox, Label, useId } from "bits-ui";
 	import Check from "phosphor-svelte/lib/Check";
 	import Minus from "phosphor-svelte/lib/Minus";
+
+	let myValue = $state<string[]>(["marketing", "news"]);
 </script>
 
-<Checkbox.Group class="flex flex-col gap-3">
+<Checkbox.Group class="flex flex-col gap-3" bind:value={myValue} name="notifications">
 	<Checkbox.GroupLabel class="text-sm font-medium text-foreground-alt">
 		Notifications
 	</Checkbox.GroupLabel>

--- a/sites/docs/src/lib/components/demos/index.ts
+++ b/sites/docs/src/lib/components/demos/index.ts
@@ -8,6 +8,7 @@ export { default as ButtonDemo } from "./button-demo.svelte";
 export { default as CalendarDemo } from "./calendar-demo.svelte";
 export { default as CheckboxDemo } from "./checkbox-demo.svelte";
 export { default as CheckboxDemoCustom } from "./checkbox-demo-custom.svelte";
+export { default as CheckboxDemoGroup } from "./checkbox-demo-group.svelte";
 export { default as CollapsibleDemo } from "./collapsible-demo.svelte";
 export { default as CollapsibleDemoTransitions } from "./collapsible-demo-transitions.svelte";
 export { default as ComboboxDemo } from "./combobox-demo.svelte";

--- a/sites/docs/src/lib/content/api-reference/checkbox.api.ts
+++ b/sites/docs/src/lib/content/api-reference/checkbox.api.ts
@@ -1,16 +1,23 @@
-import type { CheckboxRootPropsWithoutHTML } from "bits-ui";
+import type {
+	CheckboxGroupLabelPropsWithoutHTML,
+	CheckboxGroupPropsWithoutHTML,
+	CheckboxRootPropsWithoutHTML,
+} from "bits-ui";
 import {
 	controlledCheckedProp,
 	controlledIndeterminateProp,
+	controlledValueProp,
 	createApiSchema,
 	createBooleanProp,
 	createDataAttrSchema,
 	createEnumDataAttr,
 	createFunctionProp,
+	createPropSchema,
 	createStringProp,
 	withChildProps,
 } from "./helpers.js";
 import {
+	CheckboxGroupOnValueChangeProp,
 	CheckboxRootChildSnippetProps,
 	CheckboxRootChildrenSnippetProps,
 	CheckboxRootOnCheckedChangeProp,
@@ -86,4 +93,67 @@ export const root = createApiSchema<CheckboxRootPropsWithoutHTML>({
 	],
 });
 
-export const checkbox = [root];
+export const group = createApiSchema<CheckboxGroupPropsWithoutHTML>({
+	title: "Group",
+	description: "A group that synchronizes its value state with its descendant checkboxes.",
+	props: {
+		value: createPropSchema({
+			description:
+				"The value of the group. This is an array of the values of the checked checkboxes within the group.",
+			bindable: true,
+			default: "[]",
+			type: "string[]",
+		}),
+		onValueChange: createFunctionProp({
+			definition: CheckboxGroupOnValueChangeProp,
+			description: "A callback that is fired when the checkbox group's value state changes.",
+		}),
+		controlledValue: controlledValueProp,
+		disabled: createBooleanProp({
+			default: C.FALSE,
+			description:
+				"Whether or not the checkbox group is disabled. If `true`, all checkboxes within the group will be disabled. To disable a specific checkbox in the group, pass the `disabled` prop to the checkbox.",
+		}),
+		required: createBooleanProp({
+			default: C.FALSE,
+			description: "Whether or not the checkbox group is required for form submission.",
+		}),
+		name: createStringProp({
+			description:
+				"The name of the checkbox group. If provided a hidden input will be rendered to use for form submission.",
+		}),
+		...withChildProps({
+			elType: "HTMLDivElement",
+		}),
+	},
+	dataAttributes: [
+		createDataAttrSchema({
+			name: "disabled",
+			description: "Present when the checkbox group is disabled.",
+		}),
+		createDataAttrSchema({
+			name: "checkbox-group",
+			description: "Present on the group element.",
+		}),
+	],
+});
+
+export const groupLabel = createApiSchema<CheckboxGroupLabelPropsWithoutHTML>({
+	title: "GroupLabel",
+	description: "An accessible label for the checkbox group.",
+	props: withChildProps({
+		elType: "HTMLLabelElement",
+	}),
+	dataAttributes: [
+		createDataAttrSchema({
+			name: "disabled",
+			description: "Present when the checkbox group is disabled.",
+		}),
+		createDataAttrSchema({
+			name: "checkbox-group-label",
+			description: "Present on the label element.",
+		}),
+	],
+});
+
+export const checkbox = [root, group, groupLabel];

--- a/sites/docs/src/lib/content/api-reference/extended-types/checkbox/checkbox-group-on-value-change-prop.md
+++ b/sites/docs/src/lib/content/api-reference/extended-types/checkbox/checkbox-group-on-value-change-prop.md
@@ -1,0 +1,3 @@
+```ts
+(value: string[]) => void;
+```

--- a/sites/docs/src/lib/content/api-reference/extended-types/checkbox/index.ts
+++ b/sites/docs/src/lib/content/api-reference/extended-types/checkbox/index.ts
@@ -3,3 +3,4 @@ export { default as CheckboxRootStateDataAttr } from "./checkbox-root-state-data
 export { default as CheckboxRootOnIndeterminateChangeProp } from "./checkbox-root-on-indeterminate-change.md";
 export { default as CheckboxRootChildSnippetProps } from "./checkbox-root-child-snippet-props.md";
 export { default as CheckboxRootChildrenSnippetProps } from "./checkbox-root-children-snippet-props.md";
+export { default as CheckboxGroupOnValueChangeProp } from "./checkbox-group-on-value-change-prop.md";


### PR DESCRIPTION
Closes #999 

This pull request introduces a new feature for the `Checkbox` component, adding support for `Checkbox.Group` and `Checkbox.GroupLabel` components. 

### New Features:
* Implemented `Checkbox.Group` and `Checkbox.GroupLabel` components to allow grouping of checkboxes and providing a label for the group. 



### Testing:
* Added new test cases for `Checkbox.Group` and `Checkbox.GroupLabel` to verify their functionality and ensure they integrate correctly with the existing `Checkbox` component. 