### PR TITLE
fix: actually disabling the button when it's disabled and using href

### DIFF
--- a/packages/bits-ui/src/lib/bits/button/components/button.svelte
+++ b/packages/bits-ui/src/lib/bits/button/components/button.svelte
@@ -1,13 +1,15 @@
 <script lang="ts">
 	import type { ButtonRootProps } from "../types.js";
 
-	let { href, type, children, ref = $bindable(), ...restProps }: ButtonRootProps = $props();
+	let { href, disabled, type, children, ref = $bindable(), ...restProps }: ButtonRootProps = $props();
+
+	const actualHref = $derived(disabled ? undefined : href);
 </script>
 
 <svelte:element
-	this={href ? "a" : "button"}
-	type={href ? undefined : type}
-	{href}
+	this={actualHref ? "a" : "button"}
+	type={actualHref ? undefined : type}
+	href={actualHref}
 	tabindex="0"
 	bind:this={ref}
 	{...restProps}


### PR DESCRIPTION
Related to https://github.com/huntabyte/bits-ui/issues/1038

Since it's gathering the props from `AnchorElement | ButtonElement`, when using href, it's actually an anchor, but the disabled is still available. It would be really useful to have this feature, since it offers a lot more flexibility for my project, and doesn't mislead when looking at the props.