### PR TITLE
feat: Allow `<Button/>` with `href` to be disabled

### DIFF
--- a/.changeset/khaki-drinks-reflect.md
+++ b/.changeset/khaki-drinks-reflect.md
@@ -1,0 +1,5 @@
+---
+"bits-ui": patch
+---
+
+Allow `<Button/>` with `href` to be disabled.

--- a/packages/bits-ui/src/lib/bits/button/components/button.svelte
+++ b/packages/bits-ui/src/lib/bits/button/components/button.svelte
@@ -1,14 +1,24 @@
 <script lang="ts">
 	import type { ButtonRootProps } from "../types.js";
 
-	let { href, type, children, ref = $bindable(), ...restProps }: ButtonRootProps = $props();
+	let {
+		href,
+		type,
+		children,
+		disabled = false,
+		ref = $bindable(),
+		...restProps
+	}: ButtonRootProps = $props();
 </script>
 
 <svelte:element
 	this={href ? "a" : "button"}
 	type={href ? undefined : type}
-	{href}
-	tabindex="0"
+	href={href && !disabled ? href : undefined}
+	disabled={href ? undefined : disabled}
+	aria-disabled={href ? disabled : undefined}
+	role={href && disabled ? "link" : undefined}
+	tabindex={href && disabled ? -1 : 0}
 	bind:this={ref}
 	{...restProps}
 >

--- a/packages/bits-ui/src/lib/bits/button/types.ts
+++ b/packages/bits-ui/src/lib/bits/button/types.ts
@@ -10,12 +10,14 @@ type AnchorElement = ButtonRootPropsWithoutHTML &
 	WithoutChildren<Omit<HTMLAnchorAttributes, "href" | "type">> & {
 		href: HTMLAnchorAttributes["href"];
 		type?: never;
+		disabled?: HTMLButtonAttributes["disabled"];
 	};
 
 type ButtonElement = ButtonRootPropsWithoutHTML &
 	WithoutChildren<Omit<HTMLButtonAttributes, "type" | "href">> & {
 		type?: HTMLButtonAttributes["type"];
 		href?: never;
+		disabled?: HTMLButtonAttributes["disabled"];
 	};
 
 export type ButtonRootProps = AnchorElement | ButtonElement;

--- a/sites/docs/src/lib/content/api-reference/button.api.ts
+++ b/sites/docs/src/lib/content/api-reference/button.api.ts
@@ -1,8 +1,11 @@
 import type { ButtonRootPropsWithoutHTML } from "bits-ui";
 import { childrenSnippet, createApiSchema, createPropSchema, refProp } from "./helpers.js";
 import * as C from "$lib/content/constants.js";
+import type { HTMLButtonAttributes } from "svelte/elements";
 
-export const root = createApiSchema<ButtonRootPropsWithoutHTML & { href: string }>({
+export const root = createApiSchema<
+	ButtonRootPropsWithoutHTML & { href: string; disabled: HTMLButtonAttributes["disabled"] }
+>({
 	title: "Root",
 	description:
 		"A component that can switch between a button and an anchor tag based on the `href`/`type` props.",
@@ -11,6 +14,12 @@ export const root = createApiSchema<ButtonRootPropsWithoutHTML & { href: string 
 			type: C.STRING,
 			description:
 				"An optional prop that when passed converts the button into an anchor tag.",
+		}),
+		disabled: createPropSchema({
+			type: C.BOOLEAN,
+			description:
+				"Whether or not the button is disabled. When disabled, the button cannot be interacted with.",
+			default: "false",
 		}),
 		ref: refProp({ elType: "HTMLButtonElement" }),
 		children: childrenSnippet(),


### PR DESCRIPTION
Alternative to #1039 

Implements the method used in the [blog post](https://www.scottohara.me/blog/2021/05/28/disabled-links.html):
```svelte
<a role="link" aria-disabled="true">Learn something!</a>
```