### PR TITLE
fix: correct syntax error in `menubar.md` (#1059)

### DIFF
--- a/sites/docs/content/components/menubar.md
+++ b/sites/docs/content/components/menubar.md
@@ -39,7 +39,7 @@ description: Organizes and presents a collection of menu options or actions with
 			<Menubar.RadioGroup>
 				<Menubar.RadioItem>
 					<Menubar.RadioIndicator />
-				<Menubar.RadioItem>
+				</Menubar.RadioItem>
 			</Menubar.RadioGroup>
 
 			<Menubar.Sub>


### PR DESCRIPTION
This PR fixes a syntax error in `menubar.md`, addressing #1059. I decided to take it because the issue was marked with the "help wanted" label.