### PR TITLE
fix: Correct to Command

### DIFF
--- a/sites/docs/content/components/command.md
+++ b/sites/docs/content/components/command.md
@@ -52,7 +52,7 @@ Here's an overview of how the Command component is structured in code:
 
 ```svelte
 <script lang="ts">
-	import { Combobox } from "bits-ui";
+	import { Command } from "bits-ui";
 </script>
 
 <Command.Root>


### PR DESCRIPTION
There is a small typo on `command.md` where it should import Command instead of Combobox.