### PR TITLE
fix: dangling event listeners on menu

### DIFF
--- a/.changeset/afraid-glasses-grow.md
+++ b/.changeset/afraid-glasses-grow.md
@@ -1,0 +1,5 @@
+---
+"bits-ui": patch
+---
+
+fix: clean up event listeners for menus

--- a/packages/bits-ui/src/lib/bits/index.ts
+++ b/packages/bits-ui/src/lib/bits/index.ts
@@ -35,4 +35,5 @@ export { Toggle } from "./toggle/index.js";
 export { ToggleGroup } from "./toggle-group/index.js";
 export { Toolbar } from "./toolbar/index.js";
 export { Tooltip } from "./tooltip/index.js";
+export { IsUsingKeyboard } from "./utilities/is-using-keyboard/is-using-keyboard.svelte.js";
 export { default as Portal } from "./utilities/portal/portal.svelte";

--- a/packages/bits-ui/src/lib/bits/utilities/is-using-keyboard/is-using-keyboard.svelte.ts
+++ b/packages/bits-ui/src/lib/bits/utilities/is-using-keyboard/is-using-keyboard.svelte.ts
@@ -1,0 +1,69 @@
+import { type AnyFn, addEventListener, executeCallbacks } from "svelte-toolbelt";
+
+// Using global state to avoid multiple listeners.
+let isUsingKeyboard = $state(false);
+
+export class IsUsingKeyboard {
+	static _refs = 0; // Reference counting to avoid multiple listeners.
+	static _cleanup?: AnyFn;
+
+	constructor() {
+		$effect(() => {
+			if (IsUsingKeyboard._refs === 0) {
+				IsUsingKeyboard._cleanup = $effect.root(() => {
+					const callbacksToDispose: AnyFn[] = [];
+
+					const handlePointer = (_: PointerEvent) => {
+						isUsingKeyboard = false;
+					};
+
+					const handleKeydown = (_: KeyboardEvent) => {
+						isUsingKeyboard = true;
+					};
+
+					callbacksToDispose.push(
+						addEventListener(document, "pointerdown", handlePointer, {
+							capture: true,
+						})
+					);
+
+					callbacksToDispose.push(
+						addEventListener(document, "pointermove", handlePointer, {
+							capture: true,
+						})
+					);
+
+					callbacksToDispose.push(
+						addEventListener(document, "keydown", handleKeydown, {
+							capture: true,
+						})
+					);
+
+					return () => {
+						// Don't forget to spread and call twice.
+						executeCallbacks(...callbacksToDispose)();
+					};
+				});
+			}
+
+			IsUsingKeyboard._refs++;
+
+			return () => {
+				IsUsingKeyboard._refs--;
+
+				if (IsUsingKeyboard._refs === 0) {
+					isUsingKeyboard = false;
+					IsUsingKeyboard._cleanup?.();
+				}
+			};
+		});
+	}
+
+	get current() {
+		return isUsingKeyboard;
+	}
+
+	set current(value: boolean) {
+		isUsingKeyboard = value;
+	}
+}

--- a/packages/bits-ui/src/lib/bits/utilities/is-using-keyboard/is-using-keyboard.svelte.ts
+++ b/packages/bits-ui/src/lib/bits/utilities/is-using-keyboard/is-using-keyboard.svelte.ts
@@ -1,4 +1,5 @@
-import { type AnyFn, addEventListener, executeCallbacks } from "svelte-toolbelt";
+import { type AnyFn, executeCallbacks } from "svelte-toolbelt";
+import { on } from "svelte/events";
 
 // Using global state to avoid multiple listeners.
 let isUsingKeyboard = $state(false);
@@ -22,19 +23,19 @@ export class IsUsingKeyboard {
 					};
 
 					callbacksToDispose.push(
-						addEventListener(document, "pointerdown", handlePointer, {
+						on(document, "pointerdown", handlePointer, {
 							capture: true,
 						})
 					);
 
 					callbacksToDispose.push(
-						addEventListener(document, "pointermove", handlePointer, {
+						on(document, "pointermove", handlePointer, {
 							capture: true,
 						})
 					);
 
 					callbacksToDispose.push(
-						addEventListener(document, "keydown", handleKeydown, {
+						on(document, "keydown", handleKeydown, {
 							capture: true,
 						})
 					);

--- a/packages/bits-ui/src/lib/bits/utilities/is-using-keyboard/is-using-keyboard.svelte.ts
+++ b/packages/bits-ui/src/lib/bits/utilities/is-using-keyboard/is-using-keyboard.svelte.ts
@@ -4,6 +4,11 @@ import { on } from "svelte/events";
 // Using global state to avoid multiple listeners.
 let isUsingKeyboard = $state(false);
 
+/**
+ * Detects whether the user is currently using the keyboard
+ * or not by listening to keyboard and pointer events. Uses shared global
+ * state to avoid listener duplication.
+ */
 export class IsUsingKeyboard {
 	static _refs = 0; // Reference counting to avoid multiple listeners.
 	static _cleanup?: AnyFn;
@@ -25,25 +30,17 @@ export class IsUsingKeyboard {
 					callbacksToDispose.push(
 						on(document, "pointerdown", handlePointer, {
 							capture: true,
-						})
-					);
-
-					callbacksToDispose.push(
+						}),
 						on(document, "pointermove", handlePointer, {
 							capture: true,
-						})
-					);
-
-					callbacksToDispose.push(
+						}),
 						on(document, "keydown", handleKeydown, {
 							capture: true,
 						})
 					);
 
-					return () => {
-						// Don't forget to spread and call twice.
-						executeCallbacks(...callbacksToDispose)();
-					};
+					// Don't forget to spread and call twice.
+					return executeCallbacks(...callbacksToDispose);
 				});
 			}
 

--- a/packages/bits-ui/src/lib/index.ts
+++ b/packages/bits-ui/src/lib/index.ts
@@ -37,6 +37,7 @@ export {
 	Toolbar,
 	Tooltip,
 	Portal,
+	IsUsingKeyboard,
 } from "./bits/index.js";
 
 export * from "./shared/index.js";

--- a/packages/tests/src/tests/utilities/is-using-keyboard/index.test.ts
+++ b/packages/tests/src/tests/utilities/is-using-keyboard/index.test.ts
@@ -1,0 +1,113 @@
+import { render } from "@testing-library/svelte/svelte5";
+import { getTestKbd, setupUserEvents } from "../../utils";
+import { vi } from "vitest";
+import IsUsingKeyboardTest from "./is-using-keyboard-test.svelte";
+
+const kbd = getTestKbd();
+
+describe("is-using-keyboard", () => {
+	function setup() {
+		const mounted = render(IsUsingKeyboardTest);
+		const user = setupUserEvents();
+		const isUsingKeyboard = mounted.component.isUsingKeyboard;
+
+		return {
+			...mounted,
+			user,
+			isUsingKeyboard,
+		};
+	}
+
+	afterEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("should detect keyboard usage", async () => {
+		const { user, isUsingKeyboard, unmount } = setup();
+
+		expect(isUsingKeyboard.current).toBe(false);
+
+		user.keyboard(kbd.SPACE);
+		expect(isUsingKeyboard.current).toBe(false);
+
+		unmount();
+	});
+
+	it("should detect pointer usage (down)", async () => {
+		const { user, isUsingKeyboard, unmount } = setup();
+
+		await user.keyboard(kbd.SPACE);
+		expect(isUsingKeyboard.current).toBe(true);
+
+		await user.pointerDownUp(document.body);
+		expect(isUsingKeyboard.current).toBe(false);
+
+		unmount();
+	});
+
+	it("should detect pointer usage (move)", async () => {
+		const { user, isUsingKeyboard, unmount } = setup();
+
+		await user.keyboard(kbd.SPACE);
+		expect(isUsingKeyboard.current).toBe(true);
+
+		await user.pointer([
+			{
+				coords: { x: 0, y: 0 },
+			},
+			{
+				coords: { x: 100, y: 100 },
+			},
+		]);
+
+		expect(isUsingKeyboard.current).toBe(false);
+
+		unmount();
+	});
+
+	it("should detect keyboard usage after pointer usage", async () => {
+		const { user, isUsingKeyboard, unmount } = setup();
+
+		await user.pointerDownUp(document.body);
+		expect(isUsingKeyboard.current).toBe(false);
+
+		await user.keyboard(kbd.SPACE);
+		expect(isUsingKeyboard.current).toBe(true);
+
+		unmount();
+	});
+
+	it("should set up only once", async () => {
+		const addEventListener = vi.spyOn(document, "addEventListener");
+		const removeEventListener = vi.spyOn(document, "removeEventListener");
+
+		expect(addEventListener).toHaveBeenCalledTimes(0);
+		expect(removeEventListener).toHaveBeenCalledTimes(0);
+
+		// Mount component multiple times.
+		const handles = [setup(), setup(), setup()];
+
+		handles.forEach(({ isUsingKeyboard }) => {
+			expect(isUsingKeyboard.current).toBe(false);
+		});
+
+		await handles[0].user.keyboard(kbd.SPACE);
+
+		handles.forEach(({ isUsingKeyboard }) => {
+			expect(isUsingKeyboard.current).toBe(true);
+		});
+
+		// All three listeners should have been set up only once.
+		expect(addEventListener).toHaveBeenCalledTimes(3);
+		expect(removeEventListener).toHaveBeenCalledTimes(0);
+
+		// Unmount all components.
+		handles.forEach(({ unmount }) => {
+			unmount();
+		});
+
+		// All listeners should have been removed.
+		expect(addEventListener).toHaveBeenCalledTimes(3);
+		expect(removeEventListener).toHaveBeenCalledTimes(3);
+	});
+});

--- a/packages/tests/src/tests/utilities/is-using-keyboard/index.test.ts
+++ b/packages/tests/src/tests/utilities/is-using-keyboard/index.test.ts
@@ -23,30 +23,26 @@ describe("is-using-keyboard", () => {
 	});
 
 	it("should detect keyboard usage", async () => {
-		const { user, isUsingKeyboard, unmount } = setup();
+		const { user, isUsingKeyboard } = setup();
 
 		expect(isUsingKeyboard.current).toBe(false);
 
 		user.keyboard(kbd.SPACE);
 		expect(isUsingKeyboard.current).toBe(false);
-
-		unmount();
 	});
 
 	it("should detect pointer usage (down)", async () => {
-		const { user, isUsingKeyboard, unmount } = setup();
+		const { user, isUsingKeyboard } = setup();
 
 		await user.keyboard(kbd.SPACE);
 		expect(isUsingKeyboard.current).toBe(true);
 
 		await user.pointerDownUp(document.body);
 		expect(isUsingKeyboard.current).toBe(false);
-
-		unmount();
 	});
 
 	it("should detect pointer usage (move)", async () => {
-		const { user, isUsingKeyboard, unmount } = setup();
+		const { user, isUsingKeyboard } = setup();
 
 		await user.keyboard(kbd.SPACE);
 		expect(isUsingKeyboard.current).toBe(true);
@@ -61,20 +57,16 @@ describe("is-using-keyboard", () => {
 		]);
 
 		expect(isUsingKeyboard.current).toBe(false);
-
-		unmount();
 	});
 
 	it("should detect keyboard usage after pointer usage", async () => {
-		const { user, isUsingKeyboard, unmount } = setup();
+		const { user, isUsingKeyboard } = setup();
 
 		await user.pointerDownUp(document.body);
 		expect(isUsingKeyboard.current).toBe(false);
 
 		await user.keyboard(kbd.SPACE);
 		expect(isUsingKeyboard.current).toBe(true);
-
-		unmount();
 	});
 
 	it("should set up only once", async () => {

--- a/packages/tests/src/tests/utilities/is-using-keyboard/index.test.ts
+++ b/packages/tests/src/tests/utilities/is-using-keyboard/index.test.ts
@@ -5,7 +5,7 @@ import IsUsingKeyboardTest from "./is-using-keyboard-test.svelte";
 
 const kbd = getTestKbd();
 
-describe("is-using-keyboard", () => {
+describe("IsUsingKeyboard", () => {
 	function setup() {
 		const mounted = render(IsUsingKeyboardTest);
 		const user = setupUserEvents();

--- a/packages/tests/src/tests/utilities/is-using-keyboard/is-using-keyboard-test.svelte
+++ b/packages/tests/src/tests/utilities/is-using-keyboard/is-using-keyboard-test.svelte
@@ -1,0 +1,7 @@
+<script>
+	import { IsUsingKeyboard } from "bits-ui";
+
+	const isUsingKeyboard = new IsUsingKeyboard();
+
+	export { isUsingKeyboard };
+</script>

--- a/sites/docs/content/utilities/is-using-keyboard.md
+++ b/sites/docs/content/utilities/is-using-keyboard.md
@@ -1,0 +1,20 @@
+---
+title: IsUsingKeyboard
+description: A utility to track whether the user is actively using the keyboard or not.
+---
+
+## Overview
+
+`IsUsingKeyboard` is a utility component that tracks whether the user is actively using the keyboard or not. This component is used internally by Bits UI components to provide keyboard accessibility features.
+
+It provides global state that is shared across all instances of the class to prevent duplicate event listener registration.
+
+## Usage
+
+```svelte
+<script lang="ts">
+	import { IsUsingKeyboard } from "bits-ui";
+
+	const shouldShowMenu = $derived(isUsingKeyboard.current);
+</script>
+```


### PR DESCRIPTION
Fixes #1070

---

I took the opportunity to optimize the determination of the user's input mode (pointer or keyboard). Now, only three event listeners are registered and can be shared between multiple components.

I took inspiration from @huntabyte's branch `fix/focus-scoping` where a class `IsUsingKeyboard` is already implemented.

---

Many thanks to @chbert with whom I troubleshot this issue extensively :)