### PR TITLE
fix: Pin Input paste behavior

### DIFF
--- a/.changeset/chatty-plums-judge.md
+++ b/.changeset/chatty-plums-judge.md
@@ -1,0 +1,5 @@
+---
+"bits-ui": patch
+---
+
+fix: Pin Input paste behavior

--- a/packages/bits-ui/src/lib/bits/pin-input/pin-input.svelte.ts
+++ b/packages/bits-ui/src/lib/bits/pin-input/pin-input.svelte.ts
@@ -432,7 +432,6 @@ class PinInputRootState {
 			if (!e.clipboardData || !input) return;
 			const content = e.clipboardData.getData("text/plain");
 			const sanitizedContent = this.#onPaste?.current?.(content) ?? content;
-			console.log("sanitizedContent", sanitizedContent);
 			if (
 				sanitizedContent.length > 0 &&
 				this.#regexPattern &&
@@ -448,7 +447,6 @@ class PinInputRootState {
 		e.preventDefault();
 
 		const sanitizedContent = this.#onPaste?.current?.(content) ?? content;
-		console.log("sanitized content", sanitizedContent);
 		if (
 			sanitizedContent.length > 0 &&
 			this.#regexPattern &&

--- a/packages/tests/src/tests/pin-input/pin-input.test.ts
+++ b/packages/tests/src/tests/pin-input/pin-input.test.ts
@@ -171,4 +171,10 @@ describe("pin Input", () => {
 		await user.keyboard("1$");
 		expect(hiddenInput).toHaveValue("1");
 	});
+
+	it("should allow pasting numbers that match the pattern", async () => {
+		const { user, hiddenInput } = setup({
+			pattern: REGEXP_ONLY_DIGITS,
+		});
+	});
 });

--- a/packages/tests/src/tests/pin-input/pin-input.test.ts
+++ b/packages/tests/src/tests/pin-input/pin-input.test.ts
@@ -11,13 +11,7 @@ function setup(props: Partial<PinInput.RootProps> = {}) {
 	const user = setupUserEvents();
 	// @ts-expect-error - testing lib needs to update their generic types
 	const returned = render(PinInputTest, { ...props });
-	const cell0 = returned.getByTestId("cell-0");
-	const cell1 = returned.getByTestId("cell-1");
-	const cell2 = returned.getByTestId("cell-2");
-	const cell3 = returned.getByTestId("cell-3");
-	const cell4 = returned.getByTestId("cell-4");
-	const cell5 = returned.getByTestId("cell-5");
-	const cells = [cell0, cell1, cell2, cell3, cell4, cell5];
+	const cells = new Array(6).fill(null).map((_, i) => returned.getByTestId(`cell-${i}`));
 	const binding = returned.getByTestId("binding");
 	const hiddenInput = returned.getByTestId("input");
 	return {
@@ -173,8 +167,35 @@ describe("pin Input", () => {
 	});
 
 	it("should allow pasting numbers that match the pattern", async () => {
+		const mockComplete = vi.fn();
+		const mockClipboard = "123456";
+		await navigator.clipboard.writeText(mockClipboard);
+
 		const { user, hiddenInput } = setup({
 			pattern: REGEXP_ONLY_DIGITS,
+			onComplete: mockComplete,
 		});
+
+		await user.click(hiddenInput);
+		await user.paste(mockClipboard);
+
+		expect(mockComplete).toHaveBeenCalledTimes(1);
+		expect(mockComplete).toHaveBeenCalledWith("123456");
+	});
+
+	it("should not allow pasting numbers that do not match the pattern", async () => {
+		const mockComplete = vi.fn();
+		const mockClipboard = "abcdef";
+		await navigator.clipboard.writeText(mockClipboard);
+
+		const { user, hiddenInput } = setup({
+			pattern: REGEXP_ONLY_DIGITS,
+			onComplete: mockComplete,
+		});
+
+		await user.click(hiddenInput);
+		await user.paste(mockClipboard);
+
+		expect(mockComplete).toHaveBeenCalledTimes(0);
 	});
 });

--- a/sites/docs/src/lib/components/demos/pin-input-demo.svelte
+++ b/sites/docs/src/lib/components/demos/pin-input-demo.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { PinInput, type PinInputRootSnippetProps } from "bits-ui";
+	import { PinInput, REGEXP_ONLY_DIGITS, type PinInputRootSnippetProps } from "bits-ui";
 	import { toast } from "svelte-sonner";
 	import { cn } from "$lib/utils/styles.js";
 
@@ -18,6 +18,7 @@
 	class="group/pininput flex items-center text-foreground has-[:disabled]:opacity-30"
 	maxlength={6}
 	{onComplete}
+	pattern={REGEXP_ONLY_DIGITS}
 >
 	{#snippet children({ cells })}
 		<div class="flex">


### PR DESCRIPTION
The issue was that we were preventing default on non-matching keys, such as `v` regardless of whether `ctrlKey` or `metaKey` was true.