### PR TITLE
Fix: Align Dates Properly in Calendar Component Example

### DIFF
--- a/sites/docs/src/lib/components/demos/calendar-demo.svelte
+++ b/sites/docs/src/lib/components/demos/calendar-demo.svelte
@@ -44,7 +44,7 @@
 				</Calendar.GridHead>
 				<Calendar.GridBody>
 					{#each month.weeks as weekDates}
-						<Calendar.GridRow class="flex w-full">
+						<Calendar.GridRow class="flex justify-between w-full">
 							{#each weekDates as date}
 								<Calendar.Cell
 									{date}


### PR DESCRIPTION
<img width="381" alt="Screenshot 2025-02-01 at 3 35 54 PM" src="https://github.com/user-attachments/assets/1c1cfc57-fa2c-409b-b8e1-82a318ed63fa" />

<img width="385" alt="Screenshot 2025-02-01 at 3 38 04 PM" src="https://github.com/user-attachments/assets/fad8e009-5283-47c5-94cb-ebbda45bb099" />

The calendar component example provided in the Bits UI documentation exhibits a misalignment of dates, as shown in the attached screenshots. This occurs because the required justify-between style is missing from the relevant container. Without this style, the dates do not distribute evenly.

While this may seem like a small issue, it can be quite frustrating to debug and resolve for users directly copying the example code from the documentation.

This issue is also present in the Shadcn-Svelte implementation. However, due to my need for additional customisation, I am currently using the Bits UI component for this specific use case.