### PR TITLE
chore: release

### DIFF
--- a/.changeset/big-dogs-sing.md
+++ b/.changeset/big-dogs-sing.md
@@ -1,0 +1,5 @@
+---
+"bits-ui": minor
+---
+
+Bits UI v1 (Svelte 5). This release includes many breaking changes, bug fixes, and new features. ([#690](https://github.com/huntabyte/bits-ui/pull/690))


### PR DESCRIPTION
Well, since somehow way back when (7 years ago) bits-ui 1.0.0-1.0.7 was published (no longer on registry), so we must start at 1.1.0. 