### PR TITLE
docs: tiny typo alert-dialog example

### DIFF
--- a/sites/docs/content/components/alert-dialog.md
+++ b/sites/docs/content/components/alert-dialog.md
@@ -106,8 +106,8 @@ This example is used in a few places throughout this documentation page to give 
 				{@render description()}
 			</AlertDialog.Description>
 			{@render children?.()}
-			<AlertDialog.Cancel>Cancel</AlertDialog.Close>
-			<AlertDialog.Action>Confirm</AlertDialog.Close>
+			<AlertDialog.Cancel>Cancel</AlertDialog.Cancel>
+			<AlertDialog.Action>Confirm</AlertDialog.Action>
 		</AlertDialog.Content>
 	</AlertDialog.Portal>
 </AlertDialog.Root>


### PR DESCRIPTION
One example of the Alert Dialog docs hat the wrong closing tags