### PR TITLE
docs: update Tooltip's Close on Trigger Click code

### DIFF
--- a/docs/content/components/tooltip.md
+++ b/docs/content/components/tooltip.md
@@ -254,11 +254,14 @@ You can change how long a user needs to hover over a trigger before the tooltip 
 
 ## Close on Trigger Click
 
-By default, the tooltip will close when the user clicks the trigger. If you want to disable this behavior, you can set the `disableCloseOnTriggerClick` prop to `true`.
+By default, the tooltip will close when the user clicks the trigger. If you want to disable this behavior, you can set the `disableCloseOnTriggerClick` prop to `true` on `Tooltip.Root`, and set the `interactOutsideBehavior` prop to `'ignore'` on `Tooltip.Content`.
 
-```svelte /disableCloseOnTriggerClick/
+```svelte /disableCloseOnTriggerClick/ /interactOutsideBehavior="ignore"/
 <Tooltip.Root disableCloseOnTriggerClick>
 	<!-- .... -->
+	<Tooltip.Content interactOutsideBehavior="ignore">
+		<!-- .... -->
+	</Tooltip.Content>
 </Tooltip.Root>
 ```
 


### PR DESCRIPTION
The [Close on Trigger Click](https://bits-ui.com/docs/components/tooltip#close-on-trigger-click) code example in Tooltip is not working properly, because we also need to pass `interactOutsideBehavior="ignore"` to `Tooltip.Content`.

This is because clicking the trigger is technically "an interaction occurred outside of the floating content", so the default value of `'close'` will close the tooltip even though `disableCloseOnTriggerClick` is set to true. This was previously raised in https://github.com/huntabyte/bits-ui/issues/872#issuecomment-2455343531, so I think we should include it in the docs.

Here's the minimal reproducible example: https://stackblitz.com/edit/vitejs-vite-rsblrcvd?file=src%2FApp.svelte

https://github.com/user-attachments/assets/57f052f4-7815-4f67-962f-6cdd747f2bb8

