### PR TITLE
fix: `disableCloseOnTriggerClick` prop for `Tooltip` component

### DIFF
--- a/.changeset/hot-shirts-grin.md
+++ b/.changeset/hot-shirts-grin.md
@@ -1,0 +1,5 @@
+---
+"bits-ui": patch
+---
+
+fix: bug causing `disableCloseOnTriggerClick` to not be respected in `Tooltip`

--- a/.changeset/mean-walls-wonder.md
+++ b/.changeset/mean-walls-wonder.md
@@ -1,0 +1,5 @@
+---
+"bits-ui": patch
+---
+
+fix: removed improperly exposed/unused `onCloseAutoFocus` prop from `Combobox.Content/ContentStatic` and `Select.Content/ContentStatic`

--- a/docs/src/lib/content/api-reference/combobox.api.ts
+++ b/docs/src/lib/content/api-reference/combobox.api.ts
@@ -41,7 +41,6 @@ import {
 	floatingProps,
 	focusScopeProps,
 	forceMountProp,
-	onCloseAutoFocusProp,
 	preventOverflowTextSelectionProp,
 	preventScrollProp,
 	withChildProps,
@@ -134,7 +133,6 @@ export const content = createApiSchema<ComboboxContentPropsWithoutHTML>({
 		...floatingProps(),
 		...escapeLayerProps,
 		...dismissibleLayerProps,
-		onCloseAutoFocus: onCloseAutoFocusProp,
 		preventOverflowTextSelection: preventOverflowTextSelectionProp,
 		dir: dirProp,
 		loop: createBooleanProp({

--- a/docs/src/lib/content/api-reference/select.api.ts
+++ b/docs/src/lib/content/api-reference/select.api.ts
@@ -17,7 +17,6 @@ import {
 	floatingProps,
 	focusScopeProps,
 	forceMountProp,
-	onCloseAutoFocusProp,
 	preventOverflowTextSelectionProp,
 	preventScrollProp,
 	withChildProps,
@@ -132,7 +131,6 @@ export const content = createApiSchema<SelectContentPropsWithoutHTML>({
 		...floatingProps(),
 		...escapeLayerProps,
 		...dismissibleLayerProps,
-		onCloseAutoFocus: onCloseAutoFocusProp,
 		preventOverflowTextSelection: preventOverflowTextSelectionProp,
 		dir: dirProp,
 		loop: createBooleanProp({

--- a/package.json
+++ b/package.json
@@ -11,8 +11,7 @@
 		"format": "prettier --write .",
 		"lint": "prettier --check . && eslint .",
 		"lint:fix": "eslint --fix .",
-		"test": "pnpm -F \"./packages/**\" --parallel --reporter append-only --color test",
-		"test:components": "pnpm -F tests test",
+		"test": "pnpm -F \"./{packages,tests}/**\" --parallel --reporter append-only --color test","test:components": "pnpm -F tests test",
 		"test:utils": "pnpm -F bits-ui test"
 	},
 	"keywords": [],

--- a/packages/bits-ui/src/lib/bits/context-menu/components/context-menu-content-static.svelte
+++ b/packages/bits-ui/src/lib/bits/context-menu/components/context-menu-content-static.svelte
@@ -65,6 +65,7 @@
 {#if forceMount}
 	<PopperLayerForceMount
 		{...mergedProps}
+		{...contentState.popperProps}
 		isStatic
 		side="right"
 		sideOffset={2}
@@ -96,6 +97,7 @@
 {:else if !forceMount}
 	<PopperLayer
 		{...mergedProps}
+		{...contentState.popperProps}
 		isStatic
 		side="right"
 		sideOffset={2}

--- a/packages/bits-ui/src/lib/bits/context-menu/components/context-menu-content.svelte
+++ b/packages/bits-ui/src/lib/bits/context-menu/components/context-menu-content.svelte
@@ -65,6 +65,7 @@
 {#if forceMount}
 	<PopperLayerForceMount
 		{...mergedProps}
+		{...contentState.popperProps}
 		side="right"
 		sideOffset={2}
 		align="start"
@@ -96,6 +97,7 @@
 {:else if !forceMount}
 	<PopperLayer
 		{...mergedProps}
+		{...contentState.popperProps}
 		side="right"
 		sideOffset={2}
 		align="start"

--- a/packages/bits-ui/src/lib/bits/dropdown-menu/components/dropdown-menu-content-static.svelte
+++ b/packages/bits-ui/src/lib/bits/dropdown-menu/components/dropdown-menu-content-static.svelte
@@ -51,6 +51,7 @@
 {#if forceMount}
 	<PopperLayerForceMount
 		{...mergedProps}
+		{...contentState.popperProps}
 		enabled={contentState.parentMenu.opts.open.current}
 		onInteractOutside={handleInteractOutside}
 		onEscapeKeydown={handleEscapeKeydown}
@@ -77,6 +78,7 @@
 {:else if !forceMount}
 	<PopperLayer
 		{...mergedProps}
+		{...contentState.popperProps}
 		present={contentState.parentMenu.opts.open.current}
 		onInteractOutside={handleInteractOutside}
 		onEscapeKeydown={handleEscapeKeydown}

--- a/packages/bits-ui/src/lib/bits/dropdown-menu/components/dropdown-menu-content.svelte
+++ b/packages/bits-ui/src/lib/bits/dropdown-menu/components/dropdown-menu-content.svelte
@@ -51,6 +51,7 @@
 {#if forceMount}
 	<PopperLayerForceMount
 		{...mergedProps}
+		{...contentState.popperProps}
 		enabled={contentState.parentMenu.opts.open.current}
 		onInteractOutside={handleInteractOutside}
 		onEscapeKeydown={handleEscapeKeydown}
@@ -78,6 +79,7 @@
 {:else if !forceMount}
 	<PopperLayer
 		{...mergedProps}
+		{...contentState.popperProps}
 		present={contentState.parentMenu.opts.open.current}
 		onInteractOutside={handleInteractOutside}
 		onEscapeKeydown={handleEscapeKeydown}

--- a/packages/bits-ui/src/lib/bits/link-preview/components/link-preview-content-static.svelte
+++ b/packages/bits-ui/src/lib/bits/link-preview/components/link-preview-content-static.svelte
@@ -6,14 +6,15 @@
 	import PopperLayer from "$lib/bits/utilities/popper-layer/popper-layer.svelte";
 	import { getFloatingContentCSSVars } from "$lib/internal/floating-svelte/floating-utils.svelte.js";
 	import PopperLayerForceMount from "$lib/bits/utilities/popper-layer/popper-layer-force-mount.svelte";
+	import { noop } from "$lib/internal/noop.js";
 
 	let {
 		children,
 		child,
 		id = useId(),
 		ref = $bindable(null),
-		onInteractOutside,
-		onEscapeKeydown,
+		onInteractOutside = noop,
+		onEscapeKeydown = noop,
 		forceMount = false,
 		...restProps
 	}: LinkPreviewContentStaticProps = $props();
@@ -24,33 +25,20 @@
 			() => ref,
 			(v) => (ref = v)
 		),
+		onInteractOutside: box.with(() => onInteractOutside),
+		onEscapeKeydown: box.with(() => onEscapeKeydown),
 	});
 
 	const mergedProps = $derived(mergeProps(restProps, contentState.props));
-
-	function handleInteractOutside(e: PointerEvent) {
-		onInteractOutside?.(e);
-		if (e.defaultPrevented) return;
-		contentState.root.handleClose();
-	}
-
-	function handleEscapeKeydown(e: KeyboardEvent) {
-		onEscapeKeydown?.(e);
-		if (e.defaultPrevented) return;
-		contentState.root.handleClose();
-	}
 </script>
 
 {#if forceMount}
 	<PopperLayerForceMount
 		{...mergedProps}
+		{...contentState.popperProps}
 		enabled={contentState.root.opts.open.current}
 		isStatic
 		{id}
-		onInteractOutside={handleInteractOutside}
-		onEscapeKeydown={handleEscapeKeydown}
-		onOpenAutoFocus={(e) => e.preventDefault()}
-		onCloseAutoFocus={(e) => e.preventDefault()}
 		trapFocus={false}
 		loop={false}
 		preventScroll={false}
@@ -72,13 +60,10 @@
 {:else if !forceMount}
 	<PopperLayer
 		{...mergedProps}
+		{...contentState.popperProps}
 		present={contentState.root.opts.open.current}
 		isStatic
 		{id}
-		onInteractOutside={handleInteractOutside}
-		onEscapeKeydown={handleEscapeKeydown}
-		onOpenAutoFocus={(e) => e.preventDefault()}
-		onCloseAutoFocus={(e) => e.preventDefault()}
 		trapFocus={false}
 		loop={false}
 		preventScroll={false}

--- a/packages/bits-ui/src/lib/bits/link-preview/components/link-preview-content.svelte
+++ b/packages/bits-ui/src/lib/bits/link-preview/components/link-preview-content.svelte
@@ -7,6 +7,7 @@
 	import { getFloatingContentCSSVars } from "$lib/internal/floating-svelte/floating-utils.svelte.js";
 	import PopperLayerForceMount from "$lib/bits/utilities/popper-layer/popper-layer-force-mount.svelte";
 	import Mounted from "$lib/bits/utilities/mounted.svelte";
+	import { noop } from "$lib/internal/noop.js";
 
 	let {
 		children,
@@ -21,8 +22,8 @@
 		sticky = "partial",
 		hideWhenDetached = false,
 		collisionPadding = 0,
-		onInteractOutside,
-		onEscapeKeydown,
+		onInteractOutside = noop,
+		onEscapeKeydown = noop,
 		forceMount = false,
 		...restProps
 	}: LinkPreviewContentProps = $props();
@@ -33,6 +34,8 @@
 			() => ref,
 			(v) => (ref = v)
 		),
+		onInteractOutside: box.with(() => onInteractOutside),
+		onEscapeKeydown: box.with(() => onEscapeKeydown),
 	});
 
 	const floatingProps = $derived({
@@ -47,29 +50,14 @@
 	});
 
 	const mergedProps = $derived(mergeProps(restProps, floatingProps, contentState.props));
-
-	function handleInteractOutside(e: PointerEvent) {
-		onInteractOutside?.(e);
-		if (e.defaultPrevented) return;
-		contentState.root.handleClose();
-	}
-
-	function handleEscapeKeydown(e: KeyboardEvent) {
-		onEscapeKeydown?.(e);
-		if (e.defaultPrevented) return;
-		contentState.root.handleClose();
-	}
 </script>
 
 {#if forceMount}
 	<PopperLayerForceMount
 		{...mergedProps}
+		{...contentState.popperProps}
 		enabled={contentState.root.opts.open.current}
 		{id}
-		onInteractOutside={handleInteractOutside}
-		onEscapeKeydown={handleEscapeKeydown}
-		onOpenAutoFocus={(e) => e.preventDefault()}
-		onCloseAutoFocus={(e) => e.preventDefault()}
 		trapFocus={false}
 		loop={false}
 		preventScroll={false}
@@ -93,12 +81,9 @@
 {:else if !forceMount}
 	<PopperLayer
 		{...mergedProps}
+		{...contentState.popperProps}
 		present={contentState.root.opts.open.current}
 		{id}
-		onInteractOutside={handleInteractOutside}
-		onEscapeKeydown={handleEscapeKeydown}
-		onOpenAutoFocus={(e) => e.preventDefault()}
-		onCloseAutoFocus={(e) => e.preventDefault()}
 		trapFocus={false}
 		loop={false}
 		preventScroll={false}

--- a/packages/bits-ui/src/lib/bits/link-preview/link-preview.svelte.ts
+++ b/packages/bits-ui/src/lib/bits/link-preview/link-preview.svelte.ts
@@ -167,7 +167,11 @@ class LinkPreviewTriggerState {
 	);
 }
 
-type LinkPreviewContentStateProps = WithRefProps;
+type LinkPreviewContentStateProps = WithRefProps &
+	ReadableBoxedValues<{
+		onInteractOutside: (e: PointerEvent) => void;
+		onEscapeKeydown: (e: KeyboardEvent) => void;
+	}>;
 
 class LinkPreviewContentState {
 	constructor(
@@ -220,6 +224,26 @@ class LinkPreviewContentState {
 		e.preventDefault();
 	}
 
+	onInteractOutside = (e: PointerEvent) => {
+		this.opts.onInteractOutside.current(e);
+		if (e.defaultPrevented) return;
+		this.root.handleClose();
+	};
+
+	onEscapeKeydown = (e: KeyboardEvent) => {
+		this.opts.onEscapeKeydown.current?.(e);
+		if (e.defaultPrevented) return;
+		this.root.handleClose();
+	};
+
+	onOpenAutoFocus = (e: Event) => {
+		e.preventDefault();
+	};
+
+	onCloseAutoFocus = (e: Event) => {
+		e.preventDefault();
+	};
+
 	snippetProps = $derived.by(() => ({ open: this.root.opts.open.current }));
 
 	props = $derived.by(
@@ -234,6 +258,13 @@ class LinkPreviewContentState {
 				onfocusout: this.onfocusout,
 			}) as const
 	);
+
+	popperProps = {
+		onInteractOutside: this.onInteractOutside,
+		onEscapeKeydown: this.onEscapeKeydown,
+		onOpenAutoFocus: this.onOpenAutoFocus,
+		onCloseAutoFocus: this.onCloseAutoFocus,
+	};
 }
 
 const LinkPreviewRootContext = new Context<LinkPreviewRootState>("LinkPreview.Root");

--- a/packages/bits-ui/src/lib/bits/menu/components/menu-content-static.svelte
+++ b/packages/bits-ui/src/lib/bits/menu/components/menu-content-static.svelte
@@ -54,6 +54,7 @@
 {#if forceMount}
 	<PopperLayerForceMount
 		{...mergedProps}
+		{...contentState.popperProps}
 		enabled={contentState.parentMenu.opts.open.current}
 		onInteractOutside={handleInteractOutside}
 		onEscapeKeydown={handleEscapeKeydown}
@@ -83,6 +84,7 @@
 {:else if !forceMount}
 	<PopperLayer
 		{...mergedProps}
+		{...contentState.popperProps}
 		present={contentState.parentMenu.opts.open.current}
 		onInteractOutside={handleInteractOutside}
 		onEscapeKeydown={handleEscapeKeydown}

--- a/packages/bits-ui/src/lib/bits/menu/components/menu-content.svelte
+++ b/packages/bits-ui/src/lib/bits/menu/components/menu-content.svelte
@@ -54,6 +54,7 @@
 {#if forceMount}
 	<PopperLayerForceMount
 		{...mergedProps}
+		{...contentState.popperProps}
 		enabled={contentState.parentMenu.opts.open.current}
 		onInteractOutside={handleInteractOutside}
 		onEscapeKeydown={handleEscapeKeydown}
@@ -84,6 +85,7 @@
 {:else if !forceMount}
 	<PopperLayer
 		{...mergedProps}
+		{...contentState.popperProps}
 		present={contentState.parentMenu.opts.open.current}
 		onInteractOutside={handleInteractOutside}
 		onEscapeKeydown={handleEscapeKeydown}

--- a/packages/bits-ui/src/lib/bits/menu/menu.svelte.ts
+++ b/packages/bits-ui/src/lib/bits/menu/menu.svelte.ts
@@ -365,13 +365,16 @@ class MenuContentState {
 				onkeydown: this.onkeydown,
 				onblur: this.onblur,
 				onfocus: this.onfocus,
-				onCloseAutoFocus: (e: Event) => this.onCloseAutoFocus(e),
 				dir: this.parentMenu.root.opts.dir.current,
 				style: {
 					pointerEvents: "auto",
 				},
 			}) as const
 	);
+
+	popperProps = {
+		onCloseAutoFocus: (e: Event) => this.onCloseAutoFocus(e),
+	};
 }
 
 type MenuItemSharedStateProps = WithRefProps &

--- a/packages/bits-ui/src/lib/bits/menubar/components/menubar-content-static.svelte
+++ b/packages/bits-ui/src/lib/bits/menubar/components/menubar-content-static.svelte
@@ -33,12 +33,4 @@
 	const mergedProps = $derived(mergeProps(restProps, contentState.props));
 </script>
 
-<MenuContentStatic
-	bind:ref
-	{...mergedProps}
-	preventScroll={false}
-	onInteractOutside={contentState.onInteractOutside}
-	onFocusOutside={contentState.onFocusOutside}
-	onCloseAutoFocus={contentState.onCloseAutoFocus}
-	onOpenAutoFocus={contentState.onOpenAutoFocus}
-/>
+<MenuContentStatic bind:ref {...mergedProps} {...contentState.popperProps} preventScroll={false} />

--- a/packages/bits-ui/src/lib/bits/menubar/components/menubar-content.svelte
+++ b/packages/bits-ui/src/lib/bits/menubar/components/menubar-content.svelte
@@ -33,12 +33,4 @@
 	const mergedProps = $derived(mergeProps(restProps, contentState.props));
 </script>
 
-<MenuContent
-	bind:ref
-	{...mergedProps}
-	preventScroll={false}
-	onInteractOutside={contentState.onInteractOutside}
-	onFocusOutside={contentState.onFocusOutside}
-	onCloseAutoFocus={contentState.onCloseAutoFocus}
-	onOpenAutoFocus={contentState.onOpenAutoFocus}
-/>
+<MenuContent bind:ref {...mergedProps} {...contentState.popperProps} preventScroll={false} />

--- a/packages/bits-ui/src/lib/bits/menubar/menubar.svelte.ts
+++ b/packages/bits-ui/src/lib/bits/menubar/menubar.svelte.ts
@@ -286,10 +286,6 @@ class MenubarContentState {
 		this.root = menu.root;
 		this.focusScopeContext = FocusScopeContext.get();
 
-		this.onCloseAutoFocus = this.onCloseAutoFocus.bind(this);
-		this.onFocusOutside = this.onFocusOutside.bind(this);
-		this.onInteractOutside = this.onInteractOutside.bind(this);
-		this.onOpenAutoFocus = this.onOpenAutoFocus.bind(this);
 		this.onkeydown = this.onkeydown.bind(this);
 
 		useRefById({
@@ -301,7 +297,7 @@ class MenubarContentState {
 		});
 	}
 
-	onCloseAutoFocus(e: Event) {
+	onCloseAutoFocus = (e: Event) => {
 		this.opts.onCloseAutoFocus.current(e);
 		if (e.defaultPrevented) return;
 		if (
@@ -314,27 +310,27 @@ class MenubarContentState {
 
 		this.hasInteractedOutside = false;
 		e.preventDefault();
-	}
+	};
 
-	onFocusOutside(e: FocusEvent) {
+	onFocusOutside = (e: FocusEvent) => {
 		const target = e.target as HTMLElement;
 		const isMenubarTrigger = this.root
 			.getTriggers()
 			.some((trigger) => trigger.contains(target));
 		if (isMenubarTrigger) e.preventDefault();
 		this.opts.onFocusOutside.current(e);
-	}
+	};
 
-	onInteractOutside(e: PointerEvent) {
+	onInteractOutside = (e: PointerEvent) => {
 		this.hasInteractedOutside = true;
 		this.opts.onInteractOutside.current(e);
-	}
+	};
 
-	onOpenAutoFocus(e: Event) {
+	onOpenAutoFocus = (e: Event) => {
 		this.opts.onOpenAutoFocus.current(e);
 		if (e.defaultPrevented) return;
 		afterTick(() => this.opts.ref.current?.focus());
-	}
+	};
 
 	onkeydown(e: BitsKeyboardEvent) {
 		if (e.key !== kbd.ARROW_LEFT && e.key !== kbd.ARROW_RIGHT) return;
@@ -388,6 +384,13 @@ class MenubarContentState {
 				"data-menu-content": "",
 			}) as const
 	);
+
+	popperProps = {
+		onCloseAutoFocus: this.onCloseAutoFocus,
+		onFocusOutside: this.onFocusOutside,
+		onInteractOutside: this.onInteractOutside,
+		onOpenAutoFocus: this.onOpenAutoFocus,
+	};
 }
 
 const MenubarRootContext = new Context<MenubarRootState>("Menubar.Root");

--- a/packages/bits-ui/src/lib/bits/popover/components/popover-content-static.svelte
+++ b/packages/bits-ui/src/lib/bits/popover/components/popover-content-static.svelte
@@ -19,7 +19,6 @@
 		onInteractOutside = noop,
 		trapFocus = true,
 		preventScroll = false,
-
 		...restProps
 	}: PopoverContentStaticProps = $props();
 
@@ -40,12 +39,10 @@
 {#if forceMount}
 	<PopperLayerForceMount
 		{...mergedProps}
+		{...contentState.popperProps}
 		isStatic
 		enabled={contentState.root.opts.open.current}
 		{id}
-		onInteractOutside={contentState.handleInteractOutside}
-		onEscapeKeydown={contentState.handleEscapeKeydown}
-		onCloseAutoFocus={contentState.handleCloseAutoFocus}
 		{trapFocus}
 		{preventScroll}
 		loop
@@ -67,12 +64,10 @@
 {:else if !forceMount}
 	<PopperLayer
 		{...mergedProps}
+		{...contentState.popperProps}
 		isStatic
 		present={contentState.root.opts.open.current}
 		{id}
-		onInteractOutside={contentState.handleInteractOutside}
-		onEscapeKeydown={contentState.handleEscapeKeydown}
-		onCloseAutoFocus={contentState.handleCloseAutoFocus}
 		{trapFocus}
 		{preventScroll}
 		loop

--- a/packages/bits-ui/src/lib/bits/popover/components/popover-content.svelte
+++ b/packages/bits-ui/src/lib/bits/popover/components/popover-content.svelte
@@ -39,11 +39,9 @@
 {#if forceMount}
 	<PopperLayerForceMount
 		{...mergedProps}
+		{...contentState.popperProps}
 		enabled={contentState.root.opts.open.current}
 		{id}
-		onInteractOutside={contentState.handleInteractOutside}
-		onEscapeKeydown={contentState.handleEscapeKeydown}
-		onCloseAutoFocus={contentState.handleCloseAutoFocus}
 		{trapFocus}
 		{preventScroll}
 		loop
@@ -67,11 +65,9 @@
 {:else if !forceMount}
 	<PopperLayer
 		{...mergedProps}
+		{...contentState.popperProps}
 		present={contentState.root.opts.open.current}
 		{id}
-		onInteractOutside={contentState.handleInteractOutside}
-		onEscapeKeydown={contentState.handleEscapeKeydown}
-		onCloseAutoFocus={contentState.handleCloseAutoFocus}
 		{trapFocus}
 		{preventScroll}
 		loop

--- a/packages/bits-ui/src/lib/bits/popover/popover.svelte.ts
+++ b/packages/bits-ui/src/lib/bits/popover/popover.svelte.ts
@@ -114,13 +114,9 @@ class PopoverContentState {
 				this.root.contentNode = node;
 			},
 		});
-
-		this.handleInteractOutside = this.handleInteractOutside.bind(this);
-		this.handleEscapeKeydown = this.handleEscapeKeydown.bind(this);
-		this.handleCloseAutoFocus = this.handleCloseAutoFocus.bind(this);
 	}
 
-	handleInteractOutside(e: PointerEvent) {
+	onInteractOutside = (e: PointerEvent) => {
 		this.opts.onInteractOutside.current(e);
 		if (e.defaultPrevented) return;
 		if (!isElement(e.target)) return;
@@ -128,20 +124,20 @@ class PopoverContentState {
 		const closestTrigger = e.target.closest(`[data-popover-trigger]`);
 		if (closestTrigger === this.root.triggerNode) return;
 		this.root.handleClose();
-	}
+	};
 
-	handleEscapeKeydown(e: KeyboardEvent) {
+	onEscapeKeydown = (e: KeyboardEvent) => {
 		this.opts.onEscapeKeydown.current(e);
 		if (e.defaultPrevented) return;
 		this.root.handleClose();
-	}
+	};
 
-	handleCloseAutoFocus(e: Event) {
+	onCloseAutoFocus = (e: Event) => {
 		this.opts.onCloseAutoFocus.current(e);
 		if (e.defaultPrevented) return;
 		e.preventDefault();
 		this.root.triggerNode?.focus();
-	}
+	};
 
 	snippetProps = $derived.by(() => ({ open: this.root.opts.open.current }));
 
@@ -157,6 +153,12 @@ class PopoverContentState {
 				},
 			}) as const
 	);
+
+	popperProps = {
+		onInteractOutside: this.onInteractOutside,
+		onEscapeKeydown: this.onEscapeKeydown,
+		onCloseAutoFocus: this.onCloseAutoFocus,
+	};
 }
 
 type PopoverCloseStateProps = WithRefProps;

--- a/packages/bits-ui/src/lib/bits/select/components/select-content-static.svelte
+++ b/packages/bits-ui/src/lib/bits/select/components/select-content-static.svelte
@@ -15,6 +15,7 @@
 		onEscapeKeydown = noop,
 		children,
 		child,
+		preventScroll = false,
 		...restProps
 	}: SelectContentStaticProps = $props();
 
@@ -24,39 +25,21 @@
 			() => ref,
 			(v) => (ref = v)
 		),
+		onInteractOutside: box.with(() => onInteractOutside),
+		onEscapeKeydown: box.with(() => onEscapeKeydown),
 	});
 
 	const mergedProps = $derived(mergeProps(restProps, contentState.props));
-
-	function handleInteractOutside(e: PointerEvent) {
-		contentState.handleInteractOutside(e);
-		if (e.defaultPrevented) return;
-		onInteractOutside(e);
-		if (e.defaultPrevented) return;
-		contentState.root.handleClose();
-	}
-
-	function handleEscapeKeydown(e: KeyboardEvent) {
-		onEscapeKeydown(e);
-		if (e.defaultPrevented) return;
-		contentState.root.handleClose();
-	}
 </script>
 
 {#if forceMount}
 	<PopperLayerForceMount
 		{...mergedProps}
+		{...contentState.popperProps}
 		isStatic
 		enabled={contentState.root.opts.open.current}
 		{id}
-		onInteractOutside={handleInteractOutside}
-		onEscapeKeydown={handleEscapeKeydown}
-		onOpenAutoFocus={(e) => e.preventDefault()}
-		onCloseAutoFocus={(e) => e.preventDefault()}
-		trapFocus={false}
-		loop={false}
-		preventScroll={false}
-		onPlaced={() => (contentState.isPositioned = true)}
+		{preventScroll}
 		forceMount={true}
 	>
 		{#snippet popper({ props })}
@@ -73,17 +56,11 @@
 {:else if !forceMount}
 	<PopperLayer
 		{...mergedProps}
+		{...contentState.popperProps}
 		isStatic
 		present={contentState.root.opts.open.current}
 		{id}
-		onInteractOutside={handleInteractOutside}
-		onEscapeKeydown={handleEscapeKeydown}
-		onOpenAutoFocus={(e) => e.preventDefault()}
-		onCloseAutoFocus={(e) => e.preventDefault()}
-		trapFocus={false}
-		loop={false}
-		preventScroll={false}
-		onPlaced={() => (contentState.isPositioned = true)}
+		{preventScroll}
 		forceMount={false}
 	>
 		{#snippet popper({ props })}

--- a/packages/bits-ui/src/lib/bits/select/components/select-content.svelte
+++ b/packages/bits-ui/src/lib/bits/select/components/select-content.svelte
@@ -26,37 +26,20 @@
 			() => ref,
 			(v) => (ref = v)
 		),
+		onInteractOutside: box.with(() => onInteractOutside),
+		onEscapeKeydown: box.with(() => onEscapeKeydown),
 	});
 
 	const mergedProps = $derived(mergeProps(restProps, contentState.props));
-
-	function handleInteractOutside(e: PointerEvent) {
-		contentState.handleInteractOutside(e);
-		if (e.defaultPrevented) return;
-		onInteractOutside(e);
-		if (e.defaultPrevented) return;
-		contentState.root.handleClose();
-	}
-
-	function handleEscapeKeydown(e: KeyboardEvent) {
-		onEscapeKeydown(e);
-		if (e.defaultPrevented) return;
-		contentState.root.handleClose();
-	}
 </script>
 
 {#if forceMount}
 	<PopperLayerForceMount
 		{...mergedProps}
+		{...contentState.popperProps}
 		{side}
 		enabled={contentState.root.opts.open.current}
 		{id}
-		onInteractOutside={handleInteractOutside}
-		onEscapeKeydown={handleEscapeKeydown}
-		onOpenAutoFocus={(e) => e.preventDefault()}
-		onCloseAutoFocus={(e) => e.preventDefault()}
-		trapFocus={false}
-		loop={false}
 		{preventScroll}
 		onPlaced={() => (contentState.isPositioned = true)}
 		forceMount={true}
@@ -77,17 +60,11 @@
 {:else if !forceMount}
 	<PopperLayer
 		{...mergedProps}
+		{...contentState.popperProps}
 		{side}
 		present={contentState.root.opts.open.current}
 		{id}
-		onInteractOutside={handleInteractOutside}
-		onEscapeKeydown={handleEscapeKeydown}
-		onOpenAutoFocus={(e) => e.preventDefault()}
-		onCloseAutoFocus={(e) => e.preventDefault()}
-		trapFocus={false}
-		loop={false}
 		{preventScroll}
-		onPlaced={() => (contentState.isPositioned = true)}
 		forceMount={false}
 	>
 		{#snippet popper({ props, wrapperProps })}

--- a/packages/bits-ui/src/lib/bits/select/types.ts
+++ b/packages/bits-ui/src/lib/bits/select/types.ts
@@ -162,7 +162,7 @@ export type _SharedSelectContentProps = {
 
 export type SelectContentPropsWithoutHTML = Expand<
 	WithChildNoChildrenSnippetProps<
-		Omit<PopperLayerProps, "content" | "onOpenAutoFocus" | "trapFocus"> &
+		Omit<PopperLayerProps, "content" | "onOpenAutoFocus" | "trapFocus" | "onCloseAutoFocus"> &
 			_SharedSelectContentProps,
 		FloatingContentSnippetProps
 	>
@@ -173,7 +173,10 @@ export type SelectContentProps = SelectContentPropsWithoutHTML &
 
 export type SelectContentStaticPropsWithoutHTML = Expand<
 	WithChildNoChildrenSnippetProps<
-		Omit<PopperLayerStaticProps, "content" | "onOpenAutoFocus" | "trapFocus"> &
+		Omit<
+			PopperLayerStaticProps,
+			"content" | "onOpenAutoFocus" | "onCloseAutoFocus" | "trapFocus"
+		> &
 			_SharedSelectContentProps,
 		StaticContentSnippetProps
 	>

--- a/packages/bits-ui/src/lib/bits/tooltip/components/tooltip-content-static.svelte
+++ b/packages/bits-ui/src/lib/bits/tooltip/components/tooltip-content-static.svelte
@@ -6,15 +6,15 @@
 	import PopperLayer from "$lib/bits/utilities/popper-layer/popper-layer.svelte";
 	import { getFloatingContentCSSVars } from "$lib/internal/floating-svelte/floating-utils.svelte.js";
 	import PopperLayerForceMount from "$lib/bits/utilities/popper-layer/popper-layer-force-mount.svelte";
+	import { noop } from "$lib/internal/noop.js";
 
 	let {
 		children,
 		child,
 		id = useId(),
 		ref = $bindable(null),
-
-		onInteractOutside,
-		onEscapeKeydown,
+		onInteractOutside = noop,
+		onEscapeKeydown = noop,
 		forceMount = false,
 		...restProps
 	}: TooltipContentStaticProps = $props();
@@ -25,33 +25,20 @@
 			() => ref,
 			(v) => (ref = v)
 		),
+		onInteractOutside: box.with(() => onInteractOutside),
+		onEscapeKeydown: box.with(() => onEscapeKeydown),
 	});
 
 	const mergedProps = $derived(mergeProps(restProps, contentState.props));
-
-	function handleInteractOutside(e: PointerEvent) {
-		onInteractOutside?.(e);
-		if (e.defaultPrevented) return;
-		contentState.root.handleClose();
-	}
-
-	function handleEscapeKeydown(e: KeyboardEvent) {
-		onEscapeKeydown?.(e);
-		if (e.defaultPrevented) return;
-		contentState.root.handleClose();
-	}
 </script>
 
 {#if forceMount}
 	<PopperLayerForceMount
 		{...mergedProps}
+		{...contentState.popperProps}
 		isStatic
 		enabled={contentState.root.opts.open.current}
 		{id}
-		onInteractOutside={handleInteractOutside}
-		onEscapeKeydown={handleEscapeKeydown}
-		onOpenAutoFocus={(e) => e.preventDefault()}
-		onCloseAutoFocus={(e) => e.preventDefault()}
 		trapFocus={false}
 		loop={false}
 		preventScroll={false}
@@ -73,13 +60,10 @@
 {:else if !forceMount}
 	<PopperLayer
 		{...mergedProps}
+		{...contentState.popperProps}
 		isStatic
 		present={contentState.root.opts.open.current}
 		{id}
-		onInteractOutside={handleInteractOutside}
-		onEscapeKeydown={handleEscapeKeydown}
-		onOpenAutoFocus={(e) => e.preventDefault()}
-		onCloseAutoFocus={(e) => e.preventDefault()}
 		trapFocus={false}
 		loop={false}
 		preventScroll={false}

--- a/packages/bits-ui/src/lib/bits/tooltip/components/tooltip-content.svelte
+++ b/packages/bits-ui/src/lib/bits/tooltip/components/tooltip-content.svelte
@@ -6,6 +6,7 @@
 	import PopperLayer from "$lib/bits/utilities/popper-layer/popper-layer.svelte";
 	import { getFloatingContentCSSVars } from "$lib/internal/floating-svelte/floating-utils.svelte.js";
 	import PopperLayerForceMount from "$lib/bits/utilities/popper-layer/popper-layer-force-mount.svelte";
+	import { noop } from "$lib/internal/noop.js";
 
 	let {
 		children,
@@ -20,8 +21,8 @@
 		sticky = "partial",
 		hideWhenDetached = false,
 		collisionPadding = 0,
-		onInteractOutside,
-		onEscapeKeydown,
+		onInteractOutside = noop,
+		onEscapeKeydown = noop,
 		forceMount = false,
 		...restProps
 	}: TooltipContentProps = $props();
@@ -32,6 +33,8 @@
 			() => ref,
 			(v) => (ref = v)
 		),
+		onInteractOutside: box.with(() => onInteractOutside),
+		onEscapeKeydown: box.with(() => onEscapeKeydown),
 	});
 
 	const floatingProps = $derived({
@@ -46,29 +49,14 @@
 	});
 
 	const mergedProps = $derived(mergeProps(restProps, floatingProps, contentState.props));
-
-	function handleInteractOutside(e: PointerEvent) {
-		onInteractOutside?.(e);
-		if (e.defaultPrevented) return;
-		contentState.root.handleClose();
-	}
-
-	function handleEscapeKeydown(e: KeyboardEvent) {
-		onEscapeKeydown?.(e);
-		if (e.defaultPrevented) return;
-		contentState.root.handleClose();
-	}
 </script>
 
 {#if forceMount}
 	<PopperLayerForceMount
 		{...mergedProps}
+		{...contentState.popperProps}
 		enabled={contentState.root.opts.open.current}
 		{id}
-		onInteractOutside={handleInteractOutside}
-		onEscapeKeydown={handleEscapeKeydown}
-		onOpenAutoFocus={(e) => e.preventDefault()}
-		onCloseAutoFocus={(e) => e.preventDefault()}
 		trapFocus={false}
 		loop={false}
 		preventScroll={false}
@@ -92,12 +80,9 @@
 {:else if !forceMount}
 	<PopperLayer
 		{...mergedProps}
+		{...contentState.popperProps}
 		present={contentState.root.opts.open.current}
 		{id}
-		onInteractOutside={handleInteractOutside}
-		onEscapeKeydown={handleEscapeKeydown}
-		onOpenAutoFocus={(e) => e.preventDefault()}
-		onCloseAutoFocus={(e) => e.preventDefault()}
 		trapFocus={false}
 		loop={false}
 		preventScroll={false}


### PR DESCRIPTION
Closes #1189 

--

Additionally, this PR removes an improperly exposed prop - `onCloseAutoFocus` on the `Select.Content/ContentStatic` and `Combobox.Content/ContentStatic`.

If you were using this prop previously, it was not doing anything as we were not forwarding it through the components.

We manage focus differently for the `Select` and `Combobox`, using the `aria-activedescendent` property, so there is no use in an `onCloseAutoFocus` or `onOpenAutoFocus` prop, I just forgot to omit it from the exposed type.