### PR TITLE
feat: `Meter` component

### DIFF
--- a/.changeset/fresh-snails-report.md
+++ b/.changeset/fresh-snails-report.md
@@ -2,4 +2,4 @@
 "bits-ui": minor
 ---
 
-feat: `Meter` component
+New Component: `Meter` [documentation](https://bits-ui.com/docs/components/meter)

--- a/.changeset/fresh-snails-report.md
+++ b/.changeset/fresh-snails-report.md
@@ -1,0 +1,5 @@
+---
+"bits-ui": minor
+---
+
+feat: `Meter` component

--- a/docs/content/components/meter.md
+++ b/docs/content/components/meter.md
@@ -1,0 +1,96 @@
+---
+title: Meter
+description: Display real-time measurements within a defined range.
+---
+
+<script>
+	import { APISection, ComponentPreviewV2, MeterDemo, DemoCodeContainer, MeterDemoCustom } from '$lib/components/index.js'
+	let { schemas } = $props()
+</script>
+
+<ComponentPreviewV2 name="meter-demo" comp="Meter">
+
+{#snippet preview()}
+<MeterDemo />
+{/snippet}
+
+</ComponentPreviewV2>
+
+While often visually similar, meters and [Progress](/docs/components/progress) bars serve distinct purposes:
+
+**Meter**:
+
+-   Displays a **static measurement** within a known range (0-100)
+-   Value can fluctuate up/down based on real-time measurements
+-   Examples: CPU usage, battery level, sound volume
+-   Use when showing current state relative to capacity
+
+**Progress**:
+
+-   Shows **completion status** of a task
+-   Value only increases as task progresses
+-   Examples: File upload, installation status, form completion
+-   Use when tracking advancement toward completion
+
+If you need a progress bar, check out the [Progress](/docs/components/progress) component.
+
+## Structure
+
+```svelte
+<script lang="ts">
+	import { Meter } from "bits-ui";
+</script>
+
+<Meter.Root />
+```
+
+## Reusable Components
+
+It's recommended to use the `Meter` primitive to create your own custom meter component that can be used throughout your application. In the example below, we're using the `Meter` primitive to create a more comprehensive meter component.
+
+```svelte
+<script lang="ts">
+	import { Meter, useId } from "bits-ui";
+	import type { ComponentProps } from "svelte";
+
+	let {
+		max = 100,
+		value = 0,
+		min = 0,
+		label,
+		valueLabel,
+	}: ComponentProps<typeof Meter.Root> & {
+		label: string;
+		valueLabel: string;
+	} = $props();
+
+	const labelId = useId();
+</script>
+
+<div>
+	<span id={labelId}> {label} </span>
+	<span>{valueLabel}</span>
+</div>
+<Meter.Root aria-labelledby={labelId} aria-valuetext={valueLabel} {value} {min} {max} />
+```
+
+You can then use the `MyMeter` component in your application like so:
+
+```svelte title="+page.svelte"
+<script lang="ts">
+	import MyMeter from "$lib/components/MyMeter.svelte";
+
+	let value = $state(3000);
+	const max = 4000;
+</script>
+
+<MyMeter label="Tokens remaining" valueLabel="{value} / {max}" {value} {max} />
+```
+
+Of course, you'd want to apply your own styles and other customizations to the `MyMeter` component to fit your application's design.
+
+<br>
+
+<MeterDemoCustom value={3000} label="Tokens remaining" valueLabel="3000 / 4000" max={4000} />
+
+<APISection {schemas} />

--- a/docs/content/components/meter.md
+++ b/docs/content/components/meter.md
@@ -25,14 +25,14 @@ While often visually similar, meters and [Progress](/docs/components/progress) b
 -   Examples: CPU usage, battery level, sound volume
 -   Use when showing current state relative to capacity
 
-**Progress**:
+**Progress bar**:
 
 -   Shows **completion status** of a task
 -   Value only increases as task progresses
 -   Examples: File upload, installation status, form completion
 -   Use when tracking advancement toward completion
 
-If you need a progress bar, check out the [Progress](/docs/components/progress) component.
+If a progress bar better fits your requirements, check out the [Progress](/docs/components/progress) component.
 
 ## Structure
 
@@ -92,5 +92,11 @@ Of course, you'd want to apply your own styles and other customizations to the `
 <br>
 
 <MeterDemoCustom value={3000} label="Tokens remaining" valueLabel="3000 / 4000" max={4000} />
+
+## Accessibility
+
+If a visual label is used, the ID of the label element should be pass via the `aria-labelledby` prop to `Meter.Root`. If no visual label is used, the `aria-label` prop should be used to provide a text description of the progress bar.
+
+Assistive technologies often present `aria-valuenow` as a percentage. If conveying the value of the meter only in terms of a percentage would not be user friendly, the `aria-valuetext` property should be set to a string that makes the meter value understandable. For example, a battery meter value might be conveyed as `aria-valuetext="50% (6 hours) remaining"`. [[source](https://www.w3.org/WAI/ARIA/apg/patterns/meter/)]
 
 <APISection {schemas} />

--- a/docs/content/components/progress.md
+++ b/docs/content/components/progress.md
@@ -16,6 +16,24 @@ description: Visualizes the progress or completion status of a task or process.
 
 </ComponentPreviewV2>
 
+While often visually similar, progress bars and [Meters](/docs/components/meter) serve distinct purposes:
+
+**Progress**:
+
+-   Shows **completion status** of a task
+-   Value only increases as task progresses
+-   Examples: File upload, installation status, form completion
+-   Use when tracking advancement toward completion
+
+**Meter**:
+
+-   Displays a **static measurement** within a known range (0-100)
+-   Value can fluctuate up/down based on real-time measurements
+-   Examples: CPU usage, battery level, sound volume
+-   Use when showing current state relative to capacity
+
+If a meter better fits your requirements, check out the [Meter](/docs/components/meter) component.
+
 ## Structure
 
 ```svelte

--- a/docs/content/components/progress.md
+++ b/docs/content/components/progress.md
@@ -4,7 +4,7 @@ description: Visualizes the progress or completion status of a task or process.
 ---
 
 <script>
-	import { APISection, ComponentPreviewV2, ProgressDemo } from '$lib/components/index.js'
+	import { APISection, ComponentPreviewV2, ProgressDemo, ProgressDemoCustom } from '$lib/components/index.js'
 	let { schemas } = $props()
 </script>
 
@@ -43,5 +43,57 @@ If a meter better fits your requirements, check out the [Meter](/docs/components
 
 <Progress.Root />
 ```
+
+## Reusable Components
+
+It's recommended to use the `Progress` primitive to create your own custom meter component that can be used throughout your application. In the example below, we're using the `Progress` primitive to create a more comprehensive meter component.
+
+```svelte
+<script lang="ts">
+	import { Progress, useId } from "bits-ui";
+	import type { ComponentProps } from "svelte";
+
+	let {
+		max = 100,
+		value = 0,
+		min = 0,
+		label,
+		valueLabel,
+	}: ComponentProps<typeof Progress.Root> & {
+		label: string;
+		valueLabel: string;
+	} = $props();
+
+	const labelId = useId();
+</script>
+
+<div>
+	<span id={labelId}> {label} </span>
+	<span>{valueLabel}</span>
+</div>
+<Progress.Root aria-labelledby={labelId} aria-valuetext={valueLabel} {value} {min} {max} />
+```
+
+You can then use the `MyProgress` component in your application like so:
+
+```svelte title="+page.svelte"
+<script lang="ts">
+	import MyProgress from "$lib/components/MyProgress.svelte";
+
+	let value = $state(50);
+</script>
+
+<MyProgress label="Loading images..." valueLabel="{value}%" {value} />
+```
+
+Of course, you'd want to apply your own styles and other customizations to the `MyProgress` component to fit your application's design.
+
+<br>
+
+<ProgressDemoCustom value={50} label="Loading images..." valueLabel="50%" />
+
+## Accessibility
+
+If a visual label is used, the ID of the label element should be pass via the `aria-labelledby` prop to `Progress.Root`. If no visual label is used, the `aria-label` prop should be used to provide a text description of the progress bar.
 
 <APISection {schemas} />

--- a/docs/src/lib/components/demos/index.ts
+++ b/docs/src/lib/components/demos/index.ts
@@ -44,6 +44,7 @@ export { default as PinInputDemo } from "./pin-input-demo.svelte";
 export { default as PopoverDemo } from "./popover-demo.svelte";
 export { default as PopoverDemoTransition } from "./popover-demo-transition.svelte";
 export { default as ProgressDemo } from "./progress-demo.svelte";
+export { default as ProgressDemoCustom } from "./progress-demo-custom.svelte";
 export { default as RadioGroupDemo } from "./radio-group-demo.svelte";
 export { default as RangeCalendarDemo } from "./range-calendar-demo.svelte";
 export { default as ScrollAreaDemo } from "./scroll-area-demo.svelte";

--- a/docs/src/lib/components/demos/index.ts
+++ b/docs/src/lib/components/demos/index.ts
@@ -35,6 +35,8 @@ export { default as SelectDemoCustomAnchor } from "./select-demo-custom-anchor.s
 export { default as SelectDemoMultiple } from "./select-demo-multiple.svelte";
 export { default as SelectDemoTransition } from "./select-demo-transition.svelte";
 export { default as MenubarDemo } from "./menubar-demo.svelte";
+export { default as MeterDemo } from "./meter-demo.svelte";
+export { default as MeterDemoCustom } from "./meter-demo-custom.svelte";
 export { default as NavigationMenuDemo } from "./navigation-menu-demo.svelte";
 export { default as NavigationMenuDemoForceMount } from "./navigation-menu-demo-force-mount.svelte";
 export { default as PaginationDemo } from "./pagination-demo.svelte";

--- a/docs/src/lib/components/demos/meter-demo-custom.svelte
+++ b/docs/src/lib/components/demos/meter-demo-custom.svelte
@@ -1,0 +1,49 @@
+<script lang="ts">
+	import { Meter, useId } from "bits-ui";
+	import type { ComponentProps } from "svelte";
+	import DemoContainer from "../demo-container.svelte";
+
+	let {
+		max = 100,
+		value = 0,
+		min = 0,
+		label,
+		valueLabel,
+	}: ComponentProps<typeof Meter.Root> & {
+		label: string;
+		valueLabel: string;
+	} = $props();
+
+	const labelId = useId();
+
+	const usedPercentage = $derived((value / max) * 100);
+	const percentageRemaining = $derived(100 - usedPercentage);
+	const color = $derived.by(() => {
+		if (percentageRemaining < 15) return "bg-red-500 dark:bg-red-400";
+		if (percentageRemaining < 35) return "bg-orange-500 dark:bg-orange-400";
+		if (percentageRemaining < 50) return "bg-yellow-500 dark:bg-yellow-400";
+		return "bg-green-500 dark:bg-green-400";
+	});
+</script>
+
+<DemoContainer size="xs" wrapperClass="rounded-bl-card rounded-br-card">
+	<div class="flex w-[60%] flex-col gap-2">
+		<div class="flex items-center justify-between text-sm font-medium">
+			<span id={labelId}> {label} </span>
+			<span>{valueLabel}</span>
+		</div>
+		<Meter.Root
+			aria-labelledby={labelId}
+			aria-valuetext={valueLabel}
+			{value}
+			{min}
+			{max}
+			class="bg-dark-10 shadow-mini-inset relative h-[15px] overflow-hidden rounded-full"
+		>
+			<div
+				class="shadow-mini-inset h-full w-full flex-1 rounded-full transition-all duration-1000 ease-in-out {color}"
+				style="transform: translateX(-{100 - (100 * (value ?? 0)) / max}%)"
+			></div>
+		</Meter.Root>
+	</div>
+</DemoContainer>

--- a/docs/src/lib/components/demos/meter-demo.svelte
+++ b/docs/src/lib/components/demos/meter-demo.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
-	import { Meter } from "bits-ui";
+	import { Meter, useId } from "bits-ui";
 
 	let value = $state(2000);
+	const labelId = useId();
 
 	const max = 4000;
 	const min = 0;
@@ -19,11 +20,11 @@
 
 <div class="flex w-[60%] flex-col gap-2">
 	<div class="flex items-center justify-between text-sm font-medium">
-		<span id="fuel-label"> Tokens used </span>
+		<span id={labelId}> Tokens used </span>
 		<span>{value} / {max}</span>
 	</div>
 	<Meter.Root
-		aria-labelledby="fuel-label"
+		aria-labelledby={labelId}
 		aria-valuetext="{value} out of {max}"
 		{value}
 		{min}

--- a/docs/src/lib/components/demos/meter-demo.svelte
+++ b/docs/src/lib/components/demos/meter-demo.svelte
@@ -1,0 +1,38 @@
+<script lang="ts">
+	import { Meter } from "bits-ui";
+
+	let value = $state(2000);
+
+	const max = 4000;
+	const min = 0;
+
+	const usedPercentage = $derived((value / max) * 100);
+	const percentageRemaining = $derived(100 - usedPercentage);
+
+	const color = $derived.by(() => {
+		if (percentageRemaining < 15) return "bg-red-500 dark:bg-red-400";
+		if (percentageRemaining < 35) return "bg-orange-500 dark:bg-orange-400";
+		if (percentageRemaining < 50) return "bg-yellow-500 dark:bg-yellow-400";
+		return "bg-green-500 dark:bg-green-400";
+	});
+</script>
+
+<div class="flex w-[60%] flex-col gap-2">
+	<div class="flex items-center justify-between text-sm font-medium">
+		<span id="fuel-label"> Tokens used </span>
+		<span>{value} / {max}</span>
+	</div>
+	<Meter.Root
+		aria-labelledby="fuel-label"
+		aria-valuetext="{value} out of {max}"
+		{value}
+		{min}
+		{max}
+		class="bg-dark-10 shadow-mini-inset relative h-[15px] overflow-hidden rounded-full"
+	>
+		<div
+			class="shadow-mini-inset h-full w-full flex-1 rounded-full transition-all duration-1000 ease-in-out {color}"
+			style="transform: translateX(-{100 - (100 * (value ?? 0)) / max}%)"
+		></div>
+	</Meter.Root>
+</div>

--- a/docs/src/lib/components/demos/progress-demo-custom.svelte
+++ b/docs/src/lib/components/demos/progress-demo-custom.svelte
@@ -1,0 +1,40 @@
+<script lang="ts">
+	import { Progress, useId } from "bits-ui";
+	import type { ComponentProps } from "svelte";
+	import DemoContainer from "../demo-container.svelte";
+
+	let {
+		max = 100,
+		value = 0,
+		min = 0,
+		label,
+		valueLabel,
+	}: ComponentProps<typeof Progress.Root> & {
+		label: string;
+		valueLabel: string;
+	} = $props();
+
+	const labelId = useId();
+</script>
+
+<DemoContainer size="xs" wrapperClass="rounded-bl-card rounded-br-card">
+	<div class="flex w-[60%] flex-col gap-2">
+		<div class="flex items-center justify-between text-sm font-medium">
+			<span id={labelId}> {label} </span>
+			<span>{valueLabel}</span>
+		</div>
+		<Progress.Root
+			aria-labelledby={labelId}
+			aria-valuetext={valueLabel}
+			{value}
+			{min}
+			{max}
+			class="bg-dark-10 shadow-mini-inset relative h-[15px] overflow-hidden rounded-full"
+		>
+			<div
+				class="bg-foreground shadow-mini-inset h-full w-full flex-1 rounded-full transition-all duration-1000 ease-in-out"
+				style={`transform: translateX(-${100 - (100 * (value ?? 0)) / max}%)`}
+			></div>
+		</Progress.Root>
+	</div>
+</DemoContainer>

--- a/docs/src/lib/components/demos/progress-demo.svelte
+++ b/docs/src/lib/components/demos/progress-demo.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
-	import { Progress } from "bits-ui";
+	import { Progress, useId } from "bits-ui";
 	import { onMount } from "svelte";
 
 	let value = $state(13);
+	const labelId = useId();
 
 	onMount(() => {
 		const timer = setTimeout(() => (value = 66), 500);
@@ -10,13 +11,20 @@
 	});
 </script>
 
-<Progress.Root
-	{value}
-	max={100}
-	class="bg-dark-10 shadow-mini-inset relative h-[15px] w-[60%] overflow-hidden rounded-full"
->
-	<div
-		class="bg-foreground shadow-mini-inset h-full w-full flex-1 rounded-full transition-all duration-1000 ease-in-out"
-		style={`transform: translateX(-${100 - (100 * (value ?? 0)) / 100}%)`}
-	></div>
-</Progress.Root>
+<div class="flex w-[60%] flex-col gap-2">
+	<div class="flex items-center justify-between text-sm font-medium">
+		<span id={labelId}> Uploading file... </span>
+		<span>{value}%</span>
+	</div>
+	<Progress.Root
+		aria-labelledby={labelId}
+		{value}
+		max={100}
+		class="bg-dark-10 shadow-mini-inset relative h-[15px] w-full overflow-hidden rounded-full"
+	>
+		<div
+			class="bg-foreground shadow-mini-inset h-full w-full flex-1 rounded-full transition-all duration-1000 ease-in-out"
+			style={`transform: translateX(-${100 - (100 * (value ?? 0)) / 100}%)`}
+		></div>
+	</Progress.Root>
+</div>

--- a/docs/src/lib/components/index.ts
+++ b/docs/src/lib/components/index.ts
@@ -17,4 +17,5 @@ export { default as Metadata } from "./metadata.svelte";
 export { default as ComponentPreviewV2 } from "./component-preview-v2.svelte";
 export { default as ComponentPreviewMin } from "./component-preview-min.svelte";
 export { default as DemoContainer } from "./demo-container.svelte";
+export { default as DemoCodeContainer } from "./demo-code-container.svelte";
 export { default as Callout } from "./callout.svelte";

--- a/docs/src/lib/content/api-reference/index.ts
+++ b/docs/src/lib/content/api-reference/index.ts
@@ -35,6 +35,7 @@ import { toggle } from "./toggle.api.js";
 import { toolbar } from "./toolbar.api.js";
 import { tooltip } from "./tooltip.api.js";
 import { menubar } from "./menubar.api.js";
+import { meter } from "./meter.api.js";
 import type { APISchema } from "$lib/types/index.js";
 
 export const bits = [
@@ -58,6 +59,7 @@ export const bits = [
 	"label",
 	"link-preview",
 	"menubar",
+	"meter",
 	"navigation-menu",
 	"pagination",
 	"pin-input",
@@ -106,6 +108,7 @@ export const apiSchemas: Record<Bit, APISchema[]> = {
 	label,
 	"link-preview": linkPreview,
 	menubar,
+	meter,
 	"navigation-menu": navigationMenu,
 	pagination,
 	"pin-input": pinInput,

--- a/docs/src/lib/content/api-reference/meter.api.ts
+++ b/docs/src/lib/content/api-reference/meter.api.ts
@@ -1,0 +1,49 @@
+import type { MeterRootPropsWithoutHTML } from "bits-ui";
+import {
+	createApiSchema,
+	createDataAttrSchema,
+	createNumberProp,
+	createPropSchema,
+	withChildProps,
+} from "./helpers.js";
+
+export const root = createApiSchema<MeterRootPropsWithoutHTML>({
+	title: "Root",
+	description: "The meter component.",
+	props: {
+		max: createNumberProp({
+			default: "100",
+			description: "The maximum value of the meter.",
+		}),
+		min: createNumberProp({
+			default: "0",
+			description: "The minimum value of the meter.",
+		}),
+		value: createPropSchema({
+			default: "0",
+			description: "The current value of the meter.",
+			type: "number",
+		}),
+		...withChildProps({ elType: "HTMLDivElement" }),
+	},
+	dataAttributes: [
+		createDataAttrSchema({
+			name: "value",
+			description: "The current value of the meter.",
+		}),
+		createDataAttrSchema({
+			name: "min",
+			description: "The minimum value of the meter.",
+		}),
+		createDataAttrSchema({
+			name: "max",
+			description: "The maximum value of the meter.",
+		}),
+		createDataAttrSchema({
+			name: "meter-root",
+			description: "Present on the root element.",
+		}),
+	],
+});
+
+export const meter = [root];

--- a/packages/bits-ui/src/lib/bits/index.ts
+++ b/packages/bits-ui/src/lib/bits/index.ts
@@ -18,6 +18,7 @@ export { DropdownMenu } from "./dropdown-menu/index.js";
 export { Label } from "./label/index.js";
 export { LinkPreview } from "./link-preview/index.js";
 export { Menubar } from "./menubar/index.js";
+export { Meter } from "./meter/index.js";
 export { NavigationMenu } from "./navigation-menu/index.js";
 export { Pagination } from "./pagination/index.js";
 export { PinInput } from "./pin-input/index.js";

--- a/packages/bits-ui/src/lib/bits/meter/components/meter.svelte
+++ b/packages/bits-ui/src/lib/bits/meter/components/meter.svelte
@@ -1,0 +1,38 @@
+<script lang="ts">
+	import { box, mergeProps } from "svelte-toolbelt";
+	import type { MeterRootProps } from "../types.js";
+	import { useMeterRootState } from "../meter.svelte.js";
+	import { useId } from "$lib/internal/use-id.js";
+
+	let {
+		child,
+		children,
+		value = 0,
+		max = 100,
+		min = 0,
+		id = useId(),
+		ref = $bindable(null),
+		...restProps
+	}: MeterRootProps = $props();
+
+	const rootState = useMeterRootState({
+		value: box.with(() => value),
+		max: box.with(() => max),
+		min: box.with(() => min),
+		id: box.with(() => id),
+		ref: box.with(
+			() => ref,
+			(v) => (ref = v)
+		),
+	});
+
+	const mergedProps = $derived(mergeProps(restProps, rootState.props));
+</script>
+
+{#if child}
+	{@render child({ props: mergedProps })}
+{:else}
+	<div {...mergedProps}>
+		{@render children?.()}
+	</div>
+{/if}

--- a/packages/bits-ui/src/lib/bits/meter/exports.ts
+++ b/packages/bits-ui/src/lib/bits/meter/exports.ts
@@ -1,0 +1,2 @@
+export { default as Root } from "./components/meter.svelte";
+export type { MeterRootProps as RootProps } from "./types.js";

--- a/packages/bits-ui/src/lib/bits/meter/index.ts
+++ b/packages/bits-ui/src/lib/bits/meter/index.ts
@@ -1,0 +1,1 @@
+export * as Meter from "./exports.js";

--- a/packages/bits-ui/src/lib/bits/meter/meter.svelte.ts
+++ b/packages/bits-ui/src/lib/bits/meter/meter.svelte.ts
@@ -20,10 +20,7 @@ class MeterRootState {
 	props = $derived.by(
 		() =>
 			({
-				// from MDN, caniuse, and other sources, it isn't clear that thr `role="meter"` is
-				// fully supported by screen readers. We fallback to 'progressbar' role if meter
-				// isn't supported.
-				role: "meter progressbar",
+				role: "meter",
 				value: this.opts.value.current,
 				"aria-valuemin": this.opts.min.current,
 				"aria-valuemax": this.opts.max.current,

--- a/packages/bits-ui/src/lib/bits/meter/meter.svelte.ts
+++ b/packages/bits-ui/src/lib/bits/meter/meter.svelte.ts
@@ -1,0 +1,41 @@
+import { useRefById } from "svelte-toolbelt";
+import type { ReadableBoxedValues } from "$lib/internal/box.svelte.js";
+import type { WithRefProps } from "$lib/internal/types.js";
+
+const METER_ROOT_ATTR = "data-meter-root";
+
+type MeterRootStateProps = WithRefProps<
+	ReadableBoxedValues<{
+		value: number;
+		max: number;
+		min: number;
+	}>
+>;
+
+class MeterRootState {
+	constructor(readonly opts: MeterRootStateProps) {
+		useRefById(opts);
+	}
+
+	props = $derived.by(
+		() =>
+			({
+				// from MDN, caniuse, and other sources, it isn't clear that thr `role="meter"` is
+				// fully supported by screen readers. We fallback to 'progressbar' role if meter
+				// isn't supported.
+				role: "meter progressbar",
+				value: this.opts.value.current,
+				"aria-valuemin": this.opts.min.current,
+				"aria-valuemax": this.opts.max.current,
+				"aria-valuenow": this.opts.value.current,
+				"data-value": this.opts.value.current,
+				"data-max": this.opts.max.current,
+				"data-min": this.opts.min.current,
+				[METER_ROOT_ATTR]: "",
+			}) as const
+	);
+}
+
+export function useMeterRootState(props: MeterRootStateProps) {
+	return new MeterRootState(props);
+}

--- a/packages/bits-ui/src/lib/bits/meter/types.ts
+++ b/packages/bits-ui/src/lib/bits/meter/types.ts
@@ -1,0 +1,28 @@
+import type { WithChild, Without } from "$lib/internal/types.js";
+import type { BitsPrimitiveDivAttributes } from "$lib/shared/attributes.js";
+
+export type MeterRootPropsWithoutHTML = WithChild<{
+	/**
+	 * The current value of the meter.
+	 *
+	 * @default 0
+	 */
+	value?: number;
+
+	/**
+	 * The maximum value of the meter.
+	 *
+	 * @default 100
+	 */
+	max?: number;
+
+	/**
+	 * The minimum value of the meter.
+	 *
+	 * @default 0
+	 */
+	min?: number;
+}>;
+
+export type MeterRootProps = MeterRootPropsWithoutHTML &
+	Without<BitsPrimitiveDivAttributes, MeterRootPropsWithoutHTML>;

--- a/packages/bits-ui/src/lib/index.ts
+++ b/packages/bits-ui/src/lib/index.ts
@@ -19,6 +19,7 @@ export {
 	Label,
 	LinkPreview,
 	Menubar,
+	Meter,
 	NavigationMenu,
 	Pagination,
 	PinInput,

--- a/packages/bits-ui/src/lib/types.ts
+++ b/packages/bits-ui/src/lib/types.ts
@@ -19,6 +19,7 @@ export type * from "$lib/bits/label/types.js";
 export type * from "$lib/bits/link-preview/types.js";
 export type * from "$lib/bits/select/types.js";
 export type * from "$lib/bits/menubar/types.js";
+export type * from "$lib/bits/meter/types.js";
 export type * from "$lib/bits/navigation-menu/types.js";
 export type * from "$lib/bits/pagination/types.js";
 export type * from "$lib/bits/pin-input/types.js";

--- a/tests/src/tests/meter/meter-test.svelte
+++ b/tests/src/tests/meter/meter-test.svelte
@@ -1,0 +1,10 @@
+<script lang="ts">
+	import { Meter } from "bits-ui";
+
+	let { value = 0, ...restProps }: Meter.RootProps = $props();
+</script>
+
+<main>
+	<Meter.Root aria-label="battery remaining" data-testid="root" {value} {...restProps} />
+	<button data-testid="binding" onclick={() => (value = 50)}>{value}</button>
+</main>

--- a/tests/src/tests/meter/meter.test.ts
+++ b/tests/src/tests/meter/meter.test.ts
@@ -1,0 +1,60 @@
+import { render } from "@testing-library/svelte/svelte5";
+import { userEvent } from "@testing-library/user-event";
+import { axe } from "jest-axe";
+import { it } from "vitest";
+import type { Meter } from "bits-ui";
+import MeterTest from "./meter-test.svelte";
+
+function setup(props: Meter.RootProps = {}) {
+	const user = userEvent.setup();
+	const returned = render(MeterTest, { ...props });
+	const { getByTestId } = returned;
+	const root = getByTestId("root");
+	return { root, user, ...returned };
+}
+
+it("should have no accessibility violations", async () => {
+	const { container } = render(MeterTest);
+	expect(await axe(container)).toHaveNoViolations();
+});
+
+it("should have bits data attrs", async () => {
+	const { root } = setup();
+	expect(root).toHaveAttribute("data-meter-root");
+});
+
+it("should respect the value prop", async () => {
+	const { root } = setup({ value: 50 });
+	expect(root).toHaveAttribute("aria-valuenow", "50");
+});
+
+it("should respect the max prop", async () => {
+	const { root } = setup({ max: 20 });
+	expect(root).toHaveAttribute("aria-valuemax", "20");
+});
+
+it("should respect the min prop", async () => {
+	const { root } = setup({ min: 10 });
+	expect(root).toHaveAttribute("aria-valuemin", "10");
+});
+
+it("should react to updates to the value prop", async () => {
+	const { user, getByTestId } = setup();
+	const root = getByTestId("root");
+	const binding = getByTestId("binding");
+	expect(root).toHaveAttribute("aria-valuenow", "0");
+	expect(binding).toHaveTextContent("0");
+	await user.click(binding);
+	expect(binding).toHaveTextContent("50");
+	expect(root).toHaveAttribute("aria-valuenow", "50");
+});
+
+it("should have a default value of 0", async () => {
+	const { root } = setup();
+	expect(root).toHaveAttribute("aria-valuenow", "0");
+});
+
+it("should have a default max of 100", async () => {
+	const { root } = setup();
+	expect(root).toHaveAttribute("aria-valuemax", "100");
+});

--- a/tests/src/tests/meter/meter.test.ts
+++ b/tests/src/tests/meter/meter.test.ts
@@ -23,6 +23,17 @@ it("should have bits data attrs", async () => {
 	expect(root).toHaveAttribute("data-meter-root");
 });
 
+it("should have role='meter'", async () => {
+	const { root } = setup();
+	expect(root).toHaveAttribute("role", "meter");
+});
+
+it("should forward `aria-labelledby` and `aria-valuetext`", async () => {
+	const { root } = setup({ "aria-labelledby": "label", "aria-valuetext": "value" });
+	expect(root).toHaveAttribute("aria-labelledby", "label");
+	expect(root).toHaveAttribute("aria-valuetext", "value");
+});
+
 it("should respect the value prop", async () => {
 	const { root } = setup({ value: 50 });
 	expect(root).toHaveAttribute("aria-valuenow", "50");

--- a/tests/src/tests/progress/progress.test.ts
+++ b/tests/src/tests/progress/progress.test.ts
@@ -23,6 +23,17 @@ it("should have bits data attrs", async () => {
 	expect(root).toHaveAttribute("data-progress-root");
 });
 
+it("should have role='progressbar'", async () => {
+	const { root } = setup();
+	expect(root).toHaveAttribute("role", "progressbar");
+});
+
+it("should forward `aria-labelledby` and `aria-valuetext`", async () => {
+	const { root } = setup({ "aria-labelledby": "label", "aria-valuetext": "value" });
+	expect(root).toHaveAttribute("aria-labelledby", "label");
+	expect(root).toHaveAttribute("aria-valuetext", "value");
+});
+
 it("should respect the value prop", async () => {
 	const { root } = setup({ value: 50 });
 	expect(root).toHaveAttribute("aria-valuenow", "50");


### PR DESCRIPTION
As discussed in #1183, we currently lack a dedicated `Meter` component. 

This absence can lead to developers incorrectly using the `Progress` component to represent values on a gauge or scale, which is semantically inaccurate and can lead to accessibility issues.  The `Progress` component is intended for indicating the completion status of a process, while `Meter` represents a measured value within a known range.

This PR introduces the missing `Meter` component to the library.

Usage of `Meter` is similar to `Progress`:

```svelte
<script lang="ts">
	import { Meter } from "bits-ui"

	let value = $state(3000);
	const max = 4000
</script>

<Meter.Root {value} {max} aria-label="Remaining tokens" aria-valuetext="{value} out of {max}" />
```