### PR TITLE
fix: `RadioGroup` tabindex calculations

### DIFF
--- a/.changeset/warm-taxis-type.md
+++ b/.changeset/warm-taxis-type.md
@@ -1,0 +1,5 @@
+---
+"bits-ui": patch
+---
+
+fix: issue where `RadioGroup` tabindex wasn't calculated before other focus logic kicks in, causing a value to be unintentionally overwritten

--- a/packages/bits-ui/src/lib/bits/radio-group/radio-group.svelte.ts
+++ b/packages/bits-ui/src/lib/bits/radio-group/radio-group.svelte.ts
@@ -92,6 +92,13 @@ class RadioGroupItemState {
 			ref: this.opts.ref,
 		});
 
+		if (this.opts.value.current === this.root.opts.value.current) {
+			this.root.rovingFocusGroup.setCurrentTabStopId(this.opts.id.current);
+			this.#tabIndex = 0;
+		} else if (!this.root.opts.value.current) {
+			this.#tabIndex = 0;
+		}
+
 		$effect(() => {
 			this.#tabIndex = this.root.rovingFocusGroup.getTabIndex(this.opts.ref.current);
 		});
@@ -121,7 +128,7 @@ class RadioGroupItemState {
 		this.root.rovingFocusGroup.handleKeydown(this.opts.ref.current, e, true);
 	}
 
-	#tabIndex = $state(0);
+	#tabIndex = $state(-1);
 
 	snippetProps = $derived.by(() => ({ checked: this.#isChecked }));
 

--- a/tests/src/tests/radio-group/radio-group-popover-test.svelte
+++ b/tests/src/tests/radio-group/radio-group-popover-test.svelte
@@ -1,0 +1,44 @@
+<script lang="ts" module>
+	import { RadioGroup } from "bits-ui";
+	export type Item = {
+		value: string;
+		disabled: boolean;
+	};
+
+	export type RadioGroupTestProps = Omit<
+		RadioGroup.RootProps,
+		"child" | "children" | "asChild"
+	> & {
+		items: Item[];
+	};
+</script>
+
+<script lang="ts">
+	import { Popover } from "bits-ui";
+
+	let { items, value = "", ...restProps }: RadioGroupTestProps = $props();
+</script>
+
+<main>
+	<Popover.Root>
+		<Popover.Trigger data-testid="trigger">open</Popover.Trigger>
+		<Popover.Content data-testid="content">
+			<RadioGroup.Root data-testid="root" bind:value {...restProps}>
+				{#each items as { value, disabled }}
+					<RadioGroup.Item id={value} {value} {disabled} data-testid="{value}-item">
+						{#snippet children({ checked })}
+							<span data-testid="{value}-indicator"> {checked} </span>
+							{value}
+						{/snippet}
+					</RadioGroup.Item>
+					<label for={value} data-testid="{value}-label">
+						Label for {value}
+					</label>
+				{/each}
+			</RadioGroup.Root>
+		</Popover.Content>
+	</Popover.Root>
+	<div data-testid="value">
+		{value}
+	</div>
+</main>

--- a/tests/src/tests/radio-group/radio-group.test.ts
+++ b/tests/src/tests/radio-group/radio-group.test.ts
@@ -1,10 +1,11 @@
-import { render } from "@testing-library/svelte/svelte5";
+import { render, waitFor } from "@testing-library/svelte/svelte5";
 import { userEvent } from "@testing-library/user-event";
 import { axe } from "jest-axe";
 import { it } from "vitest";
-import { getTestKbd } from "../utils.js";
+import { getTestKbd, setupUserEvents } from "../utils.js";
 import RadioGroupTest from "./radio-group-test.svelte";
 import type { Item, RadioGroupTestProps } from "./radio-group-test.svelte";
+import RadioGroupPopoverTest from "./radio-group-popover-test.svelte";
 
 const kbd = getTestKbd();
 
@@ -250,4 +251,20 @@ it("should change the value when a label associated with an item is clicked", as
 
 	await user.click(label);
 	expect(getByTestId(indicatorIds[itemIdx] as string)).toHaveTextContent("true");
+});
+
+it("should not change value when a value is set and an onOpenAutoFocus occurs", async () => {
+	const user = setupUserEvents();
+	const { getByTestId, queryByTestId } = render(RadioGroupPopoverTest, {
+		value: "b",
+		items: testItems,
+	});
+
+	await user.pointerDownUp(getByTestId("trigger"));
+	await waitFor(() => expect(queryByTestId("content")).not.toBeNull());
+
+	expect(getByTestId("value")).toHaveTextContent("b");
+
+	const item1 = getByTestId(`${testItems[1]?.value}-item`);
+	expect(item1).toHaveFocus();
 });


### PR DESCRIPTION
Closes #1198 

We now check if a value is set on the root and compare that to determine the `RadioGroup.Item`'s `tabindex` before it is computed within an `$effect`. The delay in computation caused focus to accidentally be set to the first radio item, due to the default `tabindex` being `0`.