### PR TITLE
fix: `Popover.Trigger` incorrectly receiving focus-visible  

### DIFF
--- a/.changeset/four-plums-invite.md
+++ b/.changeset/four-plums-invite.md
@@ -1,0 +1,5 @@
+---
+"bits-ui": patch
+---
+
+fix: `Popover.Trigger` receiving focusable when closed with outside click

--- a/packages/bits-ui/src/lib/bits/popover/popover.svelte.ts
+++ b/packages/bits-ui/src/lib/bits/popover/popover.svelte.ts
@@ -46,7 +46,6 @@ class PopoverTriggerState {
 		});
 
 		this.onclick = this.onclick.bind(this);
-		this.onpointerdown = this.onpointerdown.bind(this);
 		this.onkeydown = this.onkeydown.bind(this);
 	}
 
@@ -54,14 +53,6 @@ class PopoverTriggerState {
 		if (this.opts.disabled.current) return;
 		if (e.button !== 0) return;
 		this.root.toggleOpen();
-	}
-
-	onpointerdown(e: BitsPointerEvent) {
-		if (this.opts.disabled.current) return;
-		if (e.button !== 0) return;
-		// We prevent default to prevent focus from moving to the trigger
-		// since this action will open the popover and focus will move to the content
-		e.preventDefault();
 	}
 
 	onkeydown(e: BitsKeyboardEvent) {
@@ -89,7 +80,6 @@ class PopoverTriggerState {
 				"data-popover-trigger": "",
 				disabled: this.opts.disabled.current,
 				//
-				onpointerdown: this.onpointerdown,
 				onkeydown: this.onkeydown,
 				onclick: this.onclick,
 			}) as const


### PR DESCRIPTION
Fixes #1213 