### PR TITLE
docs: fix a snippet conflict in `DatePicker`'s structure

### DIFF
--- a/docs/content/components/date-picker.md
+++ b/docs/content/components/date-picker.md
@@ -38,8 +38,8 @@ Before diving into this component, it's important to understand how dates/times 
 					{value}
 				</DatePicker.Segment>
 			{/each}
+			<DatePicker.Trigger />
 		{/snippet}
-		<DatePicker.Trigger />
 	</DatePicker.Input>
 	<DatePicker.Content>
 		<DatePicker.Calendar>


### PR DESCRIPTION
Fixes a [snippet conflict](https://svelte.dev/docs/svelte/compiler-errors#snippet_conflict) error that appears when pasting in the structure