### PR TITLE
fix: expose `customAnchor` type for `Tooltip.Content` props

### DIFF
--- a/.changeset/mighty-windows-appear.md
+++ b/.changeset/mighty-windows-appear.md
@@ -1,0 +1,5 @@
+---
+"bits-ui": patch
+---
+
+fix: expose `customAnchor` type for `Tooltip.Content` props

--- a/docs/content/components/tooltip.md
+++ b/docs/content/components/tooltip.md
@@ -4,7 +4,7 @@ description: Provides additional information or context when users hover over or
 ---
 
 <script>
-	import { ComponentPreviewV2, TooltipDemo, TooltipDemoCustom, TooltipDemoDelayDuration, TooltipDemoTransition, APISection, Callout } from '$lib/components'
+	import { ComponentPreviewV2, TooltipDemo, TooltipDemoCustom, TooltipDemoCustomAnchor, TooltipDemoDelayDuration, TooltipDemoTransition, APISection, Callout } from '$lib/components'
 	let { schemas } = $props()
 </script>
 
@@ -306,7 +306,7 @@ By default, the `Tooltip.Content` is anchored to the `Tooltip.Trigger` component
 
 If you wish to instead anchor the content to a different element, you can pass either a selector `string` or an `HTMLElement` to the `customAnchor` prop of the `Tooltip.Content` component.
 
-```svelte
+```svelte /customAnchor/
 <script lang="ts">
 	import { Tooltip } from "bits-ui";
 	let customAnchor = $state<HTMLElement>(null!);
@@ -321,5 +321,13 @@ If you wish to instead anchor the content to a different element, you can pass e
 	</Tooltip.Content>
 </Tooltip.Root>
 ```
+
+<ComponentPreviewV2 name="tooltip-demo-custom-anchor" componentName="Tooltip Custom Anchor">
+
+{#snippet preview()}
+<TooltipDemoCustomAnchor />
+{/snippet}
+
+</ComponentPreviewV2>
 
 <APISection {schemas} />

--- a/docs/src/lib/components/demos/index.ts
+++ b/docs/src/lib/components/demos/index.ts
@@ -65,6 +65,7 @@ export { default as ToggleGroupDemo } from "./toggle-group-demo.svelte";
 export { default as ToolbarDemo } from "./toolbar-demo.svelte";
 export { default as TooltipDemo } from "./tooltip-demo.svelte";
 export { default as TooltipDemoCustom } from "./tooltip-demo-custom.svelte";
+export { default as TooltipDemoCustomAnchor } from "./tooltip-demo-custom-anchor.svelte";
 export { default as TooltipDemoDelayDuration } from "./tooltip-demo-delay-duration.svelte";
 export { default as TooltipDemoTransition } from "./tooltip-demo-transition.svelte";
 export { default as DateFieldDemoCustom } from "./date-field-demo-custom.svelte";

--- a/docs/src/lib/components/demos/tooltip-demo-custom-anchor.svelte
+++ b/docs/src/lib/components/demos/tooltip-demo-custom-anchor.svelte
@@ -1,0 +1,27 @@
+<script lang="ts">
+	import { Tooltip } from "bits-ui";
+	import MagicWand from "phosphor-svelte/lib/MagicWand";
+
+	let customAnchor = $state<HTMLElement | null>(null);
+</script>
+
+<div class="flex items-center gap-6">
+	<div class="rounded-md border p-3" bind:this={customAnchor}>Custom Anchor</div>
+	<Tooltip.Provider>
+		<Tooltip.Root delayDuration={200}>
+			<Tooltip.Trigger
+				class="border-border-input bg-background-alt shadow-btn ring-dark ring-offset-background
+			hover:bg-muted focus-visible:ring-dark focus-visible:ring-offset-background focus-visible:outline-hidden inline-flex size-10 items-center justify-center rounded-full border focus-visible:ring-2 focus-visible:ring-offset-2"
+			>
+				<MagicWand class="size-5" />
+			</Tooltip.Trigger>
+			<Tooltip.Content sideOffset={8} {customAnchor}>
+				<div
+					class="rounded-input border-dark-10 bg-background shadow-popover outline-hidden z-0 flex items-center justify-center border p-3 text-sm font-medium"
+				>
+					Make some magic!
+				</div>
+			</Tooltip.Content>
+		</Tooltip.Root>
+	</Tooltip.Provider>
+</div>

--- a/packages/bits-ui/src/lib/bits/tooltip/types.ts
+++ b/packages/bits-ui/src/lib/bits/tooltip/types.ts
@@ -130,6 +130,7 @@ export type TooltipContentPropsWithoutHTML = WithChildNoChildrenSnippetProps<
 		| "hideWhenDetached"
 		| "updatePositionStrategy"
 		| "dir"
+		| "customAnchor"
 	> &
 		Omit<DismissibleLayerProps, "onInteractOutsideStart"> &
 		EscapeLayerProps & {

--- a/tests/src/tests/tooltip/tooltip-test.svelte
+++ b/tests/src/tests/tooltip/tooltip-test.svelte
@@ -4,11 +4,20 @@
 	export type TooltipTestProps = WithoutChildrenOrChild<Tooltip.RootProps> & {
 		contentProps?: WithoutChildrenOrChild<Tooltip.ContentProps>;
 		portalProps?: WithoutChildrenOrChild<Tooltip.PortalProps>;
+		withCustomAnchor?: boolean;
 	};
 </script>
 
 <script lang="ts">
-	let { open = false, portalProps, contentProps, ...restProps }: TooltipTestProps = $props();
+	let {
+		open = false,
+		portalProps,
+		contentProps,
+		withCustomAnchor = false,
+		...restProps
+	}: TooltipTestProps = $props();
+
+	let customAnchor = $state<HTMLElement | null>(null);
 </script>
 
 <main data-testid="main">
@@ -16,7 +25,11 @@
 		<Tooltip.Root bind:open {...restProps}>
 			<Tooltip.Trigger data-testid="trigger">@sveltejs</Tooltip.Trigger>
 			<Tooltip.Portal {...portalProps}>
-				<Tooltip.Content {...contentProps} data-testid="content" class="w-80">
+				<Tooltip.Content
+					{...contentProps}
+					customAnchor={withCustomAnchor ? customAnchor : undefined}
+					data-testid="content"
+				>
 					Content
 				</Tooltip.Content>
 			</Tooltip.Portal>
@@ -25,5 +38,6 @@
 	<button data-testid="binding" onclick={() => (open = !open)}>{open}</button>
 	<div class="h-96"></div>
 	<div data-testid="outside" class="">outside</div>
+	<div data-testid="custom-anchor" bind:this={customAnchor}>Content</div>
 </main>
 <div data-testid="portal-target" id="portal-target"></div>

--- a/tests/src/tests/tooltip/tooltip.test.ts
+++ b/tests/src/tests/tooltip/tooltip.test.ts
@@ -1,6 +1,6 @@
 import { render, waitFor } from "@testing-library/svelte/svelte5";
 import { axe } from "jest-axe";
-import { describe, it } from "vitest";
+import { it } from "vitest";
 import type { Component } from "svelte";
 import { getTestKbd, setupUserEvents, sleep } from "../utils.js";
 import TooltipTest, { type TooltipTestProps } from "./tooltip-test.svelte";
@@ -28,131 +28,136 @@ async function open(props: Partial<TooltipTestProps> = {}) {
 	return { ...returned, content };
 }
 
-describe("tooltip", () => {
-	it("should have no accessibility violations", async () => {
-		const { container } = setup();
-		expect(await axe(container)).toHaveNoViolations();
+it("should have no accessibility violations", async () => {
+	const { container } = setup();
+	expect(await axe(container)).toHaveNoViolations();
+});
+
+it("should have bits data attrs", async () => {
+	const { getByTestId } = await open();
+	const parts = ["trigger", "content"];
+
+	for (const part of parts) {
+		const el = getByTestId(part);
+		expect(el).toHaveAttribute(`data-tooltip-${part}`);
+	}
+});
+
+it("should use provider delay duration if provided and the tooltip.root did not provide one", async () => {
+	const { trigger } = setup();
+	expect(trigger).toHaveAttribute("data-delay-duration", "0");
+});
+
+it("should on hover", async () => {
+	const { user, content } = await open();
+	await user.click(content);
+	expect(content).toBeVisible();
+});
+
+it("should close on escape keydown", async () => {
+	const { user, queryByTestId } = await open();
+	await user.keyboard(kbd.ESCAPE);
+	expect(queryByTestId("content")).toBeNull();
+});
+
+it.skip("should close when pointer moves outside the trigger and content", async () => {
+	const { user, getByTestId, queryByTestId, content } = await open();
+
+	const outside = getByTestId("outside") as HTMLElement;
+
+	await user.pointer([
+		// touch the screen at element1
+		{ keys: "[TouchA>]", target: content },
+		// move the touch pointer to element2
+		{ pointerName: "TouchA", target: outside },
+		// release the touch pointer at the last position (element2)
+		{ keys: "[/TouchA]" },
+	]);
+	await sleep(200);
+	await waitFor(() => expect(queryByTestId("content")).toBeNull());
+});
+
+it("should portal to the body by default", async () => {
+	const { content } = await open();
+	const contentWrapper = content.parentElement;
+	expect(contentWrapper?.parentElement).toBe(document.body);
+});
+
+it("should portal to a custom element if specified", async () => {
+	const { content, getByTestId } = await open({ portalProps: { to: "#portal-target" } });
+	const portalTarget = getByTestId("portal-target");
+	const contentWrapper = content.parentElement;
+	expect(contentWrapper?.parentElement).toBe(portalTarget);
+});
+
+it("should not portal if `disabled` is passed to the portal", async () => {
+	const { content, getByTestId } = await open({ portalProps: { disabled: true } });
+	const main = getByTestId("main");
+	const contentWrapper = content.parentElement;
+	expect(contentWrapper?.parentElement).toBe(main);
+});
+
+it("should allow ignoring escapeKeydownBehavior ", async () => {
+	const { content, user, queryByTestId } = await open({
+		contentProps: {
+			escapeKeydownBehavior: "ignore",
+		},
 	});
+	await user.click(content);
+	await user.keyboard(kbd.ESCAPE);
+	expect(queryByTestId("content")).not.toBeNull();
+});
 
-	it("should have bits data attrs", async () => {
-		const { getByTestId } = await open();
-		const parts = ["trigger", "content"];
-
-		for (const part of parts) {
-			const el = getByTestId(part);
-			expect(el).toHaveAttribute(`data-tooltip-${part}`);
-		}
+it("should allow ignoring interactOutsideBehavior", async () => {
+	const { content, user, queryByTestId, getByTestId } = await open({
+		contentProps: {
+			interactOutsideBehavior: "ignore",
+		},
 	});
+	await user.click(content);
+	const outside = getByTestId("outside");
+	await user.click(outside);
+	expect(queryByTestId("content")).not.toBeNull();
+});
 
-	it("should use provider delay duration if provided and the tooltip.root did not provide one", async () => {
-		const { trigger } = setup();
-		expect(trigger).toHaveAttribute("data-delay-duration", "0");
+it("should respect binding the open prop", async () => {
+	const { queryByTestId, getByTestId, user } = await open({
+		contentProps: {
+			interactOutsideBehavior: "ignore",
+		},
 	});
+	const binding = getByTestId("binding");
+	await waitFor(() => expect(binding).toHaveTextContent("true"));
+	await user.click(binding);
+	await waitFor(() => expect(binding).toHaveTextContent("false"));
+	expect(queryByTestId("content")).toBeNull();
+	await user.click(binding);
+	await waitFor(() => expect(binding).toHaveTextContent("true"));
+	expect(queryByTestId("content")).not.toBeNull();
+});
 
-	it("should on hover", async () => {
-		const { user, content } = await open();
-		await user.click(content);
-		expect(content).toBeVisible();
-	});
+it("should forceMount the content when `forceMount` is true", async () => {
+	const { getByTestId } = setup({}, TooltipForceMountTest);
 
-	it("should close on escape keydown", async () => {
-		const { user, queryByTestId } = await open();
-		await user.keyboard(kbd.ESCAPE);
-		expect(queryByTestId("content")).toBeNull();
-	});
+	const content = getByTestId("content");
+	expect(content).toBeVisible();
+});
 
-	it.skip("should close when pointer moves outside the trigger and content", async () => {
-		const { user, getByTestId, queryByTestId, content } = await open();
+it("should forceMount the content when `forceMount` is true and the `open` snippet prop is used to conditionally render the content", async () => {
+	const { queryByTestId, getByTestId, user, trigger } = setup(
+		{ withOpenCheck: true },
+		TooltipForceMountTest
+	);
+	expect(queryByTestId("content")).toBeNull();
+	await user.hover(trigger);
+	await waitFor(() => expect(queryByTestId("content")).not.toBeNull());
+	const content = getByTestId("content");
+	expect(content).toBeVisible();
+});
 
-		const outside = getByTestId("outside") as HTMLElement;
-
-		await user.pointer([
-			// touch the screen at element1
-			{ keys: "[TouchA>]", target: content },
-			// move the touch pointer to element2
-			{ pointerName: "TouchA", target: outside },
-			// release the touch pointer at the last position (element2)
-			{ keys: "[/TouchA]" },
-		]);
-		await sleep(200);
-		await waitFor(() => expect(queryByTestId("content")).toBeNull());
-	});
-
-	it("should portal to the body by default", async () => {
-		const { content } = await open();
-		const contentWrapper = content.parentElement;
-		expect(contentWrapper?.parentElement).toBe(document.body);
-	});
-
-	it("should portal to a custom element if specified", async () => {
-		const { content, getByTestId } = await open({ portalProps: { to: "#portal-target" } });
-		const portalTarget = getByTestId("portal-target");
-		const contentWrapper = content.parentElement;
-		expect(contentWrapper?.parentElement).toBe(portalTarget);
-	});
-
-	it("should not portal if `disabled` is passed to the portal", async () => {
-		const { content, getByTestId } = await open({ portalProps: { disabled: true } });
-		const main = getByTestId("main");
-		const contentWrapper = content.parentElement;
-		expect(contentWrapper?.parentElement).toBe(main);
-	});
-
-	it("should allow ignoring escapeKeydownBehavior ", async () => {
-		const { content, user, queryByTestId } = await open({
-			contentProps: {
-				escapeKeydownBehavior: "ignore",
-			},
-		});
-		await user.click(content);
-		await user.keyboard(kbd.ESCAPE);
-		expect(queryByTestId("content")).not.toBeNull();
-	});
-
-	it("should allow ignoring interactOutsideBehavior", async () => {
-		const { content, user, queryByTestId, getByTestId } = await open({
-			contentProps: {
-				interactOutsideBehavior: "ignore",
-			},
-		});
-		await user.click(content);
-		const outside = getByTestId("outside");
-		await user.click(outside);
-		expect(queryByTestId("content")).not.toBeNull();
-	});
-
-	it("should respect binding the open prop", async () => {
-		const { queryByTestId, getByTestId, user } = await open({
-			contentProps: {
-				interactOutsideBehavior: "ignore",
-			},
-		});
-		const binding = getByTestId("binding");
-		await waitFor(() => expect(binding).toHaveTextContent("true"));
-		await user.click(binding);
-		await waitFor(() => expect(binding).toHaveTextContent("false"));
-		expect(queryByTestId("content")).toBeNull();
-		await user.click(binding);
-		await waitFor(() => expect(binding).toHaveTextContent("true"));
-		expect(queryByTestId("content")).not.toBeNull();
-	});
-
-	it("should forceMount the content when `forceMount` is true", async () => {
-		const { getByTestId } = setup({}, TooltipForceMountTest);
-
-		const content = getByTestId("content");
-		expect(content).toBeVisible();
-	});
-
-	it("should forceMount the content when `forceMount` is true and the `open` snippet prop is used to conditionally render the content", async () => {
-		const { queryByTestId, getByTestId, user, trigger } = setup(
-			{ withOpenCheck: true },
-			TooltipForceMountTest
-		);
-		expect(queryByTestId("content")).toBeNull();
-		await user.hover(trigger);
-		await waitFor(() => expect(queryByTestId("content")).not.toBeNull());
-		const content = getByTestId("content");
-		expect(content).toBeVisible();
-	});
+it("should use the custom anchor element when `customAnchor` is provided", async () => {
+	// type check
+	const { trigger, user, queryByTestId } = setup();
+	await user.hover(trigger);
+	await waitFor(() => expect(queryByTestId("content")).not.toBeNull());
 });

--- a/tests/src/tests/utils.ts
+++ b/tests/src/tests/utils.ts
@@ -87,17 +87,17 @@ export function setupUserEvents(): CustomUserEvents {
 
 	const click = async (element: HTMLElement) => {
 		await originalClick(element);
-		await sleep(10);
+		await sleep(20);
 	};
 
 	const keyboard = async (keys: string) => {
 		await originalKeyboard(keys);
-		await sleep(10);
+		await sleep(20);
 	};
 
 	const pointer: typeof originalPointer = async (input) => {
 		await originalPointer(input);
-		await sleep(10);
+		await sleep(20);
 	};
 
 	const pointerDownUp = async (target: HTMLElement | null) => {
@@ -105,7 +105,7 @@ export function setupUserEvents(): CustomUserEvents {
 		await fireEvent.pointerDown(target);
 		await fireEvent.pointerUp(target);
 		await fireEvent.click(target);
-		await sleep(10);
+		await sleep(20);
 	};
 
 	Object.assign(user, { click, keyboard, pointer, pointerDownUp });

--- a/tests/src/tests/utils.ts
+++ b/tests/src/tests/utils.ts
@@ -87,17 +87,17 @@ export function setupUserEvents(): CustomUserEvents {
 
 	const click = async (element: HTMLElement) => {
 		await originalClick(element);
-		await sleep(20);
+		await sleep(10);
 	};
 
 	const keyboard = async (keys: string) => {
 		await originalKeyboard(keys);
-		await sleep(20);
+		await sleep(10);
 	};
 
 	const pointer: typeof originalPointer = async (input) => {
 		await originalPointer(input);
-		await sleep(20);
+		await sleep(10);
 	};
 
 	const pointerDownUp = async (target: HTMLElement | null) => {
@@ -105,7 +105,7 @@ export function setupUserEvents(): CustomUserEvents {
 		await fireEvent.pointerDown(target);
 		await fireEvent.pointerUp(target);
 		await fireEvent.click(target);
-		await sleep(20);
+		await sleep(10);
 	};
 
 	Object.assign(user, { click, keyboard, pointer, pointerDownUp });


### PR DESCRIPTION
Fixes #1279 