### PR TITLE
feat: Tags Input

### DIFF
--- a/docs/src/lib/components/demos/tags-input-demo-contenteditable.svelte
+++ b/docs/src/lib/components/demos/tags-input-demo-contenteditable.svelte
@@ -31,7 +31,6 @@
 			<TagsInput.Input
 				class="focus-override bg-transparent focus:outline-none focus:ring-0 "
 				placeholder="Add a tag..."
-				aria-label="Add a tag"
 				blurBehavior="add"
 			/>
 		</div>

--- a/docs/src/lib/components/demos/tags-input-demo-contenteditable.svelte
+++ b/docs/src/lib/components/demos/tags-input-demo-contenteditable.svelte
@@ -1,0 +1,44 @@
+<script lang="ts">
+	import { TagsInput } from "bits-ui";
+	import X from "phosphor-svelte/lib/X";
+
+	let value = $state<string[]>(["hello", "world"]);
+</script>
+
+<div class="flex items-center justify-center">
+	<TagsInput.Root bind:value class="flex flex-col gap-2" delimiters={[","]}>
+		<div
+			class="rounded-card-sm border-border-input bg-background placeholder:text-foreground-alt/50 focus-within:ring-foreground focus-within:ring-offset-background hover:border-dark-40 [&:has([data-invalid])]:border-destructive flex h-auto w-[400px] flex-col gap-4 border p-4 text-sm focus-within:outline-none focus-within:ring-2 focus-within:ring-offset-2"
+		>
+			<TagsInput.List class="flex min-h-5 flex-wrap gap-1.5">
+				{#each value as tag, index}
+					<TagsInput.Tag value={tag} {index} editMode="contenteditable">
+						<TagsInput.TagContent
+							class="flex items-center gap-3  rounded-[4px] bg-[#FCDAFE] text-[0.7rem] font-semibold leading-none text-[#2A266B] no-underline group-hover:no-underline"
+						>
+							<TagsInput.TagText class="w-full py-1 pl-1.5">
+								{tag}
+							</TagsInput.TagText>
+							<TagsInput.TagRemove
+								class="flex items-center justify-center rounded-r-[4px] border-l border-l-pink-300/50 px-1 py-1 hover:bg-[#edc6f0]"
+							>
+								<X class="size-3" />
+							</TagsInput.TagRemove>
+						</TagsInput.TagContent>
+					</TagsInput.Tag>
+				{/each}
+			</TagsInput.List>
+			<TagsInput.Input
+				class="focus-override bg-transparent focus:outline-none focus:ring-0 "
+				placeholder="Add a tag..."
+				aria-label="Add a tag"
+				blurBehavior="add"
+			/>
+		</div>
+		<TagsInput.Clear
+			class="h-input rounded-input bg-muted shadow-mini hover:bg-dark-10 focus-visible:ring-foreground focus-visible:ring-offset-background active:scale-98 inline-flex w-full items-center justify-center text-[15px] font-medium transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2"
+		>
+			Clear Tags
+		</TagsInput.Clear>
+	</TagsInput.Root>
+</div>

--- a/docs/src/lib/components/demos/tags-input-demo.svelte
+++ b/docs/src/lib/components/demos/tags-input-demo.svelte
@@ -1,0 +1,47 @@
+<script lang="ts">
+	import { TagsInput } from "bits-ui";
+	import X from "phosphor-svelte/lib/X";
+
+	let value = $state<string[]>(["hello", "world"]);
+</script>
+
+<div class="flex items-center justify-center">
+	<TagsInput.Root bind:value class="flex flex-col gap-2" delimiters={[","]}>
+		<div
+			class="rounded-card-sm border-border-input bg-background placeholder:text-foreground-alt/50 focus-within:ring-foreground focus-within:ring-offset-background hover:border-dark-40 [&:has([data-invalid])]:border-destructive flex h-auto w-[400px] flex-col gap-4 border p-4 text-sm focus-within:outline-none focus-within:ring-2 focus-within:ring-offset-2"
+		>
+			<TagsInput.List class="flex min-h-5 flex-wrap gap-1.5">
+				{#each value as tag, index}
+					<TagsInput.Tag value={tag} {index}>
+						<TagsInput.TagContent
+							class="flex items-center gap-3 rounded-[4px] bg-[#FCDAFE] text-[0.7rem] font-semibold leading-none text-[#2A266B] no-underline group-hover:no-underline"
+						>
+							<TagsInput.TagText class="w-full py-1 pl-1.5">
+								{tag}
+							</TagsInput.TagText>
+							<TagsInput.TagRemove
+								class="flex items-center justify-center rounded-r-[4px] border-l border-l-pink-300/50 px-1 py-1 hover:bg-[#edc6f0]"
+							>
+								<X class="size-3" />
+							</TagsInput.TagRemove>
+						</TagsInput.TagContent>
+						<TagsInput.TagEditInput
+							class="border-border-input bg-background placeholder:text-foreground-alt/50 hover:border-dark-40 focus:ring-foreground focus:ring-offset-background inline-flex h-5 w-auto items-center rounded-sm border px-2 text-sm focus:outline-none focus:ring-2 focus:ring-offset-2"
+						/>
+					</TagsInput.Tag>
+				{/each}
+			</TagsInput.List>
+			<TagsInput.Input
+				class="focus-override bg-transparent focus:outline-none focus:ring-0 "
+				placeholder="Add a tag..."
+				aria-label="Add a tag"
+				blurBehavior="add"
+			/>
+		</div>
+		<TagsInput.Clear
+			class="h-input rounded-input bg-muted shadow-mini hover:bg-dark-10 focus-visible:ring-foreground focus-visible:ring-offset-background active:scale-98 inline-flex w-full items-center justify-center text-[15px] font-medium transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2"
+		>
+			Clear Tags
+		</TagsInput.Clear>
+	</TagsInput.Root>
+</div>

--- a/docs/src/lib/components/demos/tags-input-demo.svelte
+++ b/docs/src/lib/components/demos/tags-input-demo.svelte
@@ -12,7 +12,7 @@
 		>
 			<TagsInput.List class="flex min-h-5 flex-wrap gap-1.5">
 				{#each value as tag, index}
-					<TagsInput.Tag value={tag} {index}>
+					<TagsInput.Tag value={tag} {index} editMode="input">
 						<TagsInput.TagContent
 							class="flex items-center gap-3 rounded-[4px] bg-[#FCDAFE] text-[0.7rem] font-semibold leading-none text-[#2A266B] no-underline group-hover:no-underline"
 						>
@@ -34,7 +34,6 @@
 			<TagsInput.Input
 				class="focus-override bg-transparent focus:outline-none focus:ring-0 "
 				placeholder="Add a tag..."
-				aria-label="Add a tag"
 				blurBehavior="add"
 			/>
 		</div>

--- a/docs/src/routes/(main)/sink/+page.svelte
+++ b/docs/src/routes/(main)/sink/+page.svelte
@@ -1,10 +1,14 @@
 <script lang="ts">
 	import DemoContainer from "$lib/components/demo-container.svelte";
-	import CalendarDemoPresets from "$lib/components/demos/calendar-demo-presets.svelte";
+	import TagsInputDemoContenteditable from "$lib/components/demos/tags-input-demo-contenteditable.svelte";
+	import TagsInputDemo from "$lib/components/demos/tags-input-demo.svelte";
 </script>
 
 <div class="w-full max-w-[756px]">
 	<DemoContainer>
-		<CalendarDemoPresets />
+		<TagsInputDemo />
+	</DemoContainer>
+	<DemoContainer>
+		<TagsInputDemoContenteditable />
 	</DemoContainer>
 </div>

--- a/packages/bits-ui/src/lib/bits/index.ts
+++ b/packages/bits-ui/src/lib/bits/index.ts
@@ -32,6 +32,7 @@ export { Separator } from "./separator/index.js";
 export { Slider } from "./slider/index.js";
 export { Switch } from "./switch/index.js";
 export { Tabs } from "./tabs/index.js";
+export { TagsInput } from "./tags-input/index.js";
 export { Toggle } from "./toggle/index.js";
 export { ToggleGroup } from "./toggle-group/index.js";
 export { Toolbar } from "./toolbar/index.js";

--- a/packages/bits-ui/src/lib/bits/tags-input/components/tags-input-announcer.svelte
+++ b/packages/bits-ui/src/lib/bits/tags-input/components/tags-input-announcer.svelte
@@ -1,0 +1,34 @@
+<script lang="ts">
+	import { box } from "svelte-toolbelt";
+	import { useTagsInputAnnouncer } from "../tags-input.svelte.js";
+	import { useId } from "$lib/internal/use-id.js";
+	import {
+		type BitsPrimitiveDivAttributes,
+		type WithChild,
+		type Without,
+		mergeProps,
+	} from "$lib/shared/index.js";
+	import Portal from "$lib/bits/utilities/portal/portal.svelte";
+
+	type Props = WithChild & Without<BitsPrimitiveDivAttributes, WithChild>;
+
+	let { id = useId(), ref = $bindable(null) }: Props = $props();
+
+	const announcerState = useTagsInputAnnouncer({
+		id: box.with(() => id),
+		ref: box.with(
+			() => ref,
+			(v) => (ref = v)
+		),
+	});
+
+	const mergedProps = $derived(mergeProps(announcerState.props));
+</script>
+
+<Portal>
+	<div {...mergedProps}>
+		{#if announcerState.root.message}
+			{announcerState.root.message}
+		{/if}
+	</div>
+</Portal>

--- a/packages/bits-ui/src/lib/bits/tags-input/components/tags-input-clear.svelte
+++ b/packages/bits-ui/src/lib/bits/tags-input/components/tags-input-clear.svelte
@@ -1,0 +1,32 @@
+<script lang="ts">
+	import { box, mergeProps } from "svelte-toolbelt";
+	import type { TagsInputClearProps } from "../types.js";
+	import { useTagsInputClear } from "../tags-input.svelte.js";
+	import { useId } from "$lib/internal/use-id.js";
+
+	let {
+		id = useId(),
+		ref = $bindable(null),
+		children,
+		child,
+		...restProps
+	}: TagsInputClearProps = $props();
+
+	const clearState = useTagsInputClear({
+		id: box.with(() => id),
+		ref: box.with(
+			() => ref,
+			(v) => (ref = v)
+		),
+	});
+
+	const mergedProps = $derived(mergeProps(restProps, clearState.props));
+</script>
+
+{#if child}
+	{@render child({ props: mergedProps })}
+{:else}
+	<button {...mergedProps}>
+		{@render children?.()}
+	</button>
+{/if}

--- a/packages/bits-ui/src/lib/bits/tags-input/components/tags-input-input.svelte
+++ b/packages/bits-ui/src/lib/bits/tags-input/components/tags-input-input.svelte
@@ -1,0 +1,50 @@
+<script lang="ts">
+	import { box, mergeProps } from "svelte-toolbelt";
+	import type { TagsInputInputProps } from "../types.js";
+	import { useTagsInputInput } from "../tags-input.svelte.js";
+	import { useId } from "$lib/internal/use-id.js";
+	import { noop } from "$lib/internal/noop.js";
+
+	let {
+		id = useId(),
+		ref = $bindable(null),
+		value = $bindable(""),
+		controlledValue = false,
+		onValueChange = noop,
+		child,
+		blurBehavior = "none",
+		pasteBehavior = "add",
+		...restProps
+	}: TagsInputInputProps = $props();
+
+	const inputState = useTagsInputInput({
+		id: box.with(() => id),
+		ref: box.with(
+			() => ref,
+			(v) => (ref = v)
+		),
+		value: box.with(
+			() => value,
+			(v) => {
+				if (controlledValue) {
+					onValueChange(v);
+				} else {
+					value = v;
+					onValueChange(v);
+				}
+			}
+		),
+		blurBehavior: box.with(() => blurBehavior),
+		pasteBehavior: box.with(() => pasteBehavior),
+	});
+
+	const mergedProps = $derived(
+		mergeProps(restProps, inputState.props, { value: inputState.opts.value.current })
+	);
+</script>
+
+{#if child}
+	{@render child({ props: mergedProps })}
+{:else}
+	<input {...mergedProps} bind:value={inputState.opts.value.current} />
+{/if}

--- a/packages/bits-ui/src/lib/bits/tags-input/components/tags-input-list.svelte
+++ b/packages/bits-ui/src/lib/bits/tags-input/components/tags-input-list.svelte
@@ -1,0 +1,35 @@
+<script lang="ts">
+	import { box, mergeProps } from "svelte-toolbelt";
+	import type { TagsInputListProps } from "../types.js";
+	import { useTagsInputList } from "../tags-input.svelte.js";
+	import { useId } from "$lib/internal/use-id.js";
+
+	let {
+		id = useId(),
+		ref = $bindable(null),
+		children,
+		child,
+		...restProps
+	}: TagsInputListProps = $props();
+
+	const listState = useTagsInputList({
+		id: box.with(() => id),
+		ref: box.with(
+			() => ref,
+			(v) => (ref = v)
+		),
+	});
+
+	const mergedProps = $derived(mergeProps(restProps, listState.props));
+	const mergedWrapperProps = $derived(mergeProps(listState.gridWrapperProps, {}));
+</script>
+
+<div {...mergedWrapperProps}>
+	{#if child}
+		{@render child({ props: mergedProps })}
+	{:else}
+		<div {...mergedProps}>
+			{@render children?.()}
+		</div>
+	{/if}
+</div>

--- a/packages/bits-ui/src/lib/bits/tags-input/components/tags-input-tag-content.svelte
+++ b/packages/bits-ui/src/lib/bits/tags-input/components/tags-input-tag-content.svelte
@@ -1,0 +1,32 @@
+<script lang="ts">
+	import { box, mergeProps } from "svelte-toolbelt";
+	import { useTagsInputContent } from "../tags-input.svelte.js";
+	import type { TagsInputTagContentProps } from "../types.js";
+	import { useId } from "$lib/internal/use-id.js";
+
+	let {
+		id = useId(),
+		ref = $bindable(null),
+		children,
+		child,
+		...restProps
+	}: TagsInputTagContentProps = $props();
+
+	const contentState = useTagsInputContent({
+		id: box.with(() => id),
+		ref: box.with(
+			() => ref,
+			(v) => (ref = v)
+		),
+	});
+
+	const mergedProps = $derived(mergeProps(restProps, contentState.props));
+</script>
+
+{#if child}
+	{@render child({ props: mergedProps })}
+{:else}
+	<div {...mergedProps}>
+		{@render children?.()}
+	</div>
+{/if}

--- a/packages/bits-ui/src/lib/bits/tags-input/components/tags-input-tag-edit-description.svelte
+++ b/packages/bits-ui/src/lib/bits/tags-input/components/tags-input-tag-edit-description.svelte
@@ -1,0 +1,27 @@
+<script lang="ts">
+	import { box, mergeProps } from "svelte-toolbelt";
+	import { useTagsInputTagEditDescription } from "../tags-input.svelte.js";
+	import { useId } from "$lib/internal/use-id.js";
+	import type { BitsPrimitiveDivAttributes, WithChild, Without } from "$lib/shared/index.js";
+	import Portal from "$lib/bits/utilities/portal/portal.svelte";
+
+	type Props = WithChild & Without<BitsPrimitiveDivAttributes, WithChild>;
+
+	let { id = useId(), ref = $bindable(null) }: Props = $props();
+
+	const editDescriptionState = useTagsInputTagEditDescription({
+		id: box.with(() => id),
+		ref: box.with(
+			() => ref,
+			(v) => (ref = v)
+		),
+	});
+
+	const mergedProps = $derived(mergeProps(editDescriptionState.props));
+</script>
+
+<Portal>
+	<div {...mergedProps}>
+		{editDescriptionState.description}
+	</div>
+</Portal>

--- a/packages/bits-ui/src/lib/bits/tags-input/components/tags-input-tag-edit-input.svelte
+++ b/packages/bits-ui/src/lib/bits/tags-input/components/tags-input-tag-edit-input.svelte
@@ -1,0 +1,29 @@
+<script lang="ts">
+	import { box, mergeProps } from "svelte-toolbelt";
+	import type { TagsInputTagEditInputProps } from "../types.js";
+	import { useTagsInputTagEditInput } from "../tags-input.svelte.js";
+	import { useId } from "$lib/internal/use-id.js";
+
+	let {
+		id = useId(),
+		ref = $bindable(null),
+		child,
+		...restProps
+	}: TagsInputTagEditInputProps = $props();
+
+	const tagEditState = useTagsInputTagEditInput({
+		id: box.with(() => id),
+		ref: box.with(
+			() => ref,
+			(v) => (ref = v)
+		),
+	});
+
+	const mergedProps = $derived(mergeProps(restProps, tagEditState.props));
+</script>
+
+{#if child}
+	{@render child({ props: mergedProps })}
+{:else}
+	<input {...mergedProps} />
+{/if}

--- a/packages/bits-ui/src/lib/bits/tags-input/components/tags-input-tag-hidden-input.svelte
+++ b/packages/bits-ui/src/lib/bits/tags-input/components/tags-input-tag-hidden-input.svelte
@@ -1,0 +1,11 @@
+<script lang="ts">
+	import { mergeProps } from "svelte-toolbelt";
+	import { useTagsInputTagHiddenInput } from "../tags-input.svelte.js";
+
+	const hiddenInputState = useTagsInputTagHiddenInput();
+	const mergedProps = $derived(mergeProps(hiddenInputState.props, {}));
+</script>
+
+{#if hiddenInputState.shouldRender}
+	<input {...mergedProps} />
+{/if}

--- a/packages/bits-ui/src/lib/bits/tags-input/components/tags-input-tag-remove.svelte
+++ b/packages/bits-ui/src/lib/bits/tags-input/components/tags-input-tag-remove.svelte
@@ -1,0 +1,32 @@
+<script lang="ts">
+	import { box, mergeProps } from "svelte-toolbelt";
+	import type { TagsInputTagRemoveProps } from "../types.js";
+	import { useTagsInputTagRemove } from "../tags-input.svelte.js";
+	import { useId } from "$lib/internal/use-id.js";
+
+	let {
+		id = useId(),
+		ref = $bindable(null),
+		child,
+		children,
+		...restProps
+	}: TagsInputTagRemoveProps = $props();
+
+	const tagRemoveState = useTagsInputTagRemove({
+		id: box.with(() => id),
+		ref: box.with(
+			() => ref,
+			(v) => (ref = v)
+		),
+	});
+
+	const mergedProps = $derived(mergeProps(restProps, tagRemoveState.props));
+</script>
+
+{#if child}
+	{@render child({ props: mergedProps })}
+{:else}
+	<button {...mergedProps}>
+		{@render children?.()}
+	</button>
+{/if}

--- a/packages/bits-ui/src/lib/bits/tags-input/components/tags-input-tag-text.svelte
+++ b/packages/bits-ui/src/lib/bits/tags-input/components/tags-input-tag-text.svelte
@@ -1,0 +1,32 @@
+<script lang="ts">
+	import { box, mergeProps } from "svelte-toolbelt";
+	import type { TagsInputTagTextProps } from "../types.js";
+	import { useTagsInputTagText } from "../tags-input.svelte.js";
+	import { useId } from "$lib/internal/use-id.js";
+
+	let {
+		id = useId(),
+		ref = $bindable(null),
+		child,
+		children,
+		...restProps
+	}: TagsInputTagTextProps = $props();
+
+	const tagContentState = useTagsInputTagText({
+		id: box.with(() => id),
+		ref: box.with(
+			() => ref,
+			(v) => (ref = v)
+		),
+	});
+
+	const mergedProps = $derived(mergeProps(restProps, tagContentState.props));
+</script>
+
+{#if child}
+	{@render child({ props: mergedProps })}
+{:else}
+	<div {...mergedProps}>
+		{@render children?.()}
+	</div>
+{/if}

--- a/packages/bits-ui/src/lib/bits/tags-input/components/tags-input-tag.svelte
+++ b/packages/bits-ui/src/lib/bits/tags-input/components/tags-input-tag.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { box, mergeProps, srOnlyStyles } from "svelte-toolbelt";
+	import { box, mergeProps, srOnlyStylesString } from "svelte-toolbelt";
 	import type { TagsInputTagProps } from "../types.js";
 	import { useTagsInputTag } from "../tags-input.svelte.js";
 	import TagsInputTagHiddenInput from "./tags-input-tag-hidden-input.svelte";
@@ -10,7 +10,7 @@
 		ref = $bindable(null),
 		value,
 		index,
-		editMode = "input",
+		editMode = "none",
 		removable = true,
 		children,
 		child,
@@ -33,17 +33,12 @@
 	});
 
 	const mergedProps = $derived(mergeProps(restProps, tagState.props));
-	const mergedBtnProps = $derived(mergeProps({ style: srOnlyStyles }));
 </script>
 
 {#snippet EditButton()}
 	{#if tagState.opts.editMode.current !== "none"}
-		<button
-			tabindex={-1}
-			onclick={tagState.startEditing}
-			aria-label="Edit {tagState.opts.value.current}"
-			{...mergedBtnProps}
-		>
+		<button tabindex={-1} onclick={tagState.startEditing} style={srOnlyStylesString}>
+			Edit {value}
 		</button>
 	{/if}
 {/snippet}

--- a/packages/bits-ui/src/lib/bits/tags-input/components/tags-input-tag.svelte
+++ b/packages/bits-ui/src/lib/bits/tags-input/components/tags-input-tag.svelte
@@ -1,0 +1,61 @@
+<script lang="ts">
+	import { box, mergeProps, srOnlyStyles } from "svelte-toolbelt";
+	import type { TagsInputTagProps } from "../types.js";
+	import { useTagsInputTag } from "../tags-input.svelte.js";
+	import TagsInputTagHiddenInput from "./tags-input-tag-hidden-input.svelte";
+	import { useId } from "$lib/internal/use-id.js";
+
+	let {
+		id = useId(),
+		ref = $bindable(null),
+		value,
+		index,
+		editMode = "input",
+		removable = true,
+		children,
+		child,
+		...restProps
+	}: TagsInputTagProps = $props();
+
+	const tagState = useTagsInputTag({
+		id: box.with(() => id),
+		ref: box.with(
+			() => ref,
+			(v) => (ref = v)
+		),
+		value: box.with(
+			() => value,
+			(v) => (value = v)
+		),
+		index: box.with(() => index),
+		editMode: box.with(() => editMode),
+		removable: box.with(() => removable),
+	});
+
+	const mergedProps = $derived(mergeProps(restProps, tagState.props));
+	const mergedBtnProps = $derived(mergeProps({ style: srOnlyStyles }));
+</script>
+
+{#snippet EditButton()}
+	{#if tagState.opts.editMode.current !== "none"}
+		<button
+			tabindex={-1}
+			onclick={tagState.startEditing}
+			aria-label="Edit {tagState.opts.value.current}"
+			{...mergedBtnProps}
+		>
+		</button>
+	{/if}
+{/snippet}
+
+{#if child}
+	{@render child({ props: mergedProps })}
+	{@render EditButton()}
+{:else}
+	<div {...mergedProps}>
+		{@render children?.()}
+		{@render EditButton()}
+	</div>
+{/if}
+
+<TagsInputTagHiddenInput />

--- a/packages/bits-ui/src/lib/bits/tags-input/components/tags-input.svelte
+++ b/packages/bits-ui/src/lib/bits/tags-input/components/tags-input.svelte
@@ -1,0 +1,60 @@
+<script lang="ts">
+	import { box, mergeProps } from "svelte-toolbelt";
+	import type { TagsInputRootProps } from "../types.js";
+	import { useTagsInputRoot } from "../tags-input.svelte.js";
+	import TagsInputTagEditDescription from "./tags-input-tag-edit-description.svelte";
+	import TagsInputAnnouncer from "./tags-input-announcer.svelte";
+	import { useId } from "$lib/internal/use-id.js";
+	import { noop } from "$lib/internal/noop.js";
+
+	let {
+		id = useId(),
+		value = $bindable([]),
+		ref = $bindable(null),
+		onValueChange = noop,
+		validate = () => true,
+		controlledValue = false,
+		delimiters = [","],
+		required = false,
+		name = "",
+		children,
+		child,
+		...restProps
+	}: TagsInputRootProps = $props();
+
+	const rootState = useTagsInputRoot({
+		id: box.with(() => id),
+		value: box.with(
+			() => value,
+			(v) => {
+				if (controlledValue) {
+					onValueChange(v);
+				} else {
+					value = v;
+					onValueChange(v);
+				}
+			}
+		),
+		ref: box.with(
+			() => ref,
+			(v) => (ref = v)
+		),
+		delimiters: box.with(() => delimiters),
+		name: box.with(() => name),
+		required: box.with(() => required),
+		validate: box.with(() => validate),
+	});
+
+	const mergedProps = $derived(mergeProps(restProps, rootState.props));
+</script>
+
+{#if child}
+	{@render child({ props: mergedProps })}
+{:else}
+	<div {...mergedProps}>
+		{@render children?.()}
+	</div>
+{/if}
+
+<TagsInputTagEditDescription />
+<TagsInputAnnouncer />

--- a/packages/bits-ui/src/lib/bits/tags-input/components/tags-input.svelte
+++ b/packages/bits-ui/src/lib/bits/tags-input/components/tags-input.svelte
@@ -13,12 +13,12 @@
 		ref = $bindable(null),
 		onValueChange = noop,
 		validate = () => true,
-		controlledValue = false,
 		delimiters = [","],
 		required = false,
 		name = "",
 		children,
 		child,
+		announceTransformers,
 		...restProps
 	}: TagsInputRootProps = $props();
 
@@ -27,12 +27,8 @@
 		value: box.with(
 			() => value,
 			(v) => {
-				if (controlledValue) {
-					onValueChange(v);
-				} else {
-					value = v;
-					onValueChange(v);
-				}
+				value = v;
+				onValueChange(v);
 			}
 		),
 		ref: box.with(
@@ -43,6 +39,7 @@
 		name: box.with(() => name),
 		required: box.with(() => required),
 		validate: box.with(() => validate),
+		announceTransformers: box.with(() => announceTransformers),
 	});
 
 	const mergedProps = $derived(mergeProps(restProps, rootState.props));

--- a/packages/bits-ui/src/lib/bits/tags-input/exports.ts
+++ b/packages/bits-ui/src/lib/bits/tags-input/exports.ts
@@ -1,0 +1,21 @@
+export { default as Root } from "./components/tags-input.svelte";
+export { default as List } from "./components/tags-input-list.svelte";
+export { default as Input } from "./components/tags-input-input.svelte";
+export { default as Clear } from "./components/tags-input-clear.svelte";
+export { default as Tag } from "./components/tags-input-tag.svelte";
+export { default as TagText } from "./components/tags-input-tag-text.svelte";
+export { default as TagRemove } from "./components/tags-input-tag-remove.svelte";
+export { default as TagEditInput } from "./components/tags-input-tag-edit-input.svelte";
+export { default as TagContent } from "./components/tags-input-tag-content.svelte";
+
+export type {
+	TagsInputRootProps as RootProps,
+	TagsInputListProps as ListProps,
+	TagsInputInputProps as InputProps,
+	TagsInputClearProps as ClearProps,
+	TagsInputTagProps as TagProps,
+	TagsInputTagTextProps as TagTextProps,
+	TagsInputTagRemoveProps as TagRemoveProps,
+	TagsInputTagEditInputProps as TagEditInputProps,
+	TagsInputTagContentProps as TagContentProps,
+} from "./types.js";

--- a/packages/bits-ui/src/lib/bits/tags-input/index.ts
+++ b/packages/bits-ui/src/lib/bits/tags-input/index.ts
@@ -1,0 +1,1 @@
+export * as TagsInput from "./exports.js";

--- a/packages/bits-ui/src/lib/bits/tags-input/tags-input.svelte.ts
+++ b/packages/bits-ui/src/lib/bits/tags-input/tags-input.svelte.ts
@@ -1,0 +1,758 @@
+import {
+	type ReadableBoxedValues,
+	type WritableBoxedValues,
+	afterSleep,
+	afterTick,
+	box,
+	srOnlyStyles,
+	useRefById,
+} from "svelte-toolbelt";
+import type {
+	ClipboardEventHandler,
+	FocusEventHandler,
+	KeyboardEventHandler,
+	MouseEventHandler,
+} from "svelte/elements";
+import { Context } from "runed";
+import type { TagsInputBlurBehavior, TagsInputPasteBehavior } from "./types.js";
+import type { WithRefProps } from "$lib/internal/types.js";
+import { getAriaHidden, getDataInvalid, getRequired } from "$lib/internal/attrs.js";
+import { kbd } from "$lib/internal/kbd.js";
+import { RovingFocusGroup } from "$lib/internal/use-roving-focus.svelte.js";
+import { isOrContainsTarget } from "$lib/internal/elements.js";
+
+const ROOT_ATTR = "data-tags-input-root";
+const LIST_ATTR = "data-tags-input-list";
+const INPUT_ATTR = "data-tags-input-input";
+const CLEAR_ATTR = "data-tags-input-clear";
+const TAG_ATTR = "data-tags-input-tag";
+const TAG_TEXT_ATTR = "data-tags-input-tag-text";
+const TAG_CONTENT_ATTR = "data-tags-input-tag-content";
+const TAG_REMOVE_ATTR = "data-tags-input-tag-remove";
+const TAG_EDIT_INPUT_ATTR = "data-tags-input-tag-edit-input";
+
+type TagsInputRootStateProps = WithRefProps &
+	WritableBoxedValues<{
+		value: string[];
+	}> &
+	ReadableBoxedValues<{
+		delimiters: string[];
+		name: string;
+		required: boolean;
+		validate: (value: string) => boolean;
+	}>;
+
+// prettier-ignore
+const HORIZONTAL_NAV_KEYS = [kbd.ARROW_LEFT, kbd.ARROW_RIGHT, kbd.HOME, kbd.END];
+const VERTICAL_NAV_KEYS = [kbd.ARROW_UP, kbd.ARROW_DOWN];
+const REMOVAL_KEYS = [kbd.BACKSPACE, kbd.DELETE];
+
+class TagsInputRootState {
+	valueSnapshot = $derived.by(() => $state.snapshot(this.opts.value.current));
+	inputNode = $state<HTMLElement | null>(null);
+	listRovingFocusGroup: RovingFocusGroup | null = null;
+	delimitersRegex = $derived.by(() => new RegExp(this.opts.delimiters.current.join("|"), "g"));
+	editDescriptionNode = $state<HTMLElement | null>(null);
+	message = $state<string | null>(null);
+	messageTimeout: number | null = null;
+	/**
+	 * Whether the tags input is invalid or not. It enters an invalid state when the
+	 * `validate` prop returns `false` for any of the tags.
+	 */
+	isInvalid = $state(false);
+	hasValue = $derived.by(() => this.opts.value.current.length > 0);
+
+	constructor(readonly opts: TagsInputRootStateProps) {
+		useRefById(opts);
+	}
+
+	includesValue = (value: string) => {
+		return this.opts.value.current.includes(value);
+	};
+
+	addValue = (value: string): boolean => {
+		if (value === "") return true;
+		const isValid = this.opts.validate.current?.(value) ?? true;
+		if (!isValid) {
+			this.isInvalid = true;
+			return false;
+		}
+		this.isInvalid = false;
+		this.opts.value.current.push(value);
+		this.announceAdd(value);
+		return true;
+	};
+
+	addValues = (values: string[]) => {
+		const newValues = values.filter((value) => value !== "");
+		const anyInvalid = newValues.some((value) => this.opts.validate.current?.(value) === false);
+		if (anyInvalid) {
+			this.isInvalid = true;
+			return;
+		}
+		this.isInvalid = false;
+		this.opts.value.current.push(...newValues);
+		this.announceAddMultiple(newValues);
+	};
+
+	removeValueByIndex = (index: number, value: string) => {
+		this.opts.value.current.splice(index, 1);
+		this.announceRemove(value);
+	};
+
+	updateValueByIndex = (index: number, value: string) => {
+		const curr = this.opts.value.current[index];
+		this.opts.value.current[index] = value;
+		if (curr) {
+			this.announceEdit(curr, value);
+		}
+	};
+
+	clearValue = () => {
+		this.isInvalid = false;
+		this.opts.value.current = [];
+	};
+
+	recomputeTabIndex = () => {
+		this.listRovingFocusGroup?.recomputeActiveTabNode();
+	};
+
+	#announce = (message: string) => {
+		if (this.messageTimeout) {
+			window.clearTimeout(this.messageTimeout);
+		}
+		this.message = message;
+		this.messageTimeout = window.setTimeout(() => {
+			this.message = null;
+		});
+	};
+
+	announceEdit = (from: string, to: string) => {
+		this.#announce(`${from} has been changed to ${to}`);
+	};
+
+	announceRemove = (value: string) => {
+		this.#announce(`${value} has been removed`);
+	};
+
+	announceAdd = (value: string) => {
+		this.#announce(`${value} has been added`);
+	};
+
+	announceAddMultiple = (values: string[]) => {
+		this.#announce(`${values.join(", ")} has been added`);
+	};
+
+	props = $derived.by(
+		() =>
+			({
+				id: this.opts.id.current,
+				[ROOT_ATTR]: "",
+				"data-invalid": getDataInvalid(this.isInvalid),
+			}) as const
+	);
+}
+
+type TagsInputListStateProps = WithRefProps;
+
+class TagsInputListState {
+	rovingFocusGroup: RovingFocusGroup;
+
+	constructor(
+		readonly opts: TagsInputListStateProps,
+		readonly root: TagsInputRootState
+	) {
+		useRefById(opts);
+		this.rovingFocusGroup = new RovingFocusGroup({
+			rootNodeId: this.opts.id,
+			candidateSelector: `[role=gridcell]:not([aria-hidden=true])`,
+			loop: box(false),
+			orientation: box("horizontal"),
+		});
+		this.root.listRovingFocusGroup = this.rovingFocusGroup;
+	}
+
+	gridWrapperProps = $derived.by(
+		() =>
+			({
+				role: this.root.hasValue ? "grid" : undefined,
+				style: {
+					display: "contents",
+				},
+			}) as const
+	);
+
+	props = $derived.by(
+		() =>
+			({
+				id: this.opts.id.current,
+				[LIST_ATTR]: "",
+				role: this.root.hasValue ? "row" : undefined,
+				"data-invalid": getDataInvalid(this.root.isInvalid),
+			}) as const
+	);
+}
+
+type TagsInputTagStateProps = WithRefProps &
+	ReadableBoxedValues<{
+		index: number;
+		removable: boolean;
+		editMode: "input" | "contenteditable" | "none";
+	}> &
+	WritableBoxedValues<{
+		value: string;
+	}>;
+
+class TagsInputTagState {
+	textNode = $state<HTMLElement | null>(null);
+	removeNode = $state<HTMLElement | null>(null);
+	editCell = $state<HTMLElement | null>(null);
+	editInput = $state<HTMLInputElement | null>(null);
+	isEditable = $derived.by(() => this.opts.editMode.current !== "none");
+	isEditing = $state(false);
+	#tabIndex = $state(0);
+
+	constructor(
+		readonly opts: TagsInputTagStateProps,
+		readonly list: TagsInputListState
+	) {
+		useRefById({
+			...opts,
+			deps: () => this.opts.index.current,
+		});
+
+		$effect(() => {
+			// we want to track the value here so when we remove the actively focused
+			// tag, we ensure the other ones get the correct tab index
+			this.list.root.valueSnapshot;
+			this.opts.ref.current;
+			this.#tabIndex = this.list.rovingFocusGroup.getTabIndex(this.opts.ref.current);
+		});
+	}
+
+	setValue = (value: string) => {
+		this.list.root.updateValueByIndex(this.opts.index.current, value);
+	};
+
+	startEditing = () => {
+		if (this.isEditable === false) return;
+		this.isEditing = true;
+
+		if (this.opts.editMode.current === "input") {
+			this.editInput?.focus();
+			this.editInput?.select();
+		} else if (this.opts.editMode.current === "contenteditable") {
+			this.textNode?.focus();
+		}
+	};
+
+	stopEditing = (focusTag = true) => {
+		this.isEditing = false;
+
+		if (focusTag) {
+			this.opts.ref.current?.focus();
+		}
+	};
+
+	remove = () => {
+		if (this.opts.removable.current === false) return;
+		this.list.root.removeValueByIndex(this.opts.index.current, this.opts.value.current);
+		this.list.root.recomputeTabIndex();
+	};
+
+	#onkeydown: KeyboardEventHandler<HTMLElement> = (e) => {
+		if (e.target !== this.opts.ref.current) return;
+		if (HORIZONTAL_NAV_KEYS.includes(e.key)) {
+			e.preventDefault();
+			this.list.rovingFocusGroup.handleKeydown({ node: this.opts.ref.current, event: e });
+		} else if (VERTICAL_NAV_KEYS.includes(e.key)) {
+			e.preventDefault();
+			this.list.rovingFocusGroup.handleKeydown({
+				node: this.opts.ref.current,
+				event: e,
+				orientation: "vertical",
+				invert: true,
+			});
+		} else if (REMOVAL_KEYS.includes(e.key)) {
+			e.preventDefault();
+			this.remove();
+			this.list.rovingFocusGroup.navigateBackward(
+				this.opts.ref.current,
+				this.list.root.inputNode
+			);
+		} else if (e.key === kbd.ENTER) {
+			e.preventDefault();
+			this.startEditing();
+		}
+	};
+
+	props = $derived.by(
+		() =>
+			({
+				id: this.opts.id.current,
+				role: "gridcell",
+				"data-editing": this.isEditing ? "" : undefined,
+				"data-editable": this.isEditable ? "" : undefined,
+				"data-removable": this.opts.removable.current ? "" : undefined,
+				"data-invalid": getDataInvalid(this.list.root.isInvalid),
+				tabindex: this.#tabIndex,
+				[TAG_ATTR]: "",
+				onkeydown: this.#onkeydown,
+			}) as const
+	);
+}
+
+type TagsInputTagTextStateProps = WithRefProps;
+
+class TagsInputTagTextState {
+	constructor(
+		readonly opts: TagsInputTagTextStateProps,
+		readonly tag: TagsInputTagState
+	) {
+		useRefById({
+			...opts,
+			onRefChange: (node) => {
+				this.tag.textNode = node;
+			},
+		});
+	}
+
+	#onkeydown: KeyboardEventHandler<HTMLElement> = (e) => {
+		if (this.tag.opts.editMode.current !== "contenteditable" || !this.tag.isEditing) {
+			return;
+		}
+		if (e.key === kbd.ESCAPE) {
+			this.tag.stopEditing();
+			e.currentTarget.innerText = this.tag.opts.value.current;
+		} else if (e.key === kbd.TAB) {
+			this.tag.stopEditing(false);
+			e.currentTarget.innerText = this.tag.opts.value.current;
+		} else if (e.key === kbd.ENTER) {
+			e.preventDefault();
+			const value = e.currentTarget.innerText;
+			if (value === "") {
+				this.tag.stopEditing();
+				this.tag.remove();
+			} else {
+				this.tag.setValue(value);
+				this.tag.stopEditing();
+			}
+		}
+	};
+
+	#onblur: FocusEventHandler<HTMLElement> = () => {
+		if (this.tag.opts.editMode.current !== "contenteditable") return;
+		if (this.tag.isEditing) {
+			this.tag.stopEditing(false);
+		}
+	};
+
+	#onfocus: FocusEventHandler<HTMLElement> = (_) => {
+		if (this.tag.opts.editMode.current !== "contenteditable" || !this.tag.isEditing) return;
+		afterSleep(0, () => {
+			if (!this.opts.ref.current) return;
+			const selection = window.getSelection();
+			const range = document.createRange();
+
+			range.selectNodeContents(this.opts.ref.current);
+			selection?.removeAllRanges();
+			selection?.addRange(range);
+		});
+	};
+
+	props = $derived.by(
+		() =>
+			({
+				id: this.opts.id.current,
+				[TAG_TEXT_ATTR]: "",
+				tabindex: -1,
+				"data-editable": this.tag.isEditable ? "" : undefined,
+				"data-removable": this.tag.opts.removable.current ? "" : undefined,
+				contenteditable:
+					this.tag.opts.editMode.current === "contenteditable" && this.tag.isEditing
+						? "true"
+						: undefined,
+				onkeydown: this.#onkeydown,
+				onblur: this.#onblur,
+				onfocus: this.#onfocus,
+			}) as const
+	);
+}
+
+type TagsInputTagEditInputStateProps = WithRefProps;
+
+class TagsInputTagEditInputState {
+	constructor(
+		readonly opts: TagsInputTagEditInputStateProps,
+		readonly tag: TagsInputTagState
+	) {
+		useRefById({
+			...opts,
+			onRefChange: (node) => {
+				if (node instanceof HTMLInputElement) this.tag.editInput = node;
+			},
+		});
+	}
+
+	#style = $derived.by(() => {
+		if (this.tag.isEditing && this.tag.opts.editMode.current === "input") return undefined;
+		return srOnlyStyles;
+	});
+
+	#onkeydown: KeyboardEventHandler<HTMLInputElement> = (e) => {
+		if (e.key === kbd.ESCAPE) {
+			this.tag.stopEditing();
+			e.currentTarget.value = this.tag.opts.value.current;
+		} else if (e.key === kbd.TAB) {
+			this.tag.stopEditing(false);
+			e.currentTarget.value = this.tag.opts.value.current;
+		} else if (e.key === kbd.ENTER) {
+			e.preventDefault();
+			const value = e.currentTarget.value;
+			if (value === "") {
+				this.tag.stopEditing();
+				this.tag.remove();
+			} else {
+				this.tag.setValue(value);
+				this.tag.stopEditing();
+			}
+		}
+	};
+
+	#onblur: FocusEventHandler<HTMLInputElement> = () => {
+		if (this.tag.isEditing) {
+			this.tag.stopEditing(false);
+		}
+	};
+
+	props = $derived.by(
+		() =>
+			({
+				id: this.opts.id.current,
+				[TAG_EDIT_INPUT_ATTR]: "",
+				tabindex: -1,
+				"data-editing": this.tag.isEditing ? "" : undefined,
+				"data-invalid": getDataInvalid(this.tag.list.root.isInvalid),
+				"data-editable": this.tag.isEditable ? "" : undefined,
+				"data-removable": this.tag.opts.removable.current ? "" : undefined,
+				value: this.tag.opts.value.current,
+				style: this.#style,
+				onkeydown: this.#onkeydown,
+				onblur: this.#onblur,
+				"aria-label": `Edit ${this.tag.opts.value.current}`,
+				"aria-describedby": this.tag.list.root.editDescriptionNode?.id,
+				"aria-hidden": getAriaHidden(!this.tag.isEditing),
+			}) as const
+	);
+}
+
+type TagsInputTagRemoveStateProps = WithRefProps;
+
+class TagsInputTagRemoveState {
+	#ariaLabelledBy = $derived.by(() => {
+		if (this.tag.textNode && this.tag.textNode.id) {
+			return `${this.opts.id.current} ${this.tag.textNode.id}`;
+		}
+		return this.opts.id.current;
+	});
+
+	constructor(
+		readonly opts: TagsInputTagRemoveStateProps,
+		readonly tag: TagsInputTagState
+	) {
+		useRefById({
+			...opts,
+			onRefChange: (node) => {
+				this.tag.removeNode = node;
+			},
+		});
+	}
+
+	#onclick: MouseEventHandler<HTMLButtonElement> = () => {
+		this.tag.remove();
+	};
+
+	#onkeydown: KeyboardEventHandler<HTMLButtonElement> = (e) => {
+		if (e.key === kbd.ENTER || e.key === kbd.SPACE) {
+			e.preventDefault();
+			this.tag.remove();
+			afterTick(() => {
+				const success = this.tag.list.root.listRovingFocusGroup?.focusLastCandidate();
+				if (!success) {
+					this.tag.list.root.inputNode?.focus();
+				}
+			});
+		}
+	};
+
+	props = $derived.by(
+		() =>
+			({
+				id: this.opts.id.current,
+				[TAG_REMOVE_ATTR]: "",
+				role: "button",
+				"aria-label": "Remove",
+				"aria-labelledby": this.#ariaLabelledBy,
+				"data-editing": this.tag.isEditing ? "" : undefined,
+				"data-editable": this.tag.isEditable ? "" : undefined,
+				"data-removable": this.tag.opts.removable.current ? "" : undefined,
+				tabindex: -1,
+				onclick: this.#onclick,
+				onkeydown: this.#onkeydown,
+			}) as const
+	);
+}
+
+type TagsInputInputStateProps = WithRefProps &
+	ReadableBoxedValues<{
+		blurBehavior: TagsInputBlurBehavior;
+		pasteBehavior: TagsInputPasteBehavior;
+	}> &
+	WritableBoxedValues<{ value: string }>;
+
+class TagsInputInputState {
+	constructor(
+		readonly opts: TagsInputInputStateProps,
+		readonly root: TagsInputRootState
+	) {
+		useRefById({
+			...opts,
+			onRefChange: (node) => {
+				this.root.inputNode = node;
+			},
+		});
+	}
+
+	#resetValue = () => {
+		this.opts.value.current = "";
+	};
+
+	#onkeydown: KeyboardEventHandler<HTMLInputElement> = (e) => {
+		if (e.key === kbd.ENTER) {
+			const valid = this.root.addValue(e.currentTarget.value);
+			if (valid) this.#resetValue();
+		} else if (this.root.opts.delimiters.current.includes(e.key) && e.currentTarget.value) {
+			e.preventDefault();
+			const valid = this.root.addValue(e.currentTarget.value);
+			if (valid) this.#resetValue();
+		} else if (e.key === kbd.BACKSPACE && e.currentTarget.value === "") {
+			e.preventDefault();
+			const success = this.root.listRovingFocusGroup?.focusLastCandidate();
+			if (!success) {
+				this.root.inputNode?.focus();
+			}
+		}
+	};
+
+	#onpaste: ClipboardEventHandler<HTMLInputElement> = (e) => {
+		if (!e.clipboardData || this.opts.pasteBehavior.current === "none") return;
+		const rawClipboardData = e.clipboardData.getData("text/plain");
+		// we're splitting this by the delimiters
+		const pastedValues = rawClipboardData.split(this.root.delimitersRegex);
+		this.root.addValues(pastedValues);
+		e.preventDefault();
+	};
+
+	#onblur: FocusEventHandler<HTMLInputElement> = (e) => {
+		const blurBehavior = this.opts.blurBehavior.current;
+		const currTarget = e.currentTarget as HTMLInputElement;
+		if (blurBehavior === "add" && currTarget.value !== "") {
+			const valid = this.root.addValue(currTarget.value);
+			if (valid) this.#resetValue();
+		} else if (blurBehavior === "clear") {
+			this.#resetValue();
+		}
+		this.root.isInvalid = false;
+	};
+
+	props = $derived.by(
+		() =>
+			({
+				id: this.opts.id.current,
+				[INPUT_ATTR]: "",
+				"data-invalid": getDataInvalid(this.root.isInvalid),
+				onkeydown: this.#onkeydown,
+				onblur: this.#onblur,
+				onpaste: this.#onpaste,
+			}) as const
+	);
+}
+
+type TagsInputClearStateProps = WithRefProps;
+
+class TagsInputClearState {
+	constructor(
+		readonly opts: TagsInputClearStateProps,
+		readonly root: TagsInputRootState
+	) {
+		useRefById(opts);
+	}
+
+	#onclick: MouseEventHandler<HTMLButtonElement> = () => {
+		this.root.clearValue();
+	};
+
+	props = $derived.by(
+		() =>
+			({
+				id: this.opts.id.current,
+				[CLEAR_ATTR]: "",
+				role: "button",
+				"aria-label": "Clear",
+				onclick: this.#onclick,
+			}) as const
+	);
+}
+
+type TagsInputTagContentStateProps = WithRefProps;
+
+class TagsInputTagContentState {
+	constructor(
+		readonly opts: TagsInputTagContentStateProps,
+		readonly tag: TagsInputTagState
+	) {
+		useRefById(opts);
+	}
+
+	#style = $derived.by(() => {
+		if (this.tag.isEditing && this.tag.opts.editMode.current === "input") return srOnlyStyles;
+		return undefined;
+	});
+
+	#ondblclick: MouseEventHandler<HTMLElement> = (e) => {
+		if (!this.tag.isEditable) return;
+		const target = e.target as HTMLElement;
+		if (this.tag.removeNode && isOrContainsTarget(this.tag.removeNode, target)) {
+			return;
+		}
+		this.tag.startEditing();
+	};
+
+	props = $derived.by(
+		() =>
+			({
+				id: this.opts.id.current,
+				[TAG_CONTENT_ATTR]: "",
+				style: this.#style,
+				ondblclick: this.#ondblclick,
+			}) as const
+	);
+}
+
+class TagsInputTagHiddenInputState {
+	shouldRender = $derived.by(
+		() => this.tag.list.root.opts.name.current !== "" && this.tag.opts.value.current !== ""
+	);
+
+	constructor(readonly tag: TagsInputTagState) {}
+
+	props = $derived.by(
+		() =>
+			({
+				type: "text",
+				name: this.tag.list.root.opts.name.current,
+				value: this.tag.opts.value.current,
+				style: srOnlyStyles,
+				required: getRequired(this.tag.list.root.opts.required.current),
+				"aria-hidden": getAriaHidden(true),
+			}) as const
+	);
+}
+
+type TagsInputTagEditDescriptionStateProps = WithRefProps;
+
+class TagsInputTagEditDescriptionState {
+	constructor(
+		readonly opts: TagsInputTagEditDescriptionStateProps,
+		readonly root: TagsInputRootState
+	) {
+		useRefById({
+			...opts,
+			onRefChange: (node) => {
+				this.root.editDescriptionNode = node;
+			},
+		});
+	}
+
+	description = "Edit tag. Press enter to save or escape to cancel.";
+
+	props = $derived.by(
+		() =>
+			({
+				id: this.opts.id.current,
+				style: srOnlyStyles,
+			}) as const
+	);
+}
+
+type TagsInputAnnouncerStateProps = WithRefProps;
+
+class TagsInputAnnouncerState {
+	constructor(
+		readonly opts: TagsInputAnnouncerStateProps,
+		readonly root: TagsInputRootState
+	) {
+		useRefById(opts);
+	}
+
+	props = $derived.by(
+		() =>
+			({
+				id: this.opts.id.current,
+				"aria-live": "polite",
+				style: srOnlyStyles,
+			}) as const
+	);
+}
+
+const TagsInputRootContext = new Context<TagsInputRootState>("TagsInput.Root");
+const TagsInputListContext = new Context<TagsInputListState>("TagsInput.List");
+const TagsInputTagContext = new Context<TagsInputTagState>("TagsInput.Tag");
+
+export function useTagsInputRoot(props: TagsInputRootStateProps) {
+	return TagsInputRootContext.set(new TagsInputRootState(props));
+}
+
+export function useTagsInputList(props: TagsInputListStateProps) {
+	return TagsInputListContext.set(new TagsInputListState(props, TagsInputRootContext.get()));
+}
+
+export function useTagsInputTag(props: TagsInputTagStateProps) {
+	return TagsInputTagContext.set(new TagsInputTagState(props, TagsInputListContext.get()));
+}
+
+export function useTagsInputTagText(props: TagsInputTagTextStateProps) {
+	return new TagsInputTagTextState(props, TagsInputTagContext.get());
+}
+
+export function useTagsInputTagEditInput(props: TagsInputTagEditInputStateProps) {
+	return new TagsInputTagEditInputState(props, TagsInputTagContext.get());
+}
+
+export function useTagsInputTagRemove(props: TagsInputTagRemoveStateProps) {
+	return new TagsInputTagRemoveState(props, TagsInputTagContext.get());
+}
+
+export function useTagsInputTagHiddenInput() {
+	return new TagsInputTagHiddenInputState(TagsInputTagContext.get());
+}
+
+export function useTagsInputInput(props: TagsInputInputStateProps) {
+	return new TagsInputInputState(props, TagsInputRootContext.get());
+}
+
+export function useTagsInputClear(props: TagsInputClearStateProps) {
+	return new TagsInputClearState(props, TagsInputRootContext.get());
+}
+
+export function useTagsInputContent(props: TagsInputTagContentStateProps) {
+	return new TagsInputTagContentState(props, TagsInputTagContext.get());
+}
+
+export function useTagsInputTagEditDescription(props: TagsInputTagEditDescriptionStateProps) {
+	return new TagsInputTagEditDescriptionState(props, TagsInputRootContext.get());
+}
+
+export function useTagsInputAnnouncer(props: TagsInputAnnouncerStateProps) {
+	return new TagsInputAnnouncerState(props, TagsInputRootContext.get());
+}

--- a/packages/bits-ui/src/lib/bits/tags-input/types.ts
+++ b/packages/bits-ui/src/lib/bits/tags-input/types.ts
@@ -1,0 +1,183 @@
+import type { OnChangeFn } from "$lib/internal/types.js";
+import type {
+	BitsPrimitiveButtonAttributes,
+	BitsPrimitiveDivAttributes,
+	BitsPrimitiveInputAttributes,
+	WithChild,
+	Without,
+} from "$lib/shared/index.js";
+
+export type TagsInputBlurBehavior = "clear" | "add" | "none";
+export type TagsInputPasteBehavior = "add" | "none";
+
+export type TagsInputRootPropsWithoutHTML = WithChild<{
+	/**
+	 * The value of the tags input.
+	 *
+	 * @bindable
+	 */
+	value?: string[];
+
+	/**
+	 * A callback function called when the value changes.
+	 */
+	onValueChange?: OnChangeFn<string[]>;
+
+	/**
+	 * Whether or not the value is controlled or not. If `true`, the component will not update
+	 * the value internally, instead it will call `onValueChange` when it would have
+	 * otherwise, and it is up to you to update the `value` prop that is passed to the component.
+	 *
+	 * @defaultValue false
+	 */
+	controlledValue?: boolean;
+
+	/**
+	 * The delimiter used to separate tags.
+	 *
+	 * @defaultValue [","]
+	 */
+	delimiters?: string[];
+
+	/**
+	 * A validation function to determine if the individual tag being added/edited is valid.
+	 *
+	 * Return true to allow the tag to be added/edited, or false to prevent it from being
+	 * added/confirm edited.
+	 */
+	validate?: (value: string) => boolean;
+
+	/**
+	 * If provided, a hidden input element will be rendered for each tag to submit the values with
+	 * a form.
+	 *
+	 * @defaultValue undefined
+	 */
+	name?: string;
+
+	/**
+	 * Whether or not the hidden input element should be marked as required or not.
+	 *
+	 * @defaultValue false
+	 */
+	required?: boolean;
+}>;
+
+export type TagsInputRootProps = TagsInputRootPropsWithoutHTML &
+	Without<BitsPrimitiveDivAttributes, TagsInputRootPropsWithoutHTML>;
+
+export type TagsInputListPropsWithoutHTML = WithChild;
+
+export type TagsInputListProps = TagsInputListPropsWithoutHTML &
+	Without<BitsPrimitiveDivAttributes, TagsInputListPropsWithoutHTML>;
+
+export type TagsInputInputPropsWithoutHTML = WithChild<{
+	/**
+	 * The value of the input.
+	 *
+	 * @bindable
+	 */
+	value?: string;
+
+	/**
+	 * A callback function called when the value changes.
+	 *
+	 *
+	 */
+	onValueChange?: OnChangeFn<string>;
+
+	/**
+	 * Whether or not the value is controlled or not. If `true`, the component will not update
+	 * the value internally, instead it will call `onValueChange` when it would have otherwise,
+	 * and it is up to you to update the `value` prop that is passed to the component.
+	 */
+	controlledValue?: boolean;
+
+	/**
+	 * How to handle when the input is blurred with text in it.
+	 *
+	 * - `'clear'`: Clear the input and remove all tags.
+	 * - `'add'`: Add the text as a new tag. If it contains valid delimiters, it will be split into multiple tags.
+	 * - `'none'`: Don't do anything special when the input is blurred. Just leave the input as is.
+	 *
+	 * @defaultValue "none"
+	 */
+	blurBehavior?: TagsInputBlurBehavior;
+
+	/**
+	 * How to handle when text is pasted into the input.
+	 * - `'add'`: Add the pasted text as a new tag. If it contains valid delimiters, it will be split into multiple tags.
+	 * - `'none'`: Do not add the pasted text as a new tag, just insert it into the input.
+	 *
+	 * @defaultValue "add"
+	 */
+	pasteBehavior?: TagsInputPasteBehavior;
+}>;
+
+export type TagsInputInputProps = TagsInputInputPropsWithoutHTML &
+	Without<BitsPrimitiveInputAttributes, TagsInputInputPropsWithoutHTML>;
+
+export type TagsInputClearPropsWithoutHTML = WithChild;
+
+export type TagsInputClearProps = TagsInputClearPropsWithoutHTML &
+	Without<BitsPrimitiveButtonAttributes, TagsInputClearPropsWithoutHTML>;
+
+export type TagsInputTagPropsWithoutHTML = WithChild<{
+	/**
+	 * The value of this specific tag. This should be unique for the tag.
+	 */
+	value: string;
+
+	/**
+	 * The index of this specific tag in the value array.
+	 */
+	index: number;
+
+	/**
+	 * The type of edit mode to use for the tag. If set to `'input'`, the tag will be editable
+	 * using the `TagsInput.TagEdit` component. If set to `'contenteditable'`, the tag will be
+	 * editable using the `contenteditable` attribute on the `TagsInput.TagText` component. If
+	 * set to `'none'`, the tag will not be editable.
+	 *
+	 * @defaultValue true
+	 */
+	editMode?: "input" | "contenteditable" | "none";
+
+	/**
+	 * Whether the tag can be removed or not.
+	 *
+	 * @defaultValue true
+	 */
+	removable?: boolean;
+}>;
+
+export type TagsInputTagProps = TagsInputTagPropsWithoutHTML &
+	Without<BitsPrimitiveDivAttributes, TagsInputTagPropsWithoutHTML>;
+
+export type TagsInputTagTextPropsWithoutHTML = WithChild;
+
+export type TagsInputTagTextProps = TagsInputTagTextPropsWithoutHTML &
+	Without<BitsPrimitiveDivAttributes, TagsInputTagTextPropsWithoutHTML>;
+
+export type TagsInputTagRemovePropsWithoutHTML = WithChild;
+
+export type TagsInputTagRemoveProps = TagsInputTagRemovePropsWithoutHTML &
+	Without<BitsPrimitiveButtonAttributes, TagsInputTagRemovePropsWithoutHTML>;
+
+export type TagsInputTagEditPropsWithoutHTML = WithChild;
+
+export type TagsInputTagEditProps = TagsInputTagEditPropsWithoutHTML &
+	Without<BitsPrimitiveButtonAttributes, TagsInputTagEditPropsWithoutHTML>;
+
+export type TagsInputTagEditInputPropsWithoutHTML = WithChild;
+
+export type TagsInputTagEditInputProps = Omit<
+	TagsInputTagEditInputPropsWithoutHTML &
+		Without<BitsPrimitiveInputAttributes, TagsInputTagEditInputPropsWithoutHTML>,
+	"children"
+>;
+
+export type TagsInputTagContentPropsWithoutHTML = WithChild;
+
+export type TagsInputTagContentProps = TagsInputTagContentPropsWithoutHTML &
+	Without<BitsPrimitiveDivAttributes, TagsInputTagContentPropsWithoutHTML>;

--- a/packages/bits-ui/src/lib/bits/tags-input/types.ts
+++ b/packages/bits-ui/src/lib/bits/tags-input/types.ts
@@ -10,6 +10,46 @@ import type {
 export type TagsInputBlurBehavior = "clear" | "add" | "none";
 export type TagsInputPasteBehavior = "add" | "none";
 
+/**
+ * Custom announcers to use for the tags input. These will be read out when the various
+ * actions are performed to screen readers. For each that isn't provided, the following
+ * default announcers will be used. The goal is to eventually support localization on our
+ * end for these, but for now we want to allow for custom announcers to be passed in.
+ *
+ * - `add`: `(value: string) => "${value} added"`
+ * - `addMultiple`: `(value: string[]) => "${values.join(", ")} added"`
+ * - `edit`: `(fromValue: string, toValue: string) => "${fromValue} changed to ${toValue}"`
+ * - `remove`: `(value: string) => "${value} removed"`
+ */
+export type TagsInputAnnounceTransformers = {
+	/**
+	 * A function that returns the announcement to make when a tag is edited.
+	 * @param fromValue - the value that was changed from
+	 * @param toValue - the value that was changed to
+	 * @returns - the announcement to make
+	 */
+	edit?: (fromValue: string, toValue: string) => string;
+	/**
+	 * A function that returns the announcement to make when a tag is added.
+	 * @param value - the value that was added
+	 * @returns  the announcement to make
+	 */
+	add?: (addedValue: string) => string;
+	/**
+	 * A function that returns the announcement to make when multiple tags are
+	 * added at once.
+	 * @param value - the value that was added
+	 * @returns  the announcement to make
+	 */
+	addMultiple?: (addedValues: string[]) => string;
+	/**
+	 * A function that returns the announcement to make when a tag is removed.
+	 * @param value - the value that was removed
+	 * @returns the announcement to make
+	 */
+	remove?: (removedValue: string) => string;
+};
+
 export type TagsInputRootPropsWithoutHTML = WithChild<{
 	/**
 	 * The value of the tags input.
@@ -24,18 +64,9 @@ export type TagsInputRootPropsWithoutHTML = WithChild<{
 	onValueChange?: OnChangeFn<string[]>;
 
 	/**
-	 * Whether or not the value is controlled or not. If `true`, the component will not update
-	 * the value internally, instead it will call `onValueChange` when it would have
-	 * otherwise, and it is up to you to update the `value` prop that is passed to the component.
-	 *
-	 * @defaultValue false
-	 */
-	controlledValue?: boolean;
-
-	/**
 	 * The delimiter used to separate tags.
 	 *
-	 * @defaultValue [","]
+	 * @default [","]
 	 */
 	delimiters?: string[];
 
@@ -61,6 +92,19 @@ export type TagsInputRootPropsWithoutHTML = WithChild<{
 	 * @defaultValue false
 	 */
 	required?: boolean;
+
+	/**
+	 * Custom announcers to use for the tags input. These will be read out when the various
+	 * actions are performed to screen readers. For each that isn't provided, the following
+	 * default announcers will be used. The goal is to eventually support localization on our
+	 * end for these, but for now we want to allow for custom announcers to be passed in.
+	 *
+	 * - `add`: `(value: string) => "${value} added"`
+	 * - `addMultiple`: `(value: string[]) => "${values.join(", ")} added"`
+	 * - `edit`: `(fromValue: string, toValue: string) => "${fromValue} changed to ${toValue}"`
+	 * - `remove`: `(value: string) => "${value} removed"`
+	 */
+	announceTransformers?: TagsInputAnnounceTransformers;
 }>;
 
 export type TagsInputRootProps = TagsInputRootPropsWithoutHTML &

--- a/packages/bits-ui/src/lib/index.ts
+++ b/packages/bits-ui/src/lib/index.ts
@@ -33,6 +33,7 @@ export {
 	Slider,
 	Switch,
 	Tabs,
+	TagsInput,
 	Toggle,
 	ToggleGroup,
 	Toolbar,

--- a/packages/bits-ui/src/lib/types.ts
+++ b/packages/bits-ui/src/lib/types.ts
@@ -33,6 +33,7 @@ export type * from "$lib/bits/separator/types.js";
 export type * from "$lib/bits/slider/types.js";
 export type * from "$lib/bits/switch/types.js";
 export type * from "$lib/bits/tabs/types.js";
+export type * from "$lib/bits/tags-input/types.js";
 export type * from "$lib/bits/toggle/types.js";
 export type * from "$lib/bits/toggle-group/types.js";
 export type * from "$lib/bits/toolbar/types.js";


### PR DESCRIPTION
WIP - still need to polish screen reader support and add tests.

When released, this will be released as an `unstable` alpha for a period of time while we collect feedback, rework to accommodate use cases, etc.

Once released, to import the component, you'll need to do the following:

```ts
import { unstable_TagsInput as TagsInput } from 'bits-ui';
```

Once stable, we will drop the `unstable_` and commit to no further breaking changes in the API until a major version bump.
