### PR TITLE
docs: Select example to use the destructured label

### DIFF
--- a/docs/content/components/select.md
+++ b/docs/content/components/select.md
@@ -112,7 +112,7 @@ from the perspective of the consumer of this component, it will be typed appropr
 					<Select.Item {value} {label} {disabled}>
 						{#snippet children({ selected })}
 							{selected ? "✅" : ""}
-							{item.label}
+							{label}
 						{/snippet}
 					</Select.Item>
 				{/each}


### PR DESCRIPTION
Found a documentation error in the [Reusable Components](https://bits-ui.com/docs/components/select#reusable-components) example of the Select component:

`{item.label}` should be `{label}`. `item` does not exist since `Select.Item` is destructured as `{value} {label} {disabled}`.