### PR TITLE
fix: forward `trapFocus` prop

### DIFF
--- a/.changeset/cold-horses-destroy.md
+++ b/.changeset/cold-horses-destroy.md
@@ -1,0 +1,5 @@
+---
+"bits-ui": patch
+---
+
+fix(Context Menu): forward `trapFocus` prop

--- a/packages/bits-ui/src/lib/bits/context-menu/components/context-menu-content.svelte
+++ b/packages/bits-ui/src/lib/bits/context-menu/components/context-menu-content.svelte
@@ -23,6 +23,7 @@
 		// the default menu behavior of handling outside interactions on the trigger
 		onEscapeKeydown = noop,
 		forceMount = false,
+		trapFocus = true,
 		...restProps
 	}: ContextMenuContentProps = $props();
 
@@ -76,7 +77,7 @@
 		onEscapeKeydown={handleEscapeKeydown}
 		{onOpenAutoFocus}
 		{isValidEvent}
-		trapFocus
+		{trapFocus}
 		{loop}
 		{id}
 	>
@@ -109,7 +110,7 @@
 		onEscapeKeydown={handleEscapeKeydown}
 		{onOpenAutoFocus}
 		{isValidEvent}
-		trapFocus
+		{trapFocus}
 		{loop}
 		{id}
 	>

--- a/packages/bits-ui/src/lib/bits/menu/components/menu-sub-content-static.svelte
+++ b/packages/bits-ui/src/lib/bits/menu/components/menu-sub-content-static.svelte
@@ -25,6 +25,7 @@
 		onOpenAutoFocus: onOpenAutoFocusProp = noop,
 		onCloseAutoFocus: onCloseAutoFocusProp = noop,
 		onFocusOutside = noop,
+		trapFocus = false,
 		...restProps
 	}: MenuSubContentStaticProps = $props();
 
@@ -115,7 +116,7 @@
 		onFocusOutside={handleOnFocusOutside}
 		preventScroll={false}
 		{loop}
-		trapFocus={false}
+		{trapFocus}
 		isStatic
 	>
 		{#snippet popper({ props })}
@@ -145,7 +146,7 @@
 		onFocusOutside={handleOnFocusOutside}
 		preventScroll={false}
 		{loop}
-		trapFocus={false}
+		{trapFocus}
 		isStatic
 	>
 		{#snippet popper({ props })}

--- a/packages/bits-ui/src/lib/bits/menu/components/menu-sub-content.svelte
+++ b/packages/bits-ui/src/lib/bits/menu/components/menu-sub-content.svelte
@@ -26,6 +26,7 @@
 		onCloseAutoFocus: onCloseAutoFocusProp = noop,
 		onFocusOutside = noop,
 		side = "right",
+		trapFocus = false,
 		...restProps
 	}: MenuSubContentProps = $props();
 
@@ -117,7 +118,7 @@
 		onFocusOutside={handleOnFocusOutside}
 		preventScroll={false}
 		{loop}
-		trapFocus={false}
+		{trapFocus}
 	>
 		{#snippet popper({ props, wrapperProps })}
 			{@const finalProps = mergeProps(props, mergedProps, {
@@ -152,7 +153,7 @@
 		onFocusOutside={handleOnFocusOutside}
 		preventScroll={false}
 		{loop}
-		trapFocus={false}
+		{trapFocus}
 	>
 		{#snippet popper({ props, wrapperProps })}
 			{@const finalProps = mergeProps(props, mergedProps, {


### PR DESCRIPTION
Some components accept `trapFocus` prop, but don't correctly forward it to the underlying components.

There are also some components that *don't* accept a `trapFocus` prop, but I left those intact because I'm not sure if that's intentional.