### PR TITLE
docs: add hero to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,14 +5,16 @@
 [![npm version](https://flat.badgen.net/npm/v/bits-ui?color=pink)](https://npmjs.com/package/bits-ui)
 [![npm downloads](https://flat.badgen.net/npm/dm/bits-ui?color=pink)](https://npmjs.com/package/bits-ui)
 [![license](https://flat.badgen.net/github/license/huntabyte/bits-ui?color=pink)](https://github.com/huntabyte/bits-ui/blob/main/LICENSE)
-
-<!-- /automd -->
-
 [![](https://dcbadge.vercel.app/api/server/fdXy3Sk8Gq?style=flat)](https://discord.gg/fdXy3Sk8Gq)
 
-The headless components for Svelte.
+<img style="max-width: 100%" alt="hero" src="https://github.com/user-attachments/assets/19cac792-6a93-4289-b9c7-647794a7de79" />
 
-[Read the docs](https://bits-ui.com)
+**Bits UI** – the headless components for Svelte.
+
+Flexible, unstyled, and accessible primitives that provide the foundation for building your own high-quality component library.
+
+## Documentation
+Visit https://bits-ui.com/docs to view the documentation. 
 
 ## Credits
 


### PR DESCRIPTION
Added a modified screen capture from Bits UI homepage to freshen up the readme. I think the example components are really nice looking and deserves a place there. Feel free to close the PR if not suitable 👍 

<img width="928" alt="image" src="https://github.com/user-attachments/assets/eb8a121c-cac7-4105-9b7b-f638ea5bf85b" />
