### PR TITLE
fix(Command): command sort only once per tick

### DIFF
--- a/.changeset/slimy-kings-turn.md
+++ b/.changeset/slimy-kings-turn.md
@@ -1,0 +1,5 @@
+---
+"bits-ui": patch
+---
+
+fix(Command): command sort only once per tick


### PR DESCRIPTION
When you use `Command` with a large number of items it lags every time you open it because all elements are sorted once for each item that is added instead of once after all items are added.