### PR TITLE
docs: correct typo in menubar.md code snippet (#1314)

### DIFF
--- a/sites/docs/content/components/menubar.md
+++ b/sites/docs/content/components/menubar.md
@@ -179,7 +179,7 @@ You can also use the `onValueChange` prop to update local state when the menubar
 
 <Menubar.Root
 	value={activeValue}
-	onOpenChange={(value) => {
+	onValueChange={(value) => {
 		activeValue = value;
 		// additional logic here.
 	}}


### PR DESCRIPTION
This pull request fixes a typo in the `menubar.md` file. It corrects the mismatch in the code snippet by using the `onValueChange` prop as described in the paragraph. Resolves issue #1314.
