### PR TITLE
docs: correct typo in styling.md code snippet

### DIFF
--- a/docs/content/styling.md
+++ b/docs/content/styling.md
@@ -77,7 +77,7 @@ Use the global class with the component:
 	import { Accordion } from "bits-ui";
 </script>
 
-<Accordion.Trigger class="button">Click me</Accordion.Trigger>
+<Accordion.Trigger class="accordion-trigger">Click me</Accordion.Trigger>
 ```
 
 ### Scoped Styles


### PR DESCRIPTION
This pull request fixes a typo in the `styling.md` file. It updates the incorrect class name `button` to `accordion-trigger`, which is the correct global class defined in the `app.css` code snippet under `Global Classes`.