### PR TITLE
fix(Select): enable space support in typeahead logic

### DIFF
--- a/.changeset/nice-wolves-jog.md
+++ b/.changeset/nice-wolves-jog.md
@@ -1,0 +1,5 @@
+---
+"bits-ui": patch
+---
+
+fix(Select): enable space support in typeahead logic

--- a/docs/src/lib/components/demos/select-demo.svelte
+++ b/docs/src/lib/components/demos/select-demo.svelte
@@ -12,6 +12,7 @@
 		{ value: "svelte-orange", label: "Svelte Orange" },
 		{ value: "punk-pink", label: "Punk Pink" },
 		{ value: "ocean-blue", label: "Ocean Blue", disabled: true },
+		{ value: "sunset-orange", label: "Sunset Orange" },
 		{ value: "sunset-red", label: "Sunset Red" },
 		{ value: "forest-green", label: "Forest Green" },
 		{ value: "lavender-purple", label: "Lavender Purple", disabled: true },

--- a/packages/bits-ui/src/lib/internal/arrays.test.ts
+++ b/packages/bits-ui/src/lib/internal/arrays.test.ts
@@ -424,6 +424,17 @@ describe("getNextMatch", () => {
 		expect(getNextMatch(prefixValues, "o")).toBe("other");
 		expect(getNextMatch(prefixValues, "o", "other")).toBe(undefined);
 	});
+
+	it("should handle search with spaces", () => {
+		const spaceValues = ["apple pie", "banana split", "banana bread", "cherry tart"];
+		expect(getNextMatch(spaceValues, "b")).toBe("banana split");
+		expect(getNextMatch(spaceValues, "banana ")).toBe("banana split");
+		expect(getNextMatch(spaceValues, "banana b")).toBe("banana bread");
+		expect(getNextMatch(spaceValues, "banana s")).toBe("banana split");
+		expect(getNextMatch(spaceValues, "banana  ")).toBe(undefined);
+		expect(getNextMatch(spaceValues, "apple")).toBe("apple pie");
+		expect(getNextMatch(spaceValues, "apple p")).toBe("apple pie");
+	});
 });
 
 describe("wrapArray", () => {

--- a/packages/bits-ui/src/lib/internal/use-data-typeahead.svelte.ts
+++ b/packages/bits-ui/src/lib/internal/use-data-typeahead.svelte.ts
@@ -1,3 +1,4 @@
+import type { Getter } from "svelte-toolbelt";
 import { getNextMatch } from "./arrays.js";
 import { boxAutoReset } from "./box-auto-reset.svelte.js";
 
@@ -6,14 +7,16 @@ export type DataTypeahead = ReturnType<typeof useDataTypeahead>;
 type UseDataTypeaheadOpts = {
 	onMatch: (value: string) => void;
 	getCurrentItem: () => string;
+	candidateValues: Getter<string[]>;
 	enabled: boolean;
 };
 
 export function useDataTypeahead(opts: UseDataTypeaheadOpts) {
 	// Reset `search` 1 second after it was last updated
 	const search = boxAutoReset("", 1000);
+	const candidateValues = $derived(opts.candidateValues());
 
-	function handleTypeaheadSearch(key: string, candidateValues: string[]) {
+	function handleTypeaheadSearch(key: string) {
 		if (!opts.enabled) return;
 		if (!candidateValues.length) return;
 

--- a/packages/bits-ui/src/lib/internal/use-dom-typeahead.svelte.ts
+++ b/packages/bits-ui/src/lib/internal/use-dom-typeahead.svelte.ts
@@ -21,11 +21,11 @@ export function useDOMTypeahead(opts?: UseDOMTypeaheadOpts) {
 
 		search.current = search.current + key;
 		const currentItem = getCurrentItem();
-		const currentMatch =
-			candidates.find((item) => item === currentItem)?.textContent?.trim() ?? "";
-		const values = candidates.map((item) => item.textContent?.trim() ?? "");
+
+		const currentMatch = candidates.find((item) => item === currentItem)?.textContent ?? "";
+		const values = candidates.map((item) => item.textContent ?? "");
 		const nextMatch = getNextMatch(values, search.current, currentMatch);
-		const newItem = candidates.find((item) => item.textContent?.trim() === nextMatch);
+		const newItem = candidates.find((item) => item.textContent === nextMatch);
 		if (newItem) {
 			onMatch(newItem);
 		}


### PR DESCRIPTION
This PR enhances the typeahead logic in the `Select` component, particularly to intelligently support spaces in typeahead searches.

For example, in the following video, you'll notice that since `Dark Green` is the only possible match of "dark+space", pressing space after dark will select it, but since there are multiple "Sunset+space" options, it will respect the space as long as it's typed within 1 second of the previous character, and not select/close.


https://github.com/user-attachments/assets/ab6568d0-d2fd-46cc-a3b5-ac7d14ef943d



Closes #1304  