### PR TITLE
docs: correct typo in APISchema descriptions for `group` in dropdown-menu.api.ts and context-menu.api.ts

### DIFF
--- a/docs/src/lib/content/api-reference/context-menu.api.ts
+++ b/docs/src/lib/content/api-reference/context-menu.api.ts
@@ -190,7 +190,7 @@ export const subContentStatic = createApiSchema<ContextMenuSubContentStaticProps
 export const group = createApiSchema<ContextMenuGroupPropsWithoutHTML>({
 	title: "Group",
 	description:
-		"A group of menu items. It should be passed an `aria-label` or have a child `Menu.GroupHeading` component to provide a label for a group of menu items.",
+		"A group of menu items. It should be passed an `aria-label` or have a child `ContextMenu.GroupHeading` component to provide a label for a group of menu items.",
 	...menu.group,
 });
 

--- a/docs/src/lib/content/api-reference/dropdown-menu.api.ts
+++ b/docs/src/lib/content/api-reference/dropdown-menu.api.ts
@@ -139,7 +139,7 @@ export const subContentStatic = createApiSchema<DropdownMenuSubContentStaticProp
 export const group = createApiSchema<DropdownMenuGroupPropsWithoutHTML>({
 	title: "Group",
 	description:
-		"A group of menu items. It should be passed an `aria-label` or have a child `Menu.GroupHeading` component to provide a label for a group of menu items.",
+		"A group of menu items. It should be passed an `aria-label` or have a child `DropdownMenu.GroupHeading` component to provide a label for a group of menu items.",
 	...menu.group,
 });
 


### PR DESCRIPTION
This PR corrects a typo in the description property of the `group` const in the following files:

docs/src/lib/content/api-reference/dropdown-menu.api.ts
docs/src/lib/content/api-reference/context-menu.api.ts

The updated description now correctly references its child `GroupHeading` component.