### PR TITLE
Fix date formatting in date-value attribute

### DIFF
--- a/.changeset/silver-poets-run.md
+++ b/.changeset/silver-poets-run.md
@@ -1,0 +1,5 @@
+---
+"bits-ui": patch
+---
+
+fix: bug with date formatting in date-value attribute

--- a/packages/bits-ui/src/lib/bits/calendar/calendar.svelte.ts
+++ b/packages/bits-ui/src/lib/bits/calendar/calendar.svelte.ts
@@ -43,7 +43,7 @@ import {
 	useMonthViewOptionsSync,
 	useMonthViewPlaceholderSync,
 } from "$lib/internal/date-time/calendar-helpers.svelte.js";
-import { isBefore, toDate } from "$lib/internal/date-time/utils.js";
+import { getDateValueType, isBefore, toDate } from "$lib/internal/date-time/utils.js";
 
 type CalendarRootStateProps = WithRefProps<
 	WritableBoxedValues<{
@@ -549,7 +549,8 @@ class CalendarCellState {
 				"data-outside-visible-months": this.isOutsideVisibleMonths ? "" : undefined,
 				"data-focused": this.isFocusedDate ? "" : undefined,
 				"data-selected": getDataSelected(this.isSelectedDate),
-				"data-value": this.opts.date.current.toAbsoluteString(),
+				"data-value": this.opts.date.current.toString(),
+				"data-type": getDateValueType(this.opts.date.current),
 				"data-disabled": getDataDisabled(
 					this.isDisabled ||
 						(this.isOutsideMonth && this.root.opts.disableDaysOutsideMonth.current)

--- a/packages/bits-ui/src/lib/bits/calendar/calendar.svelte.ts
+++ b/packages/bits-ui/src/lib/bits/calendar/calendar.svelte.ts
@@ -549,7 +549,7 @@ class CalendarCellState {
 				"data-outside-visible-months": this.isOutsideVisibleMonths ? "" : undefined,
 				"data-focused": this.isFocusedDate ? "" : undefined,
 				"data-selected": getDataSelected(this.isSelectedDate),
-				"data-value": this.opts.date.current.toString(),
+				"data-value": this.opts.date.current.toAbsoluteString(),
 				"data-disabled": getDataDisabled(
 					this.isDisabled ||
 						(this.isOutsideMonth && this.root.opts.disableDaysOutsideMonth.current)

--- a/packages/bits-ui/src/lib/bits/date-field/date-field.svelte.ts
+++ b/packages/bits-ui/src/lib/bits/date-field/date-field.svelte.ts
@@ -662,7 +662,7 @@ export class DateFieldInputState {
 class DateFieldHiddenInputState {
 	shouldRender = $derived.by(() => this.root.name !== "");
 	isoValue = $derived.by(() =>
-		this.root.value.current ? this.root.value.current.toAbsoluteString() : ""
+		this.root.value.current ? this.root.value.current.toString() : ""
 	);
 
 	constructor(readonly root: DateFieldRootState) {}

--- a/packages/bits-ui/src/lib/bits/date-field/date-field.svelte.ts
+++ b/packages/bits-ui/src/lib/bits/date-field/date-field.svelte.ts
@@ -662,7 +662,7 @@ export class DateFieldInputState {
 class DateFieldHiddenInputState {
 	shouldRender = $derived.by(() => this.root.name !== "");
 	isoValue = $derived.by(() =>
-		this.root.value.current ? this.root.value.current.toString() : ""
+		this.root.value.current ? this.root.value.current.toAbsoluteString() : ""
 	);
 
 	constructor(readonly root: DateFieldRootState) {}

--- a/packages/bits-ui/src/lib/bits/range-calendar/range-calendar.svelte.ts
+++ b/packages/bits-ui/src/lib/bits/range-calendar/range-calendar.svelte.ts
@@ -44,6 +44,7 @@ import {
 } from "$lib/internal/date-time/calendar-helpers.svelte.js";
 import {
 	areAllDaysBetweenValid,
+	getDateValueType,
 	isAfter,
 	isBefore,
 	isBetweenInclusive,
@@ -646,7 +647,8 @@ export class RangeCalendarCellState {
 				"data-selection-end": this.isSelectionEnd ? "" : undefined,
 				"data-highlighted": this.isHighlighted ? "" : undefined,
 				"data-selected": getDataSelected(this.isSelectedDate),
-				"data-value": this.opts.date.current.toAbsoluteString(),
+				"data-value": this.opts.date.current.toString(),
+				"data-type": getDateValueType(this.opts.date.current),
 				"data-disabled": getDataDisabled(
 					this.isDisabled ||
 						(this.isOutsideMonth && this.root.opts.disableDaysOutsideMonth.current)

--- a/packages/bits-ui/src/lib/bits/range-calendar/range-calendar.svelte.ts
+++ b/packages/bits-ui/src/lib/bits/range-calendar/range-calendar.svelte.ts
@@ -646,7 +646,7 @@ export class RangeCalendarCellState {
 				"data-selection-end": this.isSelectionEnd ? "" : undefined,
 				"data-highlighted": this.isHighlighted ? "" : undefined,
 				"data-selected": getDataSelected(this.isSelectedDate),
-				"data-value": this.opts.date.current.toString(),
+				"data-value": this.opts.date.current.toAbsoluteString(),
 				"data-disabled": getDataDisabled(
 					this.isDisabled ||
 						(this.isOutsideMonth && this.root.opts.disableDaysOutsideMonth.current)

--- a/packages/bits-ui/src/lib/internal/date-time/calendar-helpers.svelte.ts
+++ b/packages/bits-ui/src/lib/internal/date-time/calendar-helpers.svelte.ts
@@ -15,6 +15,7 @@ import {
 	getNextLastDayOfWeek,
 	isAfter,
 	isBefore,
+	parseAnyDateValue,
 	parseStringToDateValue,
 	toDate,
 } from "./utils.js";
@@ -731,15 +732,17 @@ export function pickerOpenFocus(e: Event) {
 	}
 }
 
-export function getFirstNonDisabledDateInView(calendarRef: HTMLElement): CalendarDate | undefined {
+export function getFirstNonDisabledDateInView(calendarRef: HTMLElement): DateValue | undefined {
 	if (!isBrowser) return;
 	const daysInView = Array.from(
 		calendarRef.querySelectorAll<HTMLElement>("[data-bits-day]:not([aria-disabled=true])")
 	);
 	if (daysInView.length === 0) return;
-	const value = daysInView[0]?.getAttribute("data-value");
-	if (!value) return;
-	return parseDate(value);
+	const element = daysInView[0];
+	const value = element?.getAttribute("data-value");
+	const type = element?.getAttribute("data-type");
+	if (!value || !type) return;
+	return parseAnyDateValue(value, type);
 }
 
 /**

--- a/packages/bits-ui/src/lib/internal/date-time/calendar-helpers.svelte.ts
+++ b/packages/bits-ui/src/lib/internal/date-time/calendar-helpers.svelte.ts
@@ -1,10 +1,8 @@
 import {
-	CalendarDate,
 	type DateValue,
 	endOfMonth,
 	isSameDay,
 	isSameMonth,
-	parseDate,
 	startOfMonth,
 } from "@internationalized/date";
 import { type ReadableBox, type WritableBox, afterTick, styleToString } from "svelte-toolbelt";

--- a/packages/bits-ui/src/lib/internal/date-time/utils.ts
+++ b/packages/bits-ui/src/lib/internal/date-time/utils.ts
@@ -102,10 +102,14 @@ export function getDateValueType(date: DateValue): string {
 
 export function parseAnyDateValue(value: string, type: string): DateValue {
 	switch (type) {
-		case "date": return parseDate(value);
-		case "datetime": return parseDateTime(value);
-		case "zoneddatetime": return parseZonedDateTime(value);
-		default: throw new Error(`Unknown date type: ${type}`);
+		case "date":
+			return parseDate(value);
+		case "datetime":
+			return parseDateTime(value);
+		case "zoneddatetime":
+			return parseZonedDateTime(value);
+		default:
+			throw new Error(`Unknown date type: ${type}`);
 	}
 }
 

--- a/packages/bits-ui/src/lib/internal/date-time/utils.ts
+++ b/packages/bits-ui/src/lib/internal/date-time/utils.ts
@@ -93,6 +93,22 @@ export function toDate(dateValue: DateValue, tz: string = getLocalTimeZone()) {
 	}
 }
 
+export function getDateValueType(date: DateValue): string {
+	if (date instanceof CalendarDate) return "date";
+	if (date instanceof CalendarDateTime) return "datetime";
+	if (date instanceof ZonedDateTime) return "zoneddatetime";
+	throw new Error("Unknown date type");
+}
+
+export function parseAnyDateValue(value: string, type: string): DateValue {
+	switch (type) {
+		case "date": return parseDate(value);
+		case "datetime": return parseDateTime(value);
+		case "zoneddatetime": return parseZonedDateTime(value);
+		default: throw new Error(`Unknown date type: ${type}`);
+	}
+}
+
 function isCalendarDateTime(dateValue: DateValue): dateValue is CalendarDateTime {
 	return dateValue instanceof CalendarDateTime;
 }


### PR DESCRIPTION
This PR fixes a regression introduced in v1.3.6 (PR #1264) affecting date serialization. 

## Issue
The current implementation uses @internationalized/date `toString()` for serializing `date-value` attribute. When the boxed `DateValue` is a `ZonedDateTime`, calling `toString()` includes timezone information, causing compatibility issues with the `parseDate` function call in `calendar-helpers.svelte.js` which seems to only be able to handle ISO 8601 UTC strings.

![image](https://github.com/user-attachments/assets/fa6cb509-f0e3-4956-8846-ac6dc1998f78)

## Solution
This PR modifies the date serialization to consistently use `toAbsoluteString()` instead, generating ISO 8601 UTC dates regardless of the underlying `DateValue` type. 