### PR TITLE
fix(Calendar): ensure default value is not a string

### DIFF
--- a/.changeset/red-wolves-hug.md
+++ b/.changeset/red-wolves-hug.md
@@ -1,0 +1,5 @@
+---
+"bits-ui": patch
+---
+
+fix(Calendar): ensure default value is not a string

--- a/packages/bits-ui/src/lib/bits/calendar/components/calendar.svelte
+++ b/packages/bits-ui/src/lib/bits/calendar/components/calendar.svelte
@@ -45,7 +45,7 @@
 	}
 
 	if (value === undefined) {
-		const defaultValue = type === "single" ? "" : [];
+		const defaultValue = type === "single" ? undefined : [];
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any
 		value = defaultValue as any;
 	}


### PR DESCRIPTION
Fixes #1355 