### PR TITLE
fix(FocusScope): safely call onCloseAutoFocus handler if defined

### DIFF
--- a/.changeset/thick-ducks-train.md
+++ b/.changeset/thick-ducks-train.md
@@ -1,0 +1,5 @@
+---
+"bits-ui": patch
+---
+
+fix(FocusScope): safely call onCloseAutoFocus handler if defined

--- a/packages/bits-ui/src/lib/bits/utilities/focus-scope/use-focus-scope.svelte.ts
+++ b/packages/bits-ui/src/lib/bits/utilities/focus-scope/use-focus-scope.svelte.ts
@@ -196,7 +196,7 @@ export function useFocusScope({
 
 	function handleClose(prevFocusedElement: HTMLElement | null) {
 		const destroyEvent = AutoFocusOnDestroyEvent.createEvent();
-		onCloseAutoFocus.current(destroyEvent);
+		onCloseAutoFocus.current?.(destroyEvent);
 
 		const shouldIgnore = ctx.ignoreCloseAutoFocus;
 		afterSleep(0, () => {


### PR DESCRIPTION
> if someone wants to look into this and add undefined checks (in places they really shouldn't need to be), then I will consider merging a PR to support compat mode

from discussion #1302

I tried to find out why the box is empty in compat mode, but no luck!

This pull request includes a small change to the `useFocusScope` function in the `packages/bits-ui/src/lib/bits/utilities/focus-scope/use-focus-scope.svelte.ts` file. The change ensures that the `onCloseAutoFocus.current` method is only called if it is not null or undefined.

* [`packages/bits-ui/src/lib/bits/utilities/focus-scope/use-focus-scope.svelte.ts`](diffhunk://#diff-1120b01d2c11483511424f952b216169ec73ea4b3e1d63f2fd791adda80c131fL199-R199): Added optional chaining to the `onCloseAutoFocus.current` method call to prevent potential errors when `onCloseAutoFocus.current` is null or undefined.
