### PR TITLE
fix(DateRangePicker): do not update start date automatically

### DIFF
--- a/.changeset/olive-apes-stare.md
+++ b/.changeset/olive-apes-stare.md
@@ -1,0 +1,5 @@
+---
+"bits-ui": patch
+---
+
+fix(DateRangeField): do not update start date automatically

--- a/.changeset/violet-plums-smash.md
+++ b/.changeset/violet-plums-smash.md
@@ -1,0 +1,5 @@
+---
+"bits-ui": patch
+---
+
+fix(DateRangePicker): do not update start date automatically

--- a/packages/bits-ui/src/lib/bits/date-range-field/date-range-field.svelte.ts
+++ b/packages/bits-ui/src/lib/bits/date-range-field/date-range-field.svelte.ts
@@ -126,18 +126,10 @@ export class DateRangeFieldRootState {
 						if (prev.start === startValue && prev.end === endValue) {
 							return prev;
 						}
-						if (isBefore(endValue, startValue)) {
-							const start = startValue;
-							const end = endValue;
-							this.#setStartValue(end);
-							this.#setEndValue(start);
-							return { start: endValue, end: startValue };
-						} else {
-							return {
-								start: startValue,
-								end: endValue,
-							};
-						}
+						return {
+							start: startValue,
+							end: endValue,
+						};
 					});
 				} else if (
 					this.opts.value.current &&
@@ -198,14 +190,6 @@ export class DateRangeFieldRootState {
 		const value = this.opts.value.current;
 		const newValue = cb(value);
 		this.opts.value.current = newValue;
-	}
-
-	#setStartValue(value: DateValue | undefined) {
-		this.opts.startValue.current = value;
-	}
-
-	#setEndValue(value: DateValue | undefined) {
-		this.opts.endValue.current = value;
 	}
 
 	props = $derived.by(

--- a/tests/src/tests/date-range-field/date-range-field.test.ts
+++ b/tests/src/tests/date-range-field/date-range-field.test.ts
@@ -203,3 +203,15 @@ it("should render an input for the start and end", async () => {
 	expect(container.querySelector('input[name="start-hidden-input"]')).toBeInTheDocument();
 	expect(container.querySelector('input[name="end-hidden-input"]')).toBeInTheDocument();
 });
+
+it("should populate calendar date with keyboard", async () => {
+	const { start, end, user } = setup({ value: calendarDate });
+
+	await user.click(start.month);
+
+	await user.keyboard("2142020");
+	await user.keyboard("2152020");
+
+	expect(start.value).toHaveTextContent("2020-02-14");
+	expect(end.value).toHaveTextContent("2020-02-15");
+});

--- a/tests/src/tests/date-range-field/date-range-field.test.ts
+++ b/tests/src/tests/date-range-field/date-range-field.test.ts
@@ -1,7 +1,7 @@
 import { render } from "@testing-library/svelte/svelte5";
 import { userEvent } from "@testing-library/user-event";
 import { axe } from "jest-axe";
-import { describe, it } from "vitest";
+import { it } from "vitest";
 import { CalendarDate, CalendarDateTime, toZoned } from "@internationalized/date";
 import { getTestKbd } from "../utils.js";
 import DateRangeFieldTest, { type DateRangeFieldTestProps } from "./date-range-field-test.svelte";
@@ -49,167 +49,157 @@ function setup(props: DateRangeFieldTestProps = {}) {
 	return { ...returned, user, start, end, root, startInput, endInput, label };
 }
 
-describe("date range field", () => {
-	it("should have no axe violations", async () => {
-		const { container } = setup();
-		expect(await axe(container)).toHaveNoViolations();
+it("should have no axe violations", async () => {
+	const { container } = setup();
+	expect(await axe(container)).toHaveNoViolations();
+});
+
+it("should populate segment with value - `CalendarDate`", async () => {
+	const { start, end } = setup({
+		value: calendarDate,
 	});
 
-	it("should populate segment with value - `CalendarDate`", async () => {
-		const { start, end } = setup({
-			value: calendarDate,
-		});
+	expect(start.month).toHaveTextContent(String(calendarDate.start.month));
+	expect(start.day).toHaveTextContent(String(calendarDate.start.day));
+	expect(start.year).toHaveTextContent(String(calendarDate.start.year));
+	expect(start.value).toHaveTextContent(calendarDate.start.toString());
 
-		expect(start.month).toHaveTextContent(String(calendarDate.start.month));
-		expect(start.day).toHaveTextContent(String(calendarDate.start.day));
-		expect(start.year).toHaveTextContent(String(calendarDate.start.year));
-		expect(start.value).toHaveTextContent(calendarDate.start.toString());
+	expect(end.month).toHaveTextContent(String(calendarDate.end.month));
+	expect(end.day).toHaveTextContent(String(calendarDate.end.day));
+	expect(end.year).toHaveTextContent(String(calendarDate.end.year));
+	expect(end.value).toHaveTextContent(calendarDate.end.toString());
+});
 
-		expect(end.month).toHaveTextContent(String(calendarDate.end.month));
-		expect(end.day).toHaveTextContent(String(calendarDate.end.day));
-		expect(end.year).toHaveTextContent(String(calendarDate.end.year));
-		expect(end.value).toHaveTextContent(calendarDate.end.toString());
+it("should populate segment with value - `CalendarDateTime`", async () => {
+	const { start, end, getByTestId } = setup({
+		value: calendarDateTime,
+		granularity: "second",
 	});
 
-	it("should populate segment with value - `CalendarDateTime`", async () => {
-		const { start, end, getByTestId } = setup({
-			value: calendarDateTime,
-			granularity: "second",
-		});
+	expect(start.month).toHaveTextContent(String(calendarDateTime.start.month));
+	expect(start.day).toHaveTextContent(String(calendarDateTime.start.day));
+	expect(start.year).toHaveTextContent(String(calendarDateTime.start.year));
+	expect(getByTestId("start-hour")).toHaveTextContent(String(calendarDateTime.start.hour));
+	expect(getByTestId("start-minute")).toHaveTextContent(String(calendarDateTime.start.minute));
+	expect(getByTestId("start-second")).toHaveTextContent(String(calendarDateTime.start.second));
+	expect(start.value).toHaveTextContent(calendarDateTime.start.toString());
 
-		expect(start.month).toHaveTextContent(String(calendarDateTime.start.month));
-		expect(start.day).toHaveTextContent(String(calendarDateTime.start.day));
-		expect(start.year).toHaveTextContent(String(calendarDateTime.start.year));
-		expect(getByTestId("start-hour")).toHaveTextContent(String(calendarDateTime.start.hour));
-		expect(getByTestId("start-minute")).toHaveTextContent(
-			String(calendarDateTime.start.minute)
-		);
-		expect(getByTestId("start-second")).toHaveTextContent(
-			String(calendarDateTime.start.second)
-		);
-		expect(start.value).toHaveTextContent(calendarDateTime.start.toString());
+	expect(end.month).toHaveTextContent(String(calendarDateTime.end.month));
+	expect(end.day).toHaveTextContent(String(calendarDateTime.end.day));
+	expect(end.year).toHaveTextContent(String(calendarDateTime.end.year));
+	expect(getByTestId("end-hour")).toHaveTextContent(String(calendarDateTime.end.hour));
+	expect(getByTestId("end-minute")).toHaveTextContent(String(calendarDateTime.end.minute));
+	expect(getByTestId("end-second")).toHaveTextContent(String(calendarDateTime.end.second));
+	expect(end.value).toHaveTextContent(calendarDateTime.end.toString());
+});
 
-		expect(end.month).toHaveTextContent(String(calendarDateTime.end.month));
-		expect(end.day).toHaveTextContent(String(calendarDateTime.end.day));
-		expect(end.year).toHaveTextContent(String(calendarDateTime.end.year));
-		expect(getByTestId("end-hour")).toHaveTextContent(String(calendarDateTime.end.hour));
-		expect(getByTestId("end-minute")).toHaveTextContent(String(calendarDateTime.end.minute));
-		expect(getByTestId("end-second")).toHaveTextContent(String(calendarDateTime.end.second));
-		expect(end.value).toHaveTextContent(calendarDateTime.end.toString());
+it("should populate segment with value - `ZonedDateTime`", async () => {
+	const { start, end, getByTestId } = setup({
+		value: zonedDateTime,
+		granularity: "second",
 	});
 
-	it("should populate segment with value - `ZonedDateTime`", async () => {
-		const { start, end, getByTestId } = setup({
-			value: zonedDateTime,
-			granularity: "second",
-		});
+	expect(start.month).toHaveTextContent(String(calendarDateTime.start.month));
+	expect(start.day).toHaveTextContent(String(calendarDateTime.start.day));
+	expect(start.year).toHaveTextContent(String(calendarDateTime.start.year));
+	expect(getByTestId("start-hour")).toHaveTextContent(String(calendarDateTime.start.hour));
+	expect(getByTestId("start-minute")).toHaveTextContent(String(calendarDateTime.start.minute));
+	expect(getByTestId("start-second")).toHaveTextContent(String(calendarDateTime.start.second));
+	expect(start.value).toHaveTextContent(calendarDateTime.start.toString());
 
-		expect(start.month).toHaveTextContent(String(calendarDateTime.start.month));
-		expect(start.day).toHaveTextContent(String(calendarDateTime.start.day));
-		expect(start.year).toHaveTextContent(String(calendarDateTime.start.year));
-		expect(getByTestId("start-hour")).toHaveTextContent(String(calendarDateTime.start.hour));
-		expect(getByTestId("start-minute")).toHaveTextContent(
-			String(calendarDateTime.start.minute)
-		);
-		expect(getByTestId("start-second")).toHaveTextContent(
-			String(calendarDateTime.start.second)
-		);
-		expect(start.value).toHaveTextContent(calendarDateTime.start.toString());
+	expect(end.month).toHaveTextContent(String(calendarDateTime.end.month));
+	expect(end.day).toHaveTextContent(String(calendarDateTime.end.day));
+	expect(end.year).toHaveTextContent(String(calendarDateTime.end.year));
+	expect(getByTestId("end-hour")).toHaveTextContent(String(calendarDateTime.end.hour));
+	expect(getByTestId("end-minute")).toHaveTextContent(String(calendarDateTime.end.minute));
+	expect(getByTestId("end-second")).toHaveTextContent(String(calendarDateTime.end.second));
+	expect(end.value).toHaveTextContent(calendarDateTime.end.toString());
+});
 
-		expect(end.month).toHaveTextContent(String(calendarDateTime.end.month));
-		expect(end.day).toHaveTextContent(String(calendarDateTime.end.day));
-		expect(end.year).toHaveTextContent(String(calendarDateTime.end.year));
-		expect(getByTestId("end-hour")).toHaveTextContent(String(calendarDateTime.end.hour));
-		expect(getByTestId("end-minute")).toHaveTextContent(String(calendarDateTime.end.minute));
-		expect(getByTestId("end-second")).toHaveTextContent(String(calendarDateTime.end.second));
-		expect(end.value).toHaveTextContent(calendarDateTime.end.toString());
+it("should navigate between the fields", async () => {
+	const { getByTestId, user } = setup({
+		value: calendarDate,
 	});
 
-	it("should navigate between the fields", async () => {
-		const { getByTestId, user } = setup({
-			value: calendarDate,
-		});
+	const fields = ["start", "end"] as const;
+	const segments = ["month", "day", "year"] as const;
 
-		const fields = ["start", "end"] as const;
-		const segments = ["month", "day", "year"] as const;
+	await user.click(getByTestId("start-month"));
 
-		await user.click(getByTestId("start-month"));
-
-		for (const field of fields) {
-			for (const segment of segments) {
-				if (field === "start" && segment === "month") continue;
-				const seg = getByTestId(`${field}-${segment}`);
-				await user.keyboard(kbd.ARROW_RIGHT);
-				expect(seg).toHaveFocus();
-			}
+	for (const field of fields) {
+		for (const segment of segments) {
+			if (field === "start" && segment === "month") continue;
+			const seg = getByTestId(`${field}-${segment}`);
+			await user.keyboard(kbd.ARROW_RIGHT);
+			expect(seg).toHaveFocus();
 		}
+	}
 
-		await user.click(getByTestId("start-month"));
+	await user.click(getByTestId("start-month"));
 
-		for (const field of fields) {
-			for (const segment of segments) {
-				if (field === "start" && segment === "month") continue;
-				const seg = getByTestId(`${field}-${segment}`);
-				await user.keyboard(kbd.TAB);
-				expect(seg).toHaveFocus();
-			}
+	for (const field of fields) {
+		for (const segment of segments) {
+			if (field === "start" && segment === "month") continue;
+			const seg = getByTestId(`${field}-${segment}`);
+			await user.keyboard(kbd.TAB);
+			expect(seg).toHaveFocus();
 		}
+	}
+});
+
+it("should navigate between the fields - right to left", async () => {
+	const { getByTestId, user } = setup({
+		value: calendarDate,
 	});
 
-	it("should navigate between the fields - right to left", async () => {
-		const { getByTestId, user } = setup({
-			value: calendarDate,
-		});
+	const fields = ["end", "start"] as const;
+	const segments = ["year", "day", "month"] as const;
 
-		const fields = ["end", "start"] as const;
-		const segments = ["year", "day", "month"] as const;
+	await user.click(getByTestId("end-year"));
 
-		await user.click(getByTestId("end-year"));
-
-		for (const field of fields) {
-			for (const segment of segments) {
-				if (field === "end" && segment === "year") continue;
-				const seg = getByTestId(`${field}-${segment}`);
-				await user.keyboard(kbd.ARROW_LEFT);
-				expect(seg).toHaveFocus();
-			}
+	for (const field of fields) {
+		for (const segment of segments) {
+			if (field === "end" && segment === "year") continue;
+			const seg = getByTestId(`${field}-${segment}`);
+			await user.keyboard(kbd.ARROW_LEFT);
+			expect(seg).toHaveFocus();
 		}
+	}
 
-		await user.click(getByTestId("end-year"));
+	await user.click(getByTestId("end-year"));
 
-		for (const field of fields) {
-			for (const segment of segments) {
-				if (field === "end" && segment === "year") continue;
-				const seg = getByTestId(`${field}-${segment}`);
-				await user.keyboard(kbd.SHIFT_TAB);
-				expect(seg).toHaveFocus();
-			}
+	for (const field of fields) {
+		for (const segment of segments) {
+			if (field === "end" && segment === "year") continue;
+			const seg = getByTestId(`${field}-${segment}`);
+			await user.keyboard(kbd.SHIFT_TAB);
+			expect(seg).toHaveFocus();
 		}
-	});
+	}
+});
 
-	it("should respect `bind:value` to the value", async () => {
-		const { start, end, user } = setup({
-			value: calendarDate,
-		});
-		expect(start.value).toHaveTextContent(calendarDate.start.toString());
-		expect(end.value).toHaveTextContent(calendarDate.end.toString());
-
-		await user.click(start.month);
-		await user.keyboard("2");
-		expect(start.value).toHaveTextContent("2022-02-01");
-		expect(end.value).toHaveTextContent(calendarDate.end.toString());
+it("should respect `bind:value` to the value", async () => {
+	const { start, end, user } = setup({
+		value: calendarDate,
 	});
+	expect(start.value).toHaveTextContent(calendarDate.start.toString());
+	expect(end.value).toHaveTextContent(calendarDate.end.toString());
 
-	it("should render an input for the start and end", async () => {
-		const { container } = setup({
-			startProps: {
-				name: "start-hidden-input",
-			},
-			endProps: {
-				name: "end-hidden-input",
-			},
-		});
-		expect(container.querySelector('input[name="start-hidden-input"]')).toBeInTheDocument();
-		expect(container.querySelector('input[name="end-hidden-input"]')).toBeInTheDocument();
+	await user.click(start.month);
+	await user.keyboard("2");
+	expect(start.value).toHaveTextContent("2022-02-01");
+	expect(end.value).toHaveTextContent(calendarDate.end.toString());
+});
+
+it("should render an input for the start and end", async () => {
+	const { container } = setup({
+		startProps: {
+			name: "start-hidden-input",
+		},
+		endProps: {
+			name: "end-hidden-input",
+		},
 	});
+	expect(container.querySelector('input[name="start-hidden-input"]')).toBeInTheDocument();
+	expect(container.querySelector('input[name="end-hidden-input"]')).toBeInTheDocument();
 });

--- a/tests/src/tests/date-range-picker/date-range-picker.test.ts
+++ b/tests/src/tests/date-range-picker/date-range-picker.test.ts
@@ -272,6 +272,18 @@ it("should respect `bind:value` to the value", async () => {
 	expect(end.value).toHaveTextContent(calendarDate.end.toString());
 });
 
+it("should populate calendar date with keyboard", async () => {
+	const { start, end, user } = setup({ value: calendarDate });
+
+	await user.click(start.month);
+
+	await user.keyboard("2142020");
+	await user.keyboard("2152020");
+
+	expect(start.value).toHaveTextContent("2020-02-14");
+	expect(end.value).toHaveTextContent("2020-02-15");
+});
+
 it("should render an input for the start and end", async () => {
 	const { container } = setup({
 		startProps: {


### PR DESCRIPTION
Keyboard input is currently broken on the `DateRangePicker`. This small change removes the logic to update the start date automatically so keyboard input works fine.

https://github.com/huntabyte/bits-ui/issues/1348