### PR TITLE
docs: use command input in structure example

### DIFF
--- a/docs/content/components/command.md
+++ b/docs/content/components/command.md
@@ -55,7 +55,7 @@ Here's an overview of how the Command component is structured in code:
 </script>
 
 <Command.Root>
-	<Combobox.Input />
+	<Command.Input />
 	<Command.List>
 		<Command.Viewport>
 			<Command.Empty />


### PR DESCRIPTION
This pull request replaces the combobox input with the command input in the command component's structure example.

Ref #1388 