### PR TITLE
fix(Dialog): ensure `Dialog.Title` has the "heading" role

### DIFF
--- a/packages/bits-ui/src/lib/bits/dialog/dialog.svelte.ts
+++ b/packages/bits-ui/src/lib/bits/dialog/dialog.svelte.ts
@@ -204,7 +204,7 @@ class DialogTitleState {
 		() =>
 			({
 				id: this.opts.id.current,
-				// role: "heading",
+				role: "heading",
 				"aria-level": this.opts.level.current,
 				[this.root.attrs.title]: "",
 				...this.root.sharedProps,

--- a/tests/src/tests/dialog/dialog.test.ts
+++ b/tests/src/tests/dialog/dialog.test.ts
@@ -203,6 +203,13 @@ it("should apply the correct `aria-describedby` attribute to the `Dialog.Content
 	expect(content).toHaveAttribute("aria-describedby", description.id);
 });
 
+it("should have role='heading'", async () => {
+	const { getByTestId } = await open();
+
+	const title = getByTestId("title");
+	expect(title).toHaveAttribute("role", "heading");
+});
+
 it("should apply a default `aria-level` attribute to the `Dialog.Title` element", async () => {
 	const { getByTestId } = await open();
 


### PR DESCRIPTION
Fixes https://github.com/huntabyte/bits-ui/issues/1417

It feels like you didn't mean to leave this commented-out 😅 

Maybe a `getByRole('heading')` test would be a good idea, but you don't use any `getByRole` selectors elsewhere, so I didn't want to start a trend you may not like 😄 