### PR TITLE
fix(Dialog): ensure `role="heading"` exists on title

### DIFF
--- a/.changeset/popular-ducks-smile.md
+++ b/.changeset/popular-ducks-smile.md
@@ -1,0 +1,5 @@
+---
+"bits-ui": patch
+---
+
+fix(Dialog): ensure `role="heading"` exists on title


### PR DESCRIPTION
Forgot to add changeset for #1417
