### PR TITLE
feat(Slider): Add slider thumb positioning prop

### DIFF
--- a/.changeset/little-clocks-worry.md
+++ b/.changeset/little-clocks-worry.md
@@ -1,0 +1,5 @@
+---
+"bits-ui": minor
+---
+
+feat(Slider): `thumbPositioning` for more granular control of thumb positioning

--- a/docs/src/lib/content/api-reference/extended-types/shared/index.ts
+++ b/docs/src/lib/content/api-reference/extended-types/shared/index.ts
@@ -33,6 +33,7 @@ export { default as RadioItemChildSnippetProps } from "./radio-item-child-snippe
 export { default as RadioItemChildrenSnippetProps } from "./radio-item-children-snippet-props.md";
 export { default as SegmentPartProp } from "./segment-part-prop.md";
 export { default as SingleOrMultipleProp } from "./single-or-multiple-prop.md";
+export { default as SliderThumbPositioningProp } from "./slider-thumb-positioning-prop.md";
 export { default as StringOrArrayStringProp } from "./string-or-array-string-prop.md";
 export { default as WeekdayFormatProp } from "./weekday-format-prop.md";
 export { default as OnDateValueChangeProp } from "./on-date-value-change-prop.md";

--- a/docs/src/lib/content/api-reference/extended-types/shared/slider-thumb-positioning-prop.md
+++ b/docs/src/lib/content/api-reference/extended-types/shared/slider-thumb-positioning-prop.md
@@ -1,0 +1,3 @@
+```ts
+"exact" | "contain";
+```

--- a/docs/src/lib/content/api-reference/slider.api.ts
+++ b/docs/src/lib/content/api-reference/slider.api.ts
@@ -5,7 +5,11 @@ import type {
 	SliderTickPropsWithoutHTML,
 } from "bits-ui";
 import { SliderRootOnValueChangeProp } from "./extended-types/slider/index.js";
-import { OrientationProp, SingleOrMultipleProp } from "./extended-types/shared/index.js";
+import {
+	OrientationProp,
+	SingleOrMultipleProp,
+	SliderThumbPositioningProp,
+} from "./extended-types/shared/index.js";
 import {
 	createApiSchema,
 	createBooleanProp,
@@ -75,6 +79,12 @@ const root = createApiSchema<SliderRootPropsWithoutHTML>({
 			default: C.TRUE,
 			description:
 				"Whether to automatically sort the values in the array when moving thumbs past one another. This is only applicable to the `'multiple'` type.",
+		}),
+		thumbPositioning: createEnumProp({
+			options: ["exact", "contain"],
+			default: "'contain'",
+			description: "The positioning of the slider thumb.",
+			definition: SliderThumbPositioningProp,
 		}),
 		...withChildProps({ elType: "HTMLSpanElement" }),
 	},

--- a/packages/bits-ui/src/lib/bits/slider/components/slider.svelte
+++ b/packages/bits-ui/src/lib/bits/slider/components/slider.svelte
@@ -22,6 +22,7 @@
 		dir = "ltr",
 		autoSort = true,
 		orientation = "horizontal",
+		thumbPositioning = "contain",
 		...restProps
 	}: SliderRootProps = $props();
 
@@ -63,6 +64,7 @@
 		dir: box.with(() => dir),
 		autoSort: box.with(() => autoSort),
 		orientation: box.with(() => orientation),
+		thumbPositioning: box.with(() => thumbPositioning),
 		type,
 	});
 

--- a/packages/bits-ui/src/lib/bits/slider/slider.svelte.ts
+++ b/packages/bits-ui/src/lib/bits/slider/slider.svelte.ts
@@ -24,7 +24,7 @@ import { isElementOrSVGElement } from "$lib/internal/is.js";
 import { isValidIndex } from "$lib/internal/arrays.js";
 import type { ReadableBoxedValues, WritableBoxedValues } from "$lib/internal/box.svelte.js";
 import type { BitsKeyboardEvent, OnChangeFn, WithRefProps } from "$lib/internal/types.js";
-import type { Direction, Orientation } from "$lib/shared/index.js";
+import type { Direction, Orientation, SliderThumbPositioning } from "$lib/shared/index.js";
 import { linearScale, snapValueToStep } from "$lib/internal/math.js";
 
 const SLIDER_ROOT_ATTR = "data-slider-root";
@@ -41,6 +41,7 @@ type SliderBaseRootStateProps = WithRefProps<
 		step: number;
 		dir: Direction;
 		autoSort: boolean;
+		thumbPositioning: SliderThumbPositioning;
 	}>
 >;
 
@@ -73,6 +74,11 @@ class SliderBaseRootState {
 	};
 
 	getThumbScale = (): [number, number] => {
+		if (this.opts.thumbPositioning.current === "exact") {
+			// User opted out of containment
+			return [0, 100];
+		}
+
 		const isVertical = this.opts.orientation.current === "vertical";
 
 		// this assumes all thumbs are the same width

--- a/packages/bits-ui/src/lib/bits/slider/types.ts
+++ b/packages/bits-ui/src/lib/bits/slider/types.ts
@@ -1,6 +1,6 @@
 import type { OnChangeFn, WithChild, Without } from "$lib/internal/types.js";
 import type { BitsPrimitiveSpanAttributes } from "$lib/shared/attributes.js";
-import type { Direction, Orientation } from "$lib/shared/index.js";
+import type { Direction, Orientation, SliderThumbPositioning } from "$lib/shared/index.js";
 
 export type SliderRootSnippetProps = {
 	ticks: number[];
@@ -60,6 +60,13 @@ export type BaseSliderRootPropsWithoutHTML = {
 	 * @defaultValue false
 	 */
 	disabled?: boolean;
+
+	/**
+	 * The positioning of the slider thumb.
+	 *
+	 * @defaultValue "contain"
+	 */
+	thumbPositioning?: SliderThumbPositioning;
 };
 
 export type SliderSingleRootPropsWithoutHTML = BaseSliderRootPropsWithoutHTML & {

--- a/packages/bits-ui/src/lib/shared/index.ts
+++ b/packages/bits-ui/src/lib/shared/index.ts
@@ -34,6 +34,14 @@ export type StyleProperties = CSS.Properties & {
 export type Orientation = "horizontal" | "vertical";
 export type Direction = "ltr" | "rtl";
 
+/**
+ * Controls positioning of the slider thumb.
+ *
+ * - `exact`: The thumb is centered exactly at the value of the slider.
+ * - `contain`: The thumb is centered exactly at the value of the slider, but will be contained within the slider track at the ends.
+ */
+export type SliderThumbPositioning = "exact" | "contain";
+
 export type WithoutChildrenOrChild<T> = WithoutChildren<WithoutChild<T>>;
 export type WithoutChildren<T> = T extends { children?: any } ? Omit<T, "children"> : T;
 export type WithoutChild<T> = T extends { child?: any } ? Omit<T, "child"> : T;


### PR DESCRIPTION
Looking for feedback before I add docs - not sure if this property should be moved to the thumbs themselves somehow

Motivation:
![image](https://github.com/user-attachments/assets/8c87c5e7-dd81-4da4-956b-db9f5d72c9e9)
With an equal padding around the slider, the containment makes alignment look 'off'.
