### PR TITLE
feat(Slider): Expose active state on thumb

### DIFF
--- a/.changeset/red-moles-greet.md
+++ b/.changeset/red-moles-greet.md
@@ -1,0 +1,5 @@
+---
+"bits-ui": minor
+---
+
+feat(Slider): expose thumb `active` state

--- a/docs/src/lib/components/demos/slider-demo-multiple.svelte
+++ b/docs/src/lib/components/demos/slider-demo-multiple.svelte
@@ -21,7 +21,7 @@
 				<Slider.Thumb
 					{index}
 					class={cn(
-						"border-border-input bg-background hover:border-dark-40 focus-visible:ring-foreground dark:bg-foreground dark:shadow-card focus-visible:outline-hidden block size-[25px] cursor-pointer rounded-full border shadow-sm transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 active:scale-[0.98] disabled:pointer-events-none disabled:opacity-50"
+						"border-border-input bg-background hover:border-dark-40 focus-visible:ring-foreground dark:bg-foreground dark:shadow-card focus-visible:outline-hidden data-active:scale-[0.98] data-active:border-dark-40 block size-[25px] cursor-pointer rounded-full border shadow-sm transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50"
 					)}
 				/>
 			{/each}

--- a/docs/src/lib/components/demos/slider-demo-ticks.svelte
+++ b/docs/src/lib/components/demos/slider-demo-ticks.svelte
@@ -22,7 +22,7 @@
 			{#each thumbs as thumb}
 				<Slider.Thumb
 					index={thumb}
-					class="border-border-input bg-background hover:border-dark-40 focus-visible:ring-foreground dark:bg-foreground dark:shadow-card focus-visible:outline-hidden z-5 block size-[25px] cursor-pointer rounded-full border shadow-sm transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 active:scale-[0.98] disabled:pointer-events-none disabled:opacity-50"
+					class="border-border-input bg-background hover:border-dark-40 focus-visible:ring-foreground dark:bg-foreground dark:shadow-card focus-visible:outline-hidden z-5 data-active:scale-[0.98] data-active:border-dark-40 block size-[25px] cursor-pointer rounded-full border shadow-sm transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50"
 				/>
 			{/each}
 			{#each ticks as tick}

--- a/docs/src/lib/components/demos/slider-demo.svelte
+++ b/docs/src/lib/components/demos/slider-demo.svelte
@@ -20,7 +20,7 @@
 			<Slider.Thumb
 				index={0}
 				class={cn(
-					"border-border-input bg-background hover:border-dark-40 focus-visible:ring-foreground dark:bg-foreground dark:shadow-card focus-visible:outline-hidden block size-[25px] cursor-pointer rounded-full border shadow-sm transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 active:scale-[0.98] disabled:pointer-events-none disabled:opacity-50"
+					"border-border-input bg-background hover:border-dark-40 focus-visible:ring-foreground dark:bg-foreground dark:shadow-card focus-visible:outline-hidden data-active:scale-[0.98] data-active:border-dark-40 block size-[25px] cursor-pointer rounded-full border shadow-sm transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50"
 				)}
 			/>
 		{/snippet}

--- a/docs/src/lib/content/api-reference/slider.api.ts
+++ b/docs/src/lib/content/api-reference/slider.api.ts
@@ -112,6 +112,10 @@ const thumb = createApiSchema<SliderThumbPropsWithoutHTML>({
 			name: "slider-thumb",
 			description: "Present on the thumb elements.",
 		}),
+		createDataAttrSchema({
+			name: "active",
+			description: "Present when the thumb is active/grabbed.",
+		}),
 	],
 });
 

--- a/packages/bits-ui/src/lib/bits/slider/components/slider-thumb.svelte
+++ b/packages/bits-ui/src/lib/bits/slider/components/slider-thumb.svelte
@@ -28,9 +28,14 @@
 </script>
 
 {#if child}
-	{@render child({ active: thumbState.root.isThumbActive(thumbState.opts.index.current), props: mergedProps })}
+	{@render child({
+		active: thumbState.root.isThumbActive(thumbState.opts.index.current),
+		props: mergedProps,
+	})}
 {:else}
 	<span {...mergedProps}>
-		{@render children?.({ active: thumbState.root.isThumbActive(thumbState.opts.index.current) })}
+		{@render children?.({
+			active: thumbState.root.isThumbActive(thumbState.opts.index.current),
+		})}
 	</span>
 {/if}

--- a/packages/bits-ui/src/lib/bits/slider/components/slider-thumb.svelte
+++ b/packages/bits-ui/src/lib/bits/slider/components/slider-thumb.svelte
@@ -28,9 +28,9 @@
 </script>
 
 {#if child}
-	{@render child({ active: thumbState.root.isActive, props: mergedProps })}
+	{@render child({ active: thumbState.root.isThumbActive(thumbState.opts.index.current), props: mergedProps })}
 {:else}
 	<span {...mergedProps}>
-		{@render children?.({ active: thumbState.root.isActive })}
+		{@render children?.({ active: thumbState.root.isThumbActive(thumbState.opts.index.current) })}
 	</span>
 {/if}

--- a/packages/bits-ui/src/lib/bits/slider/components/slider-thumb.svelte
+++ b/packages/bits-ui/src/lib/bits/slider/components/slider-thumb.svelte
@@ -28,9 +28,9 @@
 </script>
 
 {#if child}
-	{@render child({ props: mergedProps })}
+	{@render child({ active: thumbState.root.isActive, props: mergedProps })}
 {:else}
 	<span {...mergedProps}>
-		{@render children?.()}
+		{@render children?.({ active: thumbState.root.isActive })}
 	</span>
 {/if}

--- a/packages/bits-ui/src/lib/bits/slider/slider.svelte.ts
+++ b/packages/bits-ui/src/lib/bits/slider/slider.svelte.ts
@@ -61,6 +61,10 @@ class SliderBaseRootState {
 		useRefById(opts);
 	}
 
+	isThumbActive(_index: number) {
+		return this.isActive;
+	}
+
 	#touchAction = $derived.by(() => {
 		if (this.opts.disabled.current) return undefined;
 		return this.opts.orientation.current === "horizontal" ? "pan-y" : "pan-x";
@@ -397,6 +401,10 @@ class SliderMultiRootState extends SliderBaseRootState {
 				}
 			}
 		);
+	}
+
+	isThumbActive(index: number): boolean {
+		return this.isActive && this.activeThumb?.idx === index;
 	}
 
 	applyPosition({
@@ -829,6 +837,7 @@ class SliderThumbState {
 				...this.root.thumbsPropsArr[this.opts.index.current]!,
 				id: this.opts.id.current,
 				onkeydown: this.onkeydown,
+				"data-active": this.root.isThumbActive(this.opts.index.current) ? "" : undefined,
 			}) as const
 	);
 }

--- a/packages/bits-ui/src/lib/bits/slider/types.ts
+++ b/packages/bits-ui/src/lib/bits/slider/types.ts
@@ -140,20 +140,25 @@ export type SliderRangePropsWithoutHTML = WithChild;
 export type SliderRangeProps = SliderRangePropsWithoutHTML &
 	Without<BitsPrimitiveSpanAttributes, SliderRangePropsWithoutHTML>;
 
-export type SliderThumbPropsWithoutHTML = WithChild<{
-	/**
-	 * Whether the thumb is disabled or not.
-	 *
-	 * @defaultValue false
-	 */
-	disabled?: boolean;
+export type SliderThumbSnippetProps = { active: boolean };
 
-	/**
-	 * The index of the thumb in the array of thumbs provided by the `children` snippet prop of the
-	 * `Slider.Root` component.
-	 */
-	index: number;
-}>;
+export type SliderThumbPropsWithoutHTML = WithChild<
+	{
+		/**
+		 * Whether the thumb is disabled or not.
+		 *
+		 * @defaultValue false
+		 */
+		disabled?: boolean;
+
+		/**
+		 * The index of the thumb in the array of thumbs provided by the `children` snippet prop of the
+		 * `Slider.Root` component.
+		 */
+		index: number;
+	},
+	SliderThumbSnippetProps
+>;
 
 export type SliderThumbProps = SliderThumbPropsWithoutHTML &
 	Without<BitsPrimitiveSpanAttributes, SliderThumbPropsWithoutHTML>;


### PR DESCRIPTION
Also adjusts example styles to use the data attribute instead of the active pseudo class.

Maybe we should expose this as a bindable prop as well? Not sure.