### PR TITLE
fix(NavigationMenu): do not close `Sub` content when clicking the trigger

### DIFF
--- a/.changeset/kind-comics-exist.md
+++ b/.changeset/kind-comics-exist.md
@@ -1,0 +1,5 @@
+---
+"bits-ui": patch
+---
+
+fix(NavigationMenu): do not close `Sub` content when clicking the trigger

--- a/packages/bits-ui/src/lib/bits/navigation-menu/navigation-menu.svelte.ts
+++ b/packages/bits-ui/src/lib/bits/navigation-menu/navigation-menu.svelte.ts
@@ -439,12 +439,13 @@ class NavigationMenuTriggerState {
 	onclick = (_: BitsMouseEvent<HTMLButtonElement>) => {
 		// if opened via pointer move, we prevent the click event
 		if (this.hasPointerMoveOpened.current) return;
-		if (this.open) {
+		const shouldClose = this.open && this.context.opts.isRootMenu;
+		if (shouldClose) {
 			this.context.onItemSelect("");
-		} else {
+		} else if (!this.open) {
 			this.context.onItemSelect(this.itemContext.opts.value.current);
 		}
-		this.wasClickClose = this.open;
+		this.wasClickClose = shouldClose;
 	};
 
 	onkeydown = (e: BitsKeyboardEvent<HTMLButtonElement>) => {

--- a/tests/src/tests/navigation-menu/navigation-menu.test.ts
+++ b/tests/src/tests/navigation-menu/navigation-menu.test.ts
@@ -65,6 +65,9 @@ it("should show submenu items on subtrigger hover", async () => {
 	expect(queryByTestId("sub-group-item-sub-viewport")).toContainElement(
 		queryByTestId("sub-group-item-sub-item2-content")
 	);
+	// does not hide when clicking open subtrigger
+	await user.click(getByTestId("sub-group-item-sub-item2-trigger"));
+	expect(queryByTestId("sub-group-item-sub-item2-content")).not.toBeNull();
 });
 
 it("should open submenu viewport when pressing enter on focused subtrigger", async () => {
@@ -78,6 +81,9 @@ it("should open submenu viewport when pressing enter on focused subtrigger", asy
 	expect(getByTestId("sub-group-item-sub-viewport")).toContainElement(
 		getByTestId("sub-group-item-sub-item2-content")
 	);
+	// does not hide when re-pressing enter
+	await user.keyboard(kbd.ENTER);
+	expect(queryByTestId("sub-group-item-sub-item2-content")).not.toBeNull();
 });
 
 it("should show indicator when hovering trigger", async () => {


### PR DESCRIPTION
Addresses this [comment](https://github.com/huntabyte/bits-ui/issues/1458#issuecomment-2892198796) in #1458