### PR TITLE
fix(NavigationMenu): render `Content` without `Viewport`

### DIFF
--- a/.changeset/nasty-brooms-tease.md
+++ b/.changeset/nasty-brooms-tease.md
@@ -1,0 +1,5 @@
+---
+"bits-ui": patch
+---
+
+fix(NavigationMenu): render `Content` without `Viewport`

--- a/docs/src/lib/content/api-reference/helpers.ts
+++ b/docs/src/lib/content/api-reference/helpers.ts
@@ -42,6 +42,7 @@ type ElementKind =
 	| "HTMLInputElement"
 	| "HTMLUListElement"
 	| "HTMLLiElement"
+	| "HTMLNavElement"
 	| "HTMLElement";
 
 type SharedPropOptions = {

--- a/docs/src/lib/content/api-reference/navigation-menu.api.ts
+++ b/docs/src/lib/content/api-reference/navigation-menu.api.ts
@@ -5,6 +5,7 @@ import type {
 	NavigationMenuLinkPropsWithoutHTML,
 	NavigationMenuListPropsWithoutHTML,
 	NavigationMenuRootPropsWithoutHTML,
+	NavigationMenuSubPropsWithoutHTML,
 	NavigationMenuTriggerPropsWithoutHTML,
 	NavigationMenuViewportPropsWithoutHTML,
 } from "bits-ui";
@@ -35,7 +36,8 @@ export const root = createApiSchema<NavigationMenuRootPropsWithoutHTML>({
 		}),
 		onValueChange: createFunctionProp({
 			definition: OnStringValueChangeProp,
-			description: "A callback function called when the active menu value changes.",
+			description:
+				"A callback function called when the active menu value changes. Called with an empty string when the menu closes.",
 			stringDefinition: "(value: string) => void",
 		}),
 		dir: dirProp,
@@ -48,6 +50,30 @@ export const root = createApiSchema<NavigationMenuRootPropsWithoutHTML>({
 			default: "200",
 			description:
 				"The duration from when the mouse enters a trigger until the content opens.",
+		}),
+		orientation: createEnumProp({
+			options: ["horizontal", "vertical"],
+			default: "horizontal",
+			description: "The orientation of the menu.",
+			definition: OrientationProp,
+		}),
+		...withChildProps({ elType: "HTMLNavElement" }),
+	},
+});
+
+export const sub = createApiSchema<NavigationMenuSubPropsWithoutHTML>({
+	title: "Sub",
+	description:
+		"A sub navigation menu component which manages & scopes the state of a submenu, inside the content of a Root menu.",
+	props: {
+		value: createStringProp({
+			description: "The value of the currently active submenu.",
+			bindable: true,
+		}),
+		onValueChange: createFunctionProp({
+			definition: OnStringValueChangeProp,
+			description: "A callback function called when the active menu value changes.",
+			stringDefinition: "(value: string) => void",
 		}),
 		orientation: createEnumProp({
 			options: ["horizontal", "vertical"],
@@ -129,11 +155,11 @@ export const indicator = createApiSchema<NavigationMenuIndicatorPropsWithoutHTML
 export const viewport = createApiSchema<NavigationMenuViewportPropsWithoutHTML>({
 	title: "Viewport",
 	description:
-		"The viewport element for the navigation menu, which is used to contain the menu items.",
+		"An optional viewport element for the navigation menu, which renders the content of the menu items if it is present. The content is rendered in place without it.",
 	props: {
 		forceMount: forceMountProp,
 		...withChildProps({ elType: "HTMLDivElement" }),
 	},
 });
 
-export const navigationMenu = [root, list, item, trigger, content, link, viewport, indicator];
+export const navigationMenu = [root, sub, list, item, trigger, content, link, viewport, indicator];

--- a/packages/bits-ui/src/lib/bits/navigation-menu/components/navigation-menu-content.svelte
+++ b/packages/bits-ui/src/lib/bits/navigation-menu/components/navigation-menu-content.svelte
@@ -28,16 +28,14 @@
 	const mergedProps = $derived(mergeProps(restProps, contentState.props));
 </script>
 
-{#if contentState.context.viewportRef.current}
-	<Portal to={contentState.context.viewportRef.current}>
-		<PresenceLayer
-			{id}
-			present={forceMount || contentState.open || contentState.isLastActiveValue}
-		>
-			{#snippet presence()}
-				<NavigationMenuContentImpl {...mergedProps} {children} {child} />
-				<Mounted bind:mounted={contentState.mounted} />
-			{/snippet}
-		</PresenceLayer>
-	</Portal>
-{/if}
+<Portal
+	to={contentState.context.viewportRef.current || undefined}
+	disabled={!contentState.context.viewportRef.current}
+>
+	<PresenceLayer {id} present={forceMount || contentState.open || contentState.isLastActiveValue}>
+		{#snippet presence()}
+			<NavigationMenuContentImpl {...mergedProps} {children} {child} />
+			<Mounted bind:mounted={contentState.mounted} />
+		{/snippet}
+	</PresenceLayer>
+</Portal>

--- a/tests/src/tests/navigation-menu/navigation-menu-test.svelte
+++ b/tests/src/tests/navigation-menu/navigation-menu-test.svelte
@@ -1,11 +1,14 @@
 <script lang="ts" module>
-	export type NavigationMenuTestProps = NavigationMenu.RootProps & {};
+	export type NavigationMenuTestProps = NavigationMenu.RootProps & {
+		noViewport?: boolean;
+		noSubViewport?: boolean;
+	};
 </script>
 
 <script lang="ts">
 	import { NavigationMenu } from "bits-ui";
 
-	let { ...restProps }: NavigationMenuTestProps = $props();
+	let { noViewport, noSubViewport, ...restProps }: NavigationMenuTestProps = $props();
 </script>
 
 <main>
@@ -64,8 +67,11 @@
 								</NavigationMenu.Content>
 							</NavigationMenu.Item>
 						</NavigationMenu.List>
-						<NavigationMenu.Viewport data-testid="sub-group-item-sub-viewport"
-						></NavigationMenu.Viewport>
+						{#if !noSubViewport}
+							<NavigationMenu.Viewport
+								data-testid="sub-group-item-sub-viewport"
+							></NavigationMenu.Viewport>
+						{/if}
 					</NavigationMenu.Sub>
 				</NavigationMenu.Content>
 			</NavigationMenu.Item>
@@ -79,7 +85,9 @@
 			<NavigationMenu.Indicator data-testid="indicator"></NavigationMenu.Indicator>
 		</NavigationMenu.List>
 
-		<NavigationMenu.Viewport data-testid="viewport"></NavigationMenu.Viewport>
+		{#if !noViewport}
+			<NavigationMenu.Viewport data-testid="viewport"></NavigationMenu.Viewport>
+		{/if}
 	</NavigationMenu.Root>
 	<button data-testid="next-button">next button</button>
 </main>

--- a/tests/src/tests/navigation-menu/navigation-menu-test.svelte
+++ b/tests/src/tests/navigation-menu/navigation-menu-test.svelte
@@ -68,8 +68,7 @@
 							</NavigationMenu.Item>
 						</NavigationMenu.List>
 						{#if !noSubViewport}
-							<NavigationMenu.Viewport
-								data-testid="sub-group-item-sub-viewport"
+							<NavigationMenu.Viewport data-testid="sub-group-item-sub-viewport"
 							></NavigationMenu.Viewport>
 						{/if}
 					</NavigationMenu.Sub>

--- a/tests/src/tests/navigation-menu/navigation-menu.test.ts
+++ b/tests/src/tests/navigation-menu/navigation-menu.test.ts
@@ -160,3 +160,28 @@ it("should focus next on content with down arrow when opened", async () => {
 	await user.keyboard(kbd.ARROW_DOWN);
 	expect(getByTestId("group-item-content-button1")).toHaveFocus();
 });
+
+it("should render content without viewport", async () => {
+	const { user, getByTestId, queryByTestId } = setup({ noViewport: true });
+	const trigger = getByTestId("group-item-trigger");
+	expect(queryByTestId("viewport")).toBeNull();
+	expect(queryByTestId("group-item-content")).toBeNull();
+	await user.hover(trigger);
+	await waitFor(() => expect(queryByTestId("group-item-content")).not.toBeNull());
+	expect(queryByTestId("viewport")).toBeNull();
+	expect(queryByTestId("group-item")).toContainElement(queryByTestId("group-item-content"));
+});
+
+it("should render subcontent without subviewport", async () => {
+	const { user, getByTestId, queryByTestId } = setup({ noSubViewport: true });
+	const trigger = getByTestId("sub-group-item-trigger");
+	await user.hover(trigger);
+	await waitFor(() => expect(queryByTestId("viewport")).not.toBeNull());
+	const subTrigger = getByTestId("sub-group-item-sub-item2-trigger");
+	await user.hover(subTrigger);
+	await waitFor(() => expect(queryByTestId("sub-group-item-sub-item2-content")).not.toBeNull());
+	expect(queryByTestId("sub-group-item-sub-item2")).toContainElement(
+		queryByTestId("sub-group-item-sub-item2-content")
+	);
+	expect(queryByTestId("sub-group-item-sub-viewport")).toBeNull();
+});


### PR DESCRIPTION
Closes #1458, I also added documentation on the `Sub` element that was missing