### PR TITLE
feat(Menu): add `*Menu.CheckboxGroup` component

### DIFF
--- a/.changeset/early-wasps-tell.md
+++ b/.changeset/early-wasps-tell.md
@@ -2,4 +2,4 @@
 "bits-ui": minor
 ---
 
-feat(Menu.CheckboxGroup): add CheckboxGroup component to the various menus
+feat(DropdownMenu): new `DropdownMenu.CheckboxGroup` component

--- a/.changeset/early-wasps-tell.md
+++ b/.changeset/early-wasps-tell.md
@@ -1,0 +1,5 @@
+---
+"bits-ui": minor
+---
+
+feat(Menu.CheckboxGroup): add CheckboxGroup component to the various menus

--- a/.changeset/lazy-geese-kneel.md
+++ b/.changeset/lazy-geese-kneel.md
@@ -2,4 +2,4 @@
 "bits-ui": minor
 ---
 
-feat(ContextMenu): new `DropdownMenu.CheckboxGroup` component
+feat(ContextMenu): new `ContextMenu.CheckboxGroup` component

--- a/.changeset/lazy-geese-kneel.md
+++ b/.changeset/lazy-geese-kneel.md
@@ -1,0 +1,5 @@
+---
+"bits-ui": minor
+---
+
+feat(ContextMenu): new `DropdownMenu.CheckboxGroup` component

--- a/.changeset/nervous-jeans-cover.md
+++ b/.changeset/nervous-jeans-cover.md
@@ -1,0 +1,5 @@
+---
+"bits-ui": minor
+---
+
+feat(Menubar): new `DropdownMenu.CheckboxGroup` component

--- a/.changeset/nervous-jeans-cover.md
+++ b/.changeset/nervous-jeans-cover.md
@@ -2,4 +2,4 @@
 "bits-ui": minor
 ---
 
-feat(Menubar): new `DropdownMenu.CheckboxGroup` component
+feat(Menubar): new `Menubar.CheckboxGroup` component

--- a/docs/content/components/context-menu.md
+++ b/docs/content/components/context-menu.md
@@ -185,31 +185,6 @@ Use a [Function Binding](https://svelte.dev/docs/svelte/bind#Function-bindings) 
 </ContextMenu.Root>
 ```
 
-## Checkbox Items
-
-You can use the `ContextMenu.CheckboxItem` component to create a `menuitemcheckbox` element to add checkbox functionality to menu items.
-
-```svelte
-<script lang="ts">
-	import { ContextMenu } from "bits-ui";
-
-	let notifications = $state(true);
-</script>
-
-<ContextMenu.CheckboxItem bind:checked={notifications}>
-	{#snippet children({ checked, indeterminate })}
-		{#if indeterminate}
-			-
-		{:else if checked}
-			✅
-		{/if}
-		Notifications
-	{/snippet}
-</ContextMenu.CheckboxItem>
-```
-
-See the [CheckboxItem API](#checkboxitem) for more information.
-
 ## Radio Groups
 
 You can combine the `ContextMenu.RadioGroup` and `ContextMenu.RadioItem` components to create a radio group within a menu.
@@ -237,6 +212,73 @@ You can combine the `ContextMenu.RadioGroup` and `ContextMenu.RadioItem` compone
 ```
 
 See the [RadioGroup](#radiogroup) and [RadioItem](#radioitem) APIs for more information.
+
+## Checkbox Items
+
+You can use the `ContextMenu.CheckboxItem` component to create a `menuitemcheckbox` element to add checkbox functionality to menu items.
+
+```svelte
+<script lang="ts">
+	import { ContextMenu } from "bits-ui";
+
+	let notifications = $state(true);
+</script>
+
+<ContextMenu.CheckboxItem bind:checked={notifications}>
+	{#snippet children({ checked, indeterminate })}
+		{#if indeterminate}
+			-
+		{:else if checked}
+			✅
+		{/if}
+		Notifications
+	{/snippet}
+</ContextMenu.CheckboxItem>
+```
+
+See the [CheckboxItem API](#checkboxitem) for more information.
+
+## Checkbox Groups
+
+You can use the `ContextMenu.CheckboxGroup` component around a set of `ContextMenu.CheckboxItem` components to create a checkbox group within a menu, where the `value` prop is an array of the selected values.
+
+```svelte
+<script lang="ts">
+	import { ContextMenu } from "bits-ui";
+
+	let colors = $state<string[]>([]);
+</script>
+
+<ContextMenu.CheckboxGroup bind:value={colors}>
+	<ContextMenu.GroupHeading>Favorite color</ContextMenu.GroupHeading>
+	<ContextMenu.CheckboxItem value="red">
+		{#snippet children({ checked })}
+			{#if checked}
+				✅
+			{/if}
+			Red
+		{/snippet}
+	</ContextMenu.CheckboxItem>
+	<ContextMenu.CheckboxItem value="blue">
+		{#snippet children({ checked })}
+			{#if checked}
+				✅
+			{/if}
+			Blue
+		{/snippet}
+	</ContextMenu.CheckboxItem>
+	<ContextMenu.CheckboxItem value="green">
+		{#snippet children({ checked })}
+			{#if checked}
+				✅
+			{/if}
+			Green
+		{/snippet}
+	</ContextMenu.CheckboxItem>
+</ContextMenu.CheckboxGroup>
+```
+
+The `value` state does not persist between menu open/close cycles. To persist the state, you must store it in a `$state` variable and pass it to the `value` prop.
 
 ## Nested Menus
 

--- a/docs/content/components/dropdown-menu.md
+++ b/docs/content/components/dropdown-menu.md
@@ -199,31 +199,6 @@ The `DropdownMenu.GroupHeading` component must be a child of either a `DropdownM
 </DropdownMenu.RadioGroup>
 ```
 
-## Checkbox Items
-
-You can use the `DropdownMenu.CheckboxItem` component to create a `menuitemcheckbox` element to add checkbox functionality to menu items.
-
-```svelte
-<script lang="ts">
-	import { DropdownMenu } from "bits-ui";
-
-	let notifications = $state(true);
-</script>
-
-<DropdownMenu.CheckboxItem bind:checked={notifications}>
-	{#snippet children({ checked, indeterminate })}
-		{#if indeterminate}
-			-
-		{:else if checked}
-			✅
-		{/if}
-		Notifications
-	{/snippet}
-</DropdownMenu.CheckboxItem>
-```
-
-The `checked` state does not persist between menu open/close cycles. To persist the state, you must store it in a `$state` variable and pass it to the `checked` prop.
-
 ## Radio Groups
 
 You can combine the `DropdownMenu.RadioGroup` and `DropdownMenu.RadioItem` components to create a radio group within a menu.
@@ -249,6 +224,73 @@ You can combine the `DropdownMenu.RadioGroup` and `DropdownMenu.RadioItem` compo
 		</DropdownMenu.RadioItem>
 	{/each}
 </DropdownMenu.RadioGroup>
+```
+
+The `value` state does not persist between menu open/close cycles. To persist the state, you must store it in a `$state` variable and pass it to the `value` prop.
+
+## Checkbox Items
+
+You can use the `DropdownMenu.CheckboxItem` component to create a `menuitemcheckbox` element to add checkbox functionality to menu items.
+
+```svelte
+<script lang="ts">
+	import { DropdownMenu } from "bits-ui";
+
+	let notifications = $state(true);
+</script>
+
+<DropdownMenu.CheckboxItem bind:checked={notifications}>
+	{#snippet children({ checked, indeterminate })}
+		{#if indeterminate}
+			-
+		{:else if checked}
+			✅
+		{/if}
+		Notifications
+	{/snippet}
+</DropdownMenu.CheckboxItem>
+```
+
+The `checked` state does not persist between menu open/close cycles. To persist the state, you must store it in a `$state` variable and pass it to the `checked` prop.
+
+## Checkbox Groups
+
+You can use the `DropdownMenu.CheckboxGroup` component around a set of `DropdownMenu.CheckboxItem` components to create a checkbox group within a menu, where the `value` prop is an array of the selected values.
+
+```svelte
+<script lang="ts">
+	import { DropdownMenu } from "bits-ui";
+
+	let colors = $state<string[]>([]);
+</script>
+
+<DropdownMenu.CheckboxGroup bind:value={colors}>
+	<DropdownMenu.GroupHeading>Favorite color</DropdownMenu.GroupHeading>
+	<DropdownMenu.CheckboxItem value="red">
+		{#snippet children({ checked })}
+			{#if checked}
+				✅
+			{/if}
+			Red
+		{/snippet}
+	</DropdownMenu.CheckboxItem>
+	<DropdownMenu.CheckboxItem value="blue">
+		{#snippet children({ checked })}
+			{#if checked}
+				✅
+			{/if}
+			Blue
+		{/snippet}
+	</DropdownMenu.CheckboxItem>
+	<DropdownMenu.CheckboxItem value="green">
+		{#snippet children({ checked })}
+			{#if checked}
+				✅
+			{/if}
+			Green
+		{/snippet}
+	</DropdownMenu.CheckboxItem>
+</DropdownMenu.CheckboxGroup>
 ```
 
 The `value` state does not persist between menu open/close cycles. To persist the state, you must store it in a `$state` variable and pass it to the `value` prop.

--- a/docs/content/components/menubar.md
+++ b/docs/content/components/menubar.md
@@ -195,29 +195,6 @@ Use a [Function Binding](https://svelte.dev/docs/svelte/bind#Function-bindings) 
 </Menubar.Root>
 ```
 
-## Checkbox Items
-
-You can use the `Menubar.CheckboxItem` component to create a `menuitemcheckbox` element to add checkbox functionality to menu items.
-
-```svelte
-<script lang="ts">
-	import { Menubar } from "bits-ui";
-
-	let notifications = $state(true);
-</script>
-
-<Menubar.CheckboxItem bind:checked={notifications}>
-	{#snippet children({ checked, indeterminate })}
-		{#if indeterminate}
-			-
-		{:else if checked}
-			✅
-		{/if}
-		Notifications
-	{/snippet}
-</Menubar.CheckboxItem>
-```
-
 ## Radio Groups
 
 You can combine the `Menubar.RadioGroup` and `Menubar.RadioItem` components to create a radio group within a menu.
@@ -243,6 +220,71 @@ You can combine the `Menubar.RadioGroup` and `Menubar.RadioItem` components to c
 	{/each}
 </Menubar.RadioGroup>
 ```
+
+## Checkbox Items
+
+You can use the `Menubar.CheckboxItem` component to create a `menuitemcheckbox` element to add checkbox functionality to menu items.
+
+```svelte
+<script lang="ts">
+	import { Menubar } from "bits-ui";
+
+	let notifications = $state(true);
+</script>
+
+<Menubar.CheckboxItem bind:checked={notifications}>
+	{#snippet children({ checked, indeterminate })}
+		{#if indeterminate}
+			-
+		{:else if checked}
+			✅
+		{/if}
+		Notifications
+	{/snippet}
+</Menubar.CheckboxItem>
+```
+
+## Checkbox Groups
+
+You can use the `Menubar.CheckboxGroup` component around a set of `Menubar.CheckboxItem` components to create a checkbox group within a menu, where the `value` prop is an array of the selected values.
+
+```svelte
+<script lang="ts">
+	import { Menubar } from "bits-ui";
+
+	let colors = $state<string[]>([]);
+</script>
+
+<Menubar.CheckboxGroup bind:value={colors}>
+	<Menubar.GroupHeading>Favorite color</Menubar.GroupHeading>
+	<Menubar.CheckboxItem value="red">
+		{#snippet children({ checked })}
+			{#if checked}
+				✅
+			{/if}
+			Red
+		{/snippet}
+	</Menubar.CheckboxItem>
+	<Menubar.CheckboxItem value="blue">
+		{#snippet children({ checked })}
+			{#if checked}
+				✅
+			{/if}
+			Blue
+		{/snippet}
+	</Menubar.CheckboxItem>
+	<Menubar.CheckboxItem value="green">
+		{#snippet children({ checked })}
+			{#if checked}
+				✅
+			{/if}
+			Green
+		{/snippet}
+	</Menubar.CheckboxItem>
+</Menubar.CheckboxGroup>
+```
+
+The `value` state does not persist between menu open/close cycles. To persist the state, you must store it in a `$state` variable and pass it to the `value` prop.
 
 ## Nested Menus
 

--- a/docs/src/lib/content/api-reference/context-menu.api.ts
+++ b/docs/src/lib/content/api-reference/context-menu.api.ts
@@ -1,5 +1,6 @@
 import type {
 	ContextMenuArrowPropsWithoutHTML,
+	ContextMenuCheckboxGroupPropsWithoutHTML,
 	ContextMenuCheckboxItemPropsWithoutHTML,
 	ContextMenuContentPropsWithoutHTML,
 	ContextMenuContentStaticPropsWithoutHTML,
@@ -148,6 +149,12 @@ export const checkboxItem = createApiSchema<ContextMenuCheckboxItemPropsWithoutH
 	...menu.checkboxItem,
 });
 
+export const checkboxGroup = createApiSchema<ContextMenuCheckboxGroupPropsWithoutHTML>({
+	title: "CheckboxGroup",
+	description: "A group of checkbox menu items, where multiple can be checked at a time.",
+	...menu.checkboxGroup,
+});
+
 export const radioGroup = createApiSchema<ContextMenuRadioGroupPropsWithoutHTML>({
 	title: "RadioGroup",
 	description: "A group of radio menu items, where only one can be checked at a time.",
@@ -208,6 +215,7 @@ export const contextMenu = [
 	content,
 	contentStatic,
 	item,
+	checkboxGroup,
 	checkboxItem,
 	radioGroup,
 	radioItem,

--- a/docs/src/lib/content/api-reference/dropdown-menu.api.ts
+++ b/docs/src/lib/content/api-reference/dropdown-menu.api.ts
@@ -1,5 +1,6 @@
 import type {
 	DropdownMenuArrowPropsWithoutHTML,
+	DropdownMenuCheckboxGroupPropsWithoutHTML,
 	DropdownMenuCheckboxItemPropsWithoutHTML,
 	DropdownMenuContentPropsWithoutHTML,
 	DropdownMenuContentStaticPropsWithoutHTML,
@@ -91,6 +92,12 @@ export const arrow = createApiSchema<DropdownMenuArrowPropsWithoutHTML>({
 	...menu.arrow,
 });
 
+export const checkboxGroup = createApiSchema<DropdownMenuCheckboxGroupPropsWithoutHTML>({
+	title: "CheckboxGroup",
+	description: "A group of checkbox menu items, where multiple can be checked at a time.",
+	...menu.checkboxGroup,
+});
+
 export const checkboxItem = createApiSchema<DropdownMenuCheckboxItemPropsWithoutHTML>({
 	title: "CheckboxItem",
 	description: "A menu item that can be controlled and toggled like a checkbox.",
@@ -157,6 +164,7 @@ export const dropdownMenu = [
 	content,
 	contentStatic,
 	item,
+	checkboxGroup,
 	checkboxItem,
 	radioGroup,
 	radioItem,

--- a/docs/src/lib/content/api-reference/menu.api.ts
+++ b/docs/src/lib/content/api-reference/menu.api.ts
@@ -1,4 +1,5 @@
 import type {
+	DropdownMenuCheckboxGroupPropsWithoutHTML,
 	DropdownMenuCheckboxItemPropsWithoutHTML,
 	DropdownMenuContentPropsWithoutHTML,
 	DropdownMenuContentStaticPropsWithoutHTML,
@@ -21,6 +22,7 @@ import {
 	createBooleanProp,
 	createDataAttrSchema,
 	createFunctionProp,
+	createPropSchema,
 	createStringProp,
 	dirProp,
 	dismissibleLayerProps,
@@ -46,6 +48,7 @@ import {
 import { MenuCheckedStateAttr } from "./extended-types/menu/index.js";
 import { RadioGroupStateAttr } from "./extended-types/radio-group/index.js";
 import {
+	CheckboxGroupOnValueChangeProp,
 	CheckboxRootChildSnippetProps,
 	CheckboxRootChildrenSnippetProps,
 	CheckboxRootOnCheckedChangeProp,
@@ -192,6 +195,10 @@ const checkboxItemProps = {
 		description: "A callback that is fired when the indeterminate state changes.",
 		stringDefinition: "(indeterminate: boolean) => void",
 	}),
+	value: createStringProp({
+		description: "The value of the checkbox item when used in a `*Menu.CheckboxGroup`.",
+		default: "",
+	}),
 	...omit(sharedItemProps, "child", "children"),
 	...withChildProps({
 		elType: "HTMLDivElement",
@@ -199,6 +206,22 @@ const checkboxItemProps = {
 		childDef: CheckboxRootChildSnippetProps,
 	}),
 } satisfies PropObj<DropdownMenuCheckboxItemPropsWithoutHTML>;
+
+const checkboxGroupProps = {
+	value: createPropSchema({
+		description:
+			"The value of the group. This is an array of the values of the checked checkboxes within the group.",
+		bindable: true,
+		default: "[]",
+		type: "string[]",
+	}),
+	onValueChange: createFunctionProp({
+		definition: CheckboxGroupOnValueChangeProp,
+		description: "A callback that is fired when the checkbox group's value state changes.",
+		stringDefinition: "(value: string[]) => void",
+	}),
+	...withChildProps({ elType: "HTMLDivElement" }),
+} satisfies PropObj<DropdownMenuCheckboxGroupPropsWithoutHTML>;
 
 const radioGroupProps = {
 	value: createStringProp({
@@ -336,6 +359,13 @@ const labelAttrs: DataAttrs = [
 	createDataAttrSchema({
 		name: "menu-group-heading",
 		description: "Present on the group heading element.",
+	}),
+];
+
+const checkboxGroupAttrs: DataAttrs = [
+	createDataAttrSchema({
+		name: "menu-checkbox-group",
+		description: "Present on the checkbox group element.",
 	}),
 ];
 
@@ -485,12 +515,18 @@ const portal = {
 	props: portalProps,
 };
 
+const checkboxGroup = {
+	props: checkboxGroupProps,
+	dataAttributes: checkboxGroupAttrs,
+};
+
 export const menu = {
 	root,
 	trigger,
 	content,
 	contentStatic,
 	item,
+	checkboxGroup,
 	checkboxItem,
 	radioGroup,
 	radioItem,

--- a/docs/src/lib/content/api-reference/menubar.api.ts
+++ b/docs/src/lib/content/api-reference/menubar.api.ts
@@ -1,5 +1,6 @@
 import type {
 	MenubarArrowPropsWithoutHTML,
+	MenubarCheckboxGroupPropsWithoutHTML,
 	MenubarCheckboxItemPropsWithoutHTML,
 	MenubarContentPropsWithoutHTML,
 	MenubarContentStaticPropsWithoutHTML,
@@ -144,6 +145,12 @@ export const checkboxItem = createApiSchema<MenubarCheckboxItemPropsWithoutHTML>
 	...m.checkboxItem,
 });
 
+export const checkboxGroup = createApiSchema<MenubarCheckboxGroupPropsWithoutHTML>({
+	title: "CheckboxGroup",
+	description: "A group of checkbox menu items, where multiple can be checked at a time.",
+	...m.checkboxGroup,
+});
+
 export const radioGroup = createApiSchema<MenubarRadioGroupPropsWithoutHTML>({
 	title: "RadioGroup",
 	description: "A group of radio menu items, where only one can be checked at a time.",
@@ -204,6 +211,7 @@ export const menubar = [
 	portal,
 	content,
 	item,
+	checkboxGroup,
 	checkboxItem,
 	radioGroup,
 	radioItem,

--- a/packages/bits-ui/src/lib/bits/context-menu/exports.ts
+++ b/packages/bits-ui/src/lib/bits/context-menu/exports.ts
@@ -15,6 +15,7 @@ export { default as SubContentStatic } from "$lib/bits/menu/components/menu-sub-
 export { default as SubTrigger } from "$lib/bits/menu/components/menu-sub-trigger.svelte";
 export { default as CheckboxItem } from "$lib/bits/menu/components/menu-checkbox-item.svelte";
 export { default as Portal } from "$lib/bits/utilities/portal/portal.svelte";
+export { default as CheckboxGroup } from "$lib/bits/menu/components/menu-checkbox-group.svelte";
 
 export type {
 	ContextMenuArrowProps as ArrowProps,
@@ -34,4 +35,5 @@ export type {
 	ContextMenuContentStaticProps as ContentStaticProps,
 	ContextMenuTriggerProps as TriggerProps,
 	ContextMenuPortalProps as PortalProps,
+	ContextMenuCheckboxGroupProps as CheckboxGroupProps,
 } from "./types.js";

--- a/packages/bits-ui/src/lib/bits/context-menu/types.ts
+++ b/packages/bits-ui/src/lib/bits/context-menu/types.ts
@@ -36,6 +36,7 @@ export type {
 	MenuSubProps as ContextMenuSubProps,
 	MenuSubTriggerProps as ContextMenuSubTriggerProps,
 	MenuPortalProps as ContextMenuPortalProps,
+	MenuCheckboxGroupProps as ContextMenuCheckboxGroupProps,
 } from "$lib/bits/menu/types.js";
 
 export type {
@@ -54,4 +55,5 @@ export type {
 	MenuSubContentPropsWithoutHTML as ContextMenuSubContentPropsWithoutHTML,
 	MenuSubContentStaticPropsWithoutHTML as ContextMenuSubContentStaticPropsWithoutHTML,
 	MenuPortalPropsWithoutHTML as ContextMenuPortalPropsWithoutHTML,
+	MenuCheckboxGroupPropsWithoutHTML as ContextMenuCheckboxGroupPropsWithoutHTML,
 } from "$lib/bits/menu/types.js";

--- a/packages/bits-ui/src/lib/bits/dropdown-menu/exports.ts
+++ b/packages/bits-ui/src/lib/bits/dropdown-menu/exports.ts
@@ -15,6 +15,7 @@ export { default as SubContentStatic } from "$lib/bits/menu/components/menu-sub-
 export { default as SubTrigger } from "$lib/bits/menu/components/menu-sub-trigger.svelte";
 export { default as CheckboxItem } from "$lib/bits/menu/components/menu-checkbox-item.svelte";
 export { default as Portal } from "$lib/bits/utilities/portal/portal.svelte";
+export { default as CheckboxGroup } from "$lib/bits/menu/components/menu-checkbox-group.svelte";
 
 export type {
 	DropdownMenuArrowProps as ArrowProps,
@@ -34,4 +35,5 @@ export type {
 	DropdownMenuSubTriggerProps as SubTriggerProps,
 	DropdownMenuTriggerProps as TriggerProps,
 	DropdownMenuPortalProps as PortalProps,
+	DropdownMenuCheckboxGroupProps as CheckboxGroupProps,
 } from "./types.js";

--- a/packages/bits-ui/src/lib/bits/dropdown-menu/types.ts
+++ b/packages/bits-ui/src/lib/bits/dropdown-menu/types.ts
@@ -16,6 +16,7 @@ export type {
 	MenuSubTriggerProps as DropdownMenuSubTriggerProps,
 	MenuTriggerProps as DropdownMenuTriggerProps,
 	MenuPortalProps as DropdownMenuPortalProps,
+	MenuCheckboxGroupProps as DropdownMenuCheckboxGroupProps,
 } from "$lib/bits/menu/types.js";
 
 export type {
@@ -36,4 +37,5 @@ export type {
 	MenuSubContentStaticPropsWithoutHTML as DropdownMenuSubContentStaticPropsWithoutHTML,
 	MenuTriggerPropsWithoutHTML as DropdownMenuTriggerPropsWithoutHTML,
 	MenuPortalPropsWithoutHTML as DropdownMenuPortalPropsWithoutHTML,
+	MenuCheckboxGroupPropsWithoutHTML as DropdownMenuCheckboxGroupPropsWithoutHTML,
 } from "$lib/bits/menu/types.js";

--- a/packages/bits-ui/src/lib/bits/menu/components/menu-checkbox-group.svelte
+++ b/packages/bits-ui/src/lib/bits/menu/components/menu-checkbox-group.svelte
@@ -1,0 +1,43 @@
+<script lang="ts">
+	import { box, mergeProps } from "svelte-toolbelt";
+	import type { MenuCheckboxGroupProps } from "../types.js";
+	import { useMenuCheckboxGroup } from "../menu.svelte.js";
+	import { noop } from "$lib/internal/noop.js";
+	import { useId } from "$lib/internal/use-id.js";
+
+	let {
+		id = useId(),
+		children,
+		child,
+		ref = $bindable(null),
+		value = $bindable([]),
+		onValueChange = noop,
+		...restProps
+	}: MenuCheckboxGroupProps = $props();
+
+	const checkboxGroupState = useMenuCheckboxGroup({
+		value: box.with(
+			() => $state.snapshot(value),
+			(v) => {
+				value = $state.snapshot(v);
+				onValueChange(v);
+			}
+		),
+		onValueChange: box.with(() => onValueChange),
+		ref: box.with(
+			() => ref,
+			(v) => (ref = v)
+		),
+		id: box.with(() => id),
+	});
+
+	const mergedProps = $derived(mergeProps(restProps, checkboxGroupState.props));
+</script>
+
+{#if child}
+	{@render child({ props: mergedProps })}
+{:else}
+	<div {...mergedProps}>
+		{@render children?.()}
+	</div>
+{/if}

--- a/packages/bits-ui/src/lib/bits/menu/exports.ts
+++ b/packages/bits-ui/src/lib/bits/menu/exports.ts
@@ -1,5 +1,6 @@
 export { default as Root } from "./components/menu.svelte";
 export { default as Arrow } from "./components/menu-arrow.svelte";
+export { default as CheckboxGroup } from "./components/menu-checkbox-group.svelte";
 export { default as CheckboxItem } from "./components/menu-checkbox-item.svelte";
 export { default as Content } from "./components/menu-content.svelte";
 export { default as ContentStatic } from "./components/menu-content-static.svelte";
@@ -27,6 +28,7 @@ export type {
 	MenuSubContentStaticProps as SubContentStaticProps,
 	MenuSeparatorProps as SeparatorProps,
 	MenuArrowProps as ArrowProps,
+	MenuCheckboxGroupProps as CheckboxGroupProps,
 	MenuCheckboxItemProps as CheckboxItemProps,
 	MenuGroupHeadingProps as GroupHeadingProps,
 	MenuGroupProps as GroupProps,

--- a/packages/bits-ui/src/lib/bits/menu/types.ts
+++ b/packages/bits-ui/src/lib/bits/menu/types.ts
@@ -140,10 +140,32 @@ export type MenuCheckboxItemPropsWithoutHTML =
 		 * @defaultValue true
 		 */
 		closeOnSelect?: boolean;
+
+		/**
+		 * The value of the checkbox item when used in a checkbox group.
+		 */
+		value?: string;
 	};
 
 export type MenuCheckboxItemProps = MenuCheckboxItemPropsWithoutHTML &
 	Without<BitsPrimitiveDivAttributes, MenuCheckboxItemPropsWithoutHTML>;
+
+export type MenuCheckboxGroupPropsWithoutHTML = WithChild<{
+	/**
+	 * The values of the selected checkbox items.
+	 *
+	 * Supports two-way binding with `bind:value`.
+	 */
+	value?: string[];
+
+	/**
+	 * A callback that is fired when the selected checkbox items change.
+	 */
+	onValueChange?: OnChangeFn<string[]>;
+}>;
+
+export type MenuCheckboxGroupProps = MenuCheckboxGroupPropsWithoutHTML &
+	Without<BitsPrimitiveDivAttributes, MenuCheckboxGroupPropsWithoutHTML>;
 
 export type MenuTriggerPropsWithoutHTML = WithChild<{
 	/**

--- a/packages/bits-ui/src/lib/bits/menubar/exports.ts
+++ b/packages/bits-ui/src/lib/bits/menubar/exports.ts
@@ -16,6 +16,7 @@ export { default as SubTrigger } from "$lib/bits/menu/components/menu-sub-trigge
 export { default as RadioGroup } from "$lib/bits/menu/components/menu-radio-group.svelte";
 export { default as CheckboxItem } from "$lib/bits/menu/components/menu-checkbox-item.svelte";
 export { default as Portal } from "$lib/bits/utilities/portal/portal.svelte";
+export { default as CheckboxGroup } from "$lib/bits/menu/components/menu-checkbox-group.svelte";
 
 export type {
 	MenubarRootProps as RootProps,
@@ -39,4 +40,5 @@ export type {
 	MenuRadioGroupProps as RadioGroupProps,
 	MenuCheckboxItemProps as CheckboxItemProps,
 	MenuSubContentStaticProps as SubContentStaticProps,
+	MenuCheckboxGroupProps as CheckboxGroupProps,
 } from "$lib/bits/menu/types.js";

--- a/packages/bits-ui/src/lib/bits/menubar/types.ts
+++ b/packages/bits-ui/src/lib/bits/menubar/types.ts
@@ -88,6 +88,8 @@ export type {
 	MenuSubPropsWithoutHTML as MenubarSubPropsWithoutHTML,
 	MenuPortalPropsWithoutHTML as MenubarPortalPropsWithoutHTML,
 	MenuPortalProps as MenubarPortalProps,
+	MenuCheckboxGroupPropsWithoutHTML as MenubarCheckboxGroupPropsWithoutHTML,
+	MenuCheckboxGroupProps as MenubarCheckboxGroupProps,
 } from "../menu/types.js";
 
 export type MenubarArrowPropsWithoutHTML = ArrowPropsWithoutHTML;

--- a/tests/src/tests/context-menu/context-menu-test.svelte
+++ b/tests/src/tests/context-menu/context-menu-test.svelte
@@ -6,6 +6,7 @@
 		radio?: string;
 		subRadio?: string;
 		open?: boolean;
+		group?: string[];
 		contentProps?: Omit<ContextMenu.ContentProps, "asChild" | "children" | "child">;
 		portalProps?: Omit<ContextMenu.PortalProps, "asChild" | "children" | "child">;
 		subTriggerProps?: Omit<ContextMenu.SubTriggerProps, "asChild" | "children" | "child">;
@@ -19,6 +20,7 @@
 		radio = "",
 		subRadio = "",
 		open = false,
+		group = [],
 		contentProps = {},
 		portalProps = {},
 		subTriggerProps = {},
@@ -103,6 +105,20 @@
 							{/snippet}
 						</ContextMenu.RadioItem>
 					</ContextMenu.RadioGroup>
+					<ContextMenu.CheckboxGroup bind:value={group} data-testid="checkbox-group">
+						<ContextMenu.CheckboxItem value="1" data-testid="checkbox-group-item-1">
+							{#snippet children({ checked })}
+								<span data-testid="checkbox-indicator-1"> {checked} </span>
+								<span>Checkbox Item 1</span>
+							{/snippet}
+						</ContextMenu.CheckboxItem>
+						<ContextMenu.CheckboxItem value="2" data-testid="checkbox-group-item-2">
+							{#snippet children({ checked })}
+								<span data-testid="checkbox-indicator-2"> {checked} </span>
+								<span>Checkbox Item 2</span>
+							{/snippet}
+						</ContextMenu.CheckboxItem>
+					</ContextMenu.CheckboxGroup>
 				</ContextMenu.Content>
 			</ContextMenu.Portal>
 		</ContextMenu.Root>
@@ -122,6 +138,10 @@
 		>{subRadio}</button
 	>
 	<button data-testid="on-focus-override" id="on-focus-override">on-focus-override</button>
-
+	<button
+		aria-label="checkbox-group-binding"
+		data-testid="checkbox-group-binding"
+		onclick={() => (group = [])}>{group}</button
+	>
 	<div id="portal-target" data-testid="portal-target"></div>
 </main>

--- a/tests/src/tests/context-menu/context-menu-test.svelte
+++ b/tests/src/tests/context-menu/context-menu-test.svelte
@@ -7,9 +7,10 @@
 		subRadio?: string;
 		open?: boolean;
 		group?: string[];
-		contentProps?: Omit<ContextMenu.ContentProps, "asChild" | "children" | "child">;
-		portalProps?: Omit<ContextMenu.PortalProps, "asChild" | "children" | "child">;
-		subTriggerProps?: Omit<ContextMenu.SubTriggerProps, "asChild" | "children" | "child">;
+		contentProps?: Omit<ContextMenu.ContentProps, "children" | "child">;
+		portalProps?: Omit<ContextMenu.PortalProps, "children" | "child">;
+		subTriggerProps?: Omit<ContextMenu.SubTriggerProps, "children" | "child">;
+		checkboxGroupProps?: Omit<ContextMenu.CheckboxGroupProps, "children" | "child" | "value">;
 	};
 </script>
 
@@ -24,6 +25,7 @@
 		contentProps = {},
 		portalProps = {},
 		subTriggerProps = {},
+		checkboxGroupProps = {},
 		...restProps
 	}: ContextMenuTestProps = $props();
 </script>
@@ -105,7 +107,11 @@
 							{/snippet}
 						</ContextMenu.RadioItem>
 					</ContextMenu.RadioGroup>
-					<ContextMenu.CheckboxGroup bind:value={group} data-testid="checkbox-group">
+					<ContextMenu.CheckboxGroup
+						bind:value={group}
+						data-testid="checkbox-group"
+						{...checkboxGroupProps}
+					>
 						<ContextMenu.CheckboxItem value="1" data-testid="checkbox-group-item-1">
 							{#snippet children({ checked })}
 								<span data-testid="checkbox-indicator-1"> {checked} </span>

--- a/tests/src/tests/context-menu/context-menu.test.ts
+++ b/tests/src/tests/context-menu/context-menu.test.ts
@@ -79,6 +79,7 @@ it("should have bits data attrs", async () => {
 		"checkbox-item",
 		"radio-group",
 		"radio-item",
+		"checkbox-group",
 	];
 
 	for (const part of parts) {
@@ -218,6 +219,10 @@ it("should not loop through the menu items when the `loop` prop is set to false"
 	await user.keyboard(kbd.ARROW_DOWN);
 	await waitFor(() => expect(queryByTestId("radio-item-2")).toHaveFocus());
 	await user.keyboard(kbd.ARROW_DOWN);
+	await waitFor(() => expect(queryByTestId("checkbox-group-item-1")).toHaveFocus());
+	await user.keyboard(kbd.ARROW_DOWN);
+	await waitFor(() => expect(queryByTestId("checkbox-group-item-2")).toHaveFocus());
+	await user.keyboard(kbd.ARROW_DOWN);
 	await waitFor(() => expect(queryByTestId("item")).not.toHaveFocus());
 });
 
@@ -239,6 +244,10 @@ it("should loop through the menu items when the `loop` prop is set to true", asy
 	await waitFor(() => expect(getByTestId("radio-item")).toHaveFocus());
 	await user.keyboard(kbd.ARROW_DOWN);
 	await waitFor(() => expect(getByTestId("radio-item-2")).toHaveFocus());
+	await user.keyboard(kbd.ARROW_DOWN);
+	await waitFor(() => expect(getByTestId("checkbox-group-item-1")).toHaveFocus());
+	await user.keyboard(kbd.ARROW_DOWN);
+	await waitFor(() => expect(getByTestId("checkbox-group-item-2")).toHaveFocus());
 	await user.keyboard(kbd.ARROW_DOWN);
 	await waitFor(() => expect(getByTestId("item")).toHaveFocus());
 });
@@ -393,4 +402,32 @@ it("should respect the `onSelect` prop on SubTrigger", async () => {
 
 	await user.keyboard(kbd.ARROW_RIGHT);
 	expect(onSelect).toHaveBeenCalledTimes(3);
+});
+
+it("should respect the `value` prop on CheckboxGroup", async () => {
+	const t = await open({
+		group: ["1"],
+	});
+
+	const checkboxGroupItem1 = t.getByTestId("checkbox-group-item-1");
+	expect(checkboxGroupItem1).toHaveAttribute("aria-checked", "true");
+
+	expect(t.getByTestId("checkbox-indicator-1")).toHaveTextContent("true");
+	expect(t.queryByTestId("checkbox-indicator-2")).toHaveTextContent("false");
+
+	await t.user.click(checkboxGroupItem1);
+	await t.user.pointer([{ target: t.trigger }, { keys: "[MouseRight]", target: t.trigger }]);
+
+	expect(t.getByTestId("checkbox-indicator-1")).toHaveTextContent("false");
+	expect(t.getByTestId("checkbox-indicator-2")).toHaveTextContent("false");
+
+	await t.user.click(t.getByTestId("checkbox-group-item-2"));
+	await t.user.pointer([{ target: t.trigger }, { keys: "[MouseRight]", target: t.trigger }]);
+
+	expect(t.getByTestId("checkbox-indicator-1")).toHaveTextContent("false");
+	expect(t.getByTestId("checkbox-indicator-2")).toHaveTextContent("true");
+
+	await t.user.click(t.getByTestId("checkbox-group-binding"));
+	expect(t.getByTestId("checkbox-indicator-1")).toHaveTextContent("false");
+	expect(t.getByTestId("checkbox-indicator-2")).toHaveTextContent("false");
 });

--- a/tests/src/tests/dropdown-menu/dropdown-menu-test.svelte
+++ b/tests/src/tests/dropdown-menu/dropdown-menu-test.svelte
@@ -10,6 +10,7 @@
 		subContentProps?: Omit<DropdownMenu.SubContentProps, "children" | "child" | "asChild">;
 		portalProps?: DropdownMenu.PortalProps;
 		subTriggerProps?: Omit<DropdownMenu.SubTriggerProps, "children" | "child" | "asChild">;
+		group?: string[];
 	};
 </script>
 
@@ -18,6 +19,7 @@
 		checked = false,
 		subChecked = false,
 		radio = "",
+		group = [],
 		subRadio = "",
 		open = false,
 		contentProps = {},
@@ -96,6 +98,20 @@
 							{/snippet}
 						</DropdownMenu.RadioItem>
 					</DropdownMenu.RadioGroup>
+					<DropdownMenu.CheckboxGroup bind:value={group} data-testid="checkbox-group">
+						<DropdownMenu.CheckboxItem value="1" data-testid="checkbox-group-item-1">
+							{#snippet children({ checked })}
+								<span data-testid="checkbox-indicator-1"> {checked} </span>
+								<span>Checkbox Item 1</span>
+							{/snippet}
+						</DropdownMenu.CheckboxItem>
+						<DropdownMenu.CheckboxItem value="2" data-testid="checkbox-group-item-2">
+							{#snippet children({ checked })}
+								<span data-testid="checkbox-indicator-2"> {checked} </span>
+								<span>Checkbox Item 2</span>
+							{/snippet}
+						</DropdownMenu.CheckboxItem>
+					</DropdownMenu.CheckboxGroup>
 				</DropdownMenu.Content>
 			</DropdownMenu.Portal>
 		</DropdownMenu.Root>
@@ -113,6 +129,11 @@
 	>
 	<button aria-label="radio-sub" data-testid="sub-radio-binding" onclick={() => (subRadio = "")}
 		>{subRadio}</button
+	>
+	<button
+		aria-label="checkbox-group-binding"
+		data-testid="checkbox-group-binding"
+		onclick={() => (group = [])}>{group}</button
 	>
 	<div id="portal-target" data-testid="portal-target"></div>
 </main>

--- a/tests/src/tests/dropdown-menu/dropdown-menu-test.svelte
+++ b/tests/src/tests/dropdown-menu/dropdown-menu-test.svelte
@@ -6,10 +6,11 @@
 		radio?: string;
 		subRadio?: string;
 		open?: boolean;
-		contentProps?: Omit<DropdownMenu.ContentProps, "children" | "child" | "asChild">;
-		subContentProps?: Omit<DropdownMenu.SubContentProps, "children" | "child" | "asChild">;
+		contentProps?: Omit<DropdownMenu.ContentProps, "children" | "child">;
+		subContentProps?: Omit<DropdownMenu.SubContentProps, "children" | "child">;
 		portalProps?: DropdownMenu.PortalProps;
-		subTriggerProps?: Omit<DropdownMenu.SubTriggerProps, "children" | "child" | "asChild">;
+		subTriggerProps?: Omit<DropdownMenu.SubTriggerProps, "children" | "child">;
+		checkboxGroupProps?: Omit<DropdownMenu.CheckboxGroupProps, "children" | "child" | "value">;
 		group?: string[];
 	};
 </script>
@@ -26,6 +27,7 @@
 		subContentProps = {},
 		portalProps = {},
 		subTriggerProps = {},
+		checkboxGroupProps = {},
 		...restProps
 	}: DropdownMenuTestProps = $props();
 </script>
@@ -98,7 +100,11 @@
 							{/snippet}
 						</DropdownMenu.RadioItem>
 					</DropdownMenu.RadioGroup>
-					<DropdownMenu.CheckboxGroup bind:value={group} data-testid="checkbox-group">
+					<DropdownMenu.CheckboxGroup
+						bind:value={group}
+						data-testid="checkbox-group"
+						{...checkboxGroupProps}
+					>
 						<DropdownMenu.CheckboxItem value="1" data-testid="checkbox-group-item-1">
 							{#snippet children({ checked })}
 								<span data-testid="checkbox-indicator-1"> {checked} </span>

--- a/tests/src/tests/dropdown-menu/dropdown-menu.test.ts
+++ b/tests/src/tests/dropdown-menu/dropdown-menu.test.ts
@@ -442,3 +442,20 @@ it("should respect the `value` prop on CheckboxGroup", async () => {
 	expect(t.getByTestId("checkbox-indicator-1")).toHaveTextContent("false");
 	expect(t.getByTestId("checkbox-indicator-2")).toHaveTextContent("false");
 });
+
+it("calls `onValueChange` when the value of the checkbox group changes", async () => {
+	const onValueChange = vi.fn();
+	const t = await openWithPointer({
+		checkboxGroupProps: {
+			onValueChange,
+		},
+	});
+	await t.user.click(t.getByTestId("checkbox-group-item-1"));
+	expect(onValueChange).toHaveBeenCalledWith(["1"]);
+	await t.user.click(t.trigger);
+	await t.user.click(t.getByTestId("checkbox-group-item-2"));
+	expect(onValueChange).toHaveBeenCalledWith(["1", "2"]);
+	await t.user.click(t.trigger);
+	await t.user.click(t.getByTestId("checkbox-group-item-1"));
+	expect(onValueChange).toHaveBeenCalledWith(["2"]);
+});

--- a/tests/src/tests/dropdown-menu/dropdown-menu.test.ts
+++ b/tests/src/tests/dropdown-menu/dropdown-menu.test.ts
@@ -1,6 +1,6 @@
 import { render, screen, waitFor } from "@testing-library/svelte/svelte5";
 import { axe } from "jest-axe";
-import { describe, it, vi } from "vitest";
+import { it, vi } from "vitest";
 import { tick } from "svelte";
 import { getTestKbd, setupUserEvents, sleep } from "../utils.js";
 import DropdownMenuTest from "./dropdown-menu-test.svelte";
@@ -71,343 +71,374 @@ async function openSubmenu(props: Awaited<ReturnType<typeof openWithKbd>>) {
 	};
 }
 
-describe("dropdown menu", () => {
-	it("should have no accessibility violations", async () => {
-		const { container } = render(DropdownMenuTest);
-		expect(await axe(container)).toHaveNoViolations();
+it("should have no accessibility violations", async () => {
+	const { container } = render(DropdownMenuTest);
+	expect(await axe(container)).toHaveNoViolations();
+});
+
+it("should have bits data attrs", async () => {
+	const { user, trigger, getByTestId } = setup();
+	await user.click(trigger);
+
+	const parts = [
+		"content",
+		"trigger",
+		"group",
+		"group-heading",
+		"separator",
+		"sub-trigger",
+		"item",
+		"checkbox-item",
+		"radio-group",
+		"radio-item",
+		"checkbox-group",
+	];
+
+	for (const part of parts) {
+		const el = screen.getByTestId(part);
+		expect(el).toHaveAttribute(`data-dropdown-menu-${part}`);
+	}
+
+	await user.click(getByTestId("sub-trigger"));
+
+	const subContent = getByTestId("sub-content");
+	expect(subContent).toHaveAttribute(`data-dropdown-menu-sub-content`);
+});
+
+it.each(OPEN_KEYS)("should open when %s is pressed & respects binding", async (key) => {
+	await openWithKbd({}, key);
+});
+
+it("should open when clicked & respects binding", async () => {
+	const { getByTestId, queryByTestId, user, trigger } = setup();
+	const binding = getByTestId("binding");
+	expect(binding).toHaveTextContent("false");
+	await user.click(trigger);
+	expect(queryByTestId("content")).not.toBeNull();
+	expect(binding).toHaveTextContent("true");
+});
+
+it("should manage focus correctly when opened with pointer", async () => {
+	const { getByTestId, user } = await openWithPointer();
+
+	const item = getByTestId("item");
+	expect(item).not.toHaveFocus();
+
+	await user.keyboard(kbd.ARROW_DOWN);
+	expect(item).toHaveFocus();
+});
+
+it("should manage focus correctly when opened with keyboard", async () => {
+	const { user, getByTestId, queryByTestId, trigger } = setup();
+
+	expect(queryByTestId("content")).toBeNull();
+
+	trigger.focus();
+	await user.keyboard(kbd.ENTER);
+
+	expect(queryByTestId("content")).not.toBeNull();
+	const item = getByTestId("item");
+	await waitFor(() => expect(item).toHaveFocus());
+});
+
+it("should open submenu with keyboard on subtrigger", async () => {
+	const { getByTestId, queryByTestId, user } = await openWithKbd();
+
+	await user.keyboard(kbd.ARROW_DOWN);
+	const subtrigger = getByTestId("sub-trigger");
+	await waitFor(() => expect(subtrigger).toHaveFocus());
+	expect(queryByTestId("sub-content")).toBeNull();
+	await user.keyboard(kbd.ARROW_RIGHT);
+	expect(queryByTestId("sub-content")).not.toBeNull();
+	await waitFor(() => expect(getByTestId("sub-item")).toHaveFocus());
+});
+
+it("should toggle the checkbox item when clicked & respects binding", async () => {
+	const { getByTestId, user, trigger } = await openWithPointer();
+	const checkedBinding = getByTestId("checked-binding");
+	const indicator = getByTestId("checkbox-indicator");
+	expect(indicator).not.toHaveTextContent("checked");
+	expect(checkedBinding).toHaveTextContent("false");
+	const checkbox = getByTestId("checkbox-item");
+	await user.click(checkbox);
+	expect(checkedBinding).toHaveTextContent("true");
+	await user.click(trigger);
+	expect(indicator).toHaveTextContent("true");
+	await user.click(getByTestId("checkbox-item"));
+	expect(checkedBinding).toHaveTextContent("false");
+
+	await user.click(checkedBinding);
+	expect(checkedBinding).toHaveTextContent("true");
+	await user.click(trigger);
+	expect(getByTestId("checkbox-indicator")).toHaveTextContent("true");
+});
+
+it("should toggle checkbox items within submenus when clicked & respects binding", async () => {
+	const props = await openWithKbd();
+	const { getByTestId, user, trigger } = props;
+	await openSubmenu(props);
+	const subCheckedBinding = getByTestId("sub-checked-binding");
+	expect(subCheckedBinding).toHaveTextContent("false");
+	const indicator = getByTestId("sub-checkbox-indicator");
+	expect(indicator).not.toHaveTextContent("true");
+	const subCheckbox = getByTestId("sub-checkbox-item");
+	await user.click(subCheckbox);
+	expect(subCheckedBinding).toHaveTextContent("true");
+	trigger.focus();
+	await user.keyboard(kbd.ARROW_DOWN);
+	await openSubmenu(props);
+	expect(getByTestId("sub-checkbox-indicator")).toHaveTextContent("true");
+	await user.click(getByTestId("sub-checkbox-item"));
+	expect(subCheckedBinding).toHaveTextContent("false");
+
+	await user.click(subCheckedBinding);
+	expect(subCheckedBinding).toHaveTextContent("true");
+	trigger.focus();
+	await user.keyboard(kbd.ARROW_DOWN);
+	await openSubmenu(props);
+	expect(getByTestId("sub-checkbox-indicator")).toHaveTextContent("true");
+});
+
+it("should check the radio item when clicked & respects binding", async () => {
+	const { getByTestId, queryByTestId, user, trigger } = await openWithPointer();
+	const radioBinding = getByTestId("radio-binding");
+	expect(radioBinding).toHaveTextContent("");
+	const radioItem1 = getByTestId("radio-item");
+	await user.click(radioItem1);
+	expect(radioBinding).toHaveTextContent("1");
+	await user.click(trigger);
+	const radioIndicator1 = getByTestId("radio-indicator-1");
+	expect(radioIndicator1).not.toBeNull();
+	expect(radioIndicator1).toHaveTextContent("true");
+	const radioItem2 = getByTestId("radio-item-2");
+	await user.click(radioItem2);
+	expect(radioBinding).toHaveTextContent("2");
+	await user.click(trigger);
+	expect(queryByTestId("radio-indicator-1")).toHaveTextContent("false");
+	expect(queryByTestId("radio-indicator-2")).toHaveTextContent("true");
+
+	await user.keyboard(kbd.ESCAPE);
+	expect(queryByTestId("content")).toBeNull();
+	await user.click(radioBinding);
+	expect(radioBinding).toHaveTextContent("");
+	await user.click(trigger);
+});
+
+it("should skip over disabled items when navigating with the keyboard", async () => {
+	const { user, getByTestId } = await openWithKbd();
+	await user.keyboard(kbd.ARROW_DOWN);
+	await waitFor(() => expect(getByTestId("sub-trigger")).toHaveFocus());
+	await user.keyboard(kbd.ARROW_DOWN);
+	await waitFor(() => expect(getByTestId("checkbox-item")).toHaveFocus());
+	expect(getByTestId("disabled-item")).not.toHaveFocus();
+	expect(getByTestId("disabled-item-2")).not.toHaveFocus();
+});
+
+it("should not loop through the menu items when the `loop` prop is set to false/undefined", async () => {
+	const { user, getByTestId } = await openWithKbd({
+		contentProps: {
+			loop: false,
+		},
 	});
+	await user.keyboard(kbd.ARROW_DOWN);
+	await waitFor(() => expect(getByTestId("sub-trigger")).toHaveFocus());
+	await user.keyboard(kbd.ARROW_DOWN);
+	await waitFor(() => expect(getByTestId("checkbox-item")).toHaveFocus());
+	await user.keyboard(kbd.ARROW_DOWN);
+	await waitFor(() => expect(getByTestId("item-2")).toHaveFocus());
+	await user.keyboard(kbd.ARROW_DOWN);
+	await waitFor(() => expect(getByTestId("radio-item")).toHaveFocus());
+	await user.keyboard(kbd.ARROW_DOWN);
+	await waitFor(() => expect(getByTestId("radio-item-2")).toHaveFocus());
+	await user.keyboard(kbd.ARROW_DOWN);
+	await waitFor(() => expect(getByTestId("item")).not.toHaveFocus());
+});
 
-	it("should have bits data attrs", async () => {
-		const { user, trigger, getByTestId } = setup();
-		await user.click(trigger);
-
-		const parts = [
-			"content",
-			"trigger",
-			"group",
-			"group-heading",
-			"separator",
-			"sub-trigger",
-			"item",
-			"checkbox-item",
-			"radio-group",
-			"radio-item",
-		];
-
-		for (const part of parts) {
-			const el = screen.getByTestId(part);
-			expect(el).toHaveAttribute(`data-dropdown-menu-${part}`);
-		}
-
-		await user.click(getByTestId("sub-trigger"));
-
-		const subContent = getByTestId("sub-content");
-		expect(subContent).toHaveAttribute(`data-dropdown-menu-sub-content`);
+it("should loop through the menu items when the `loop` prop is set to true", async () => {
+	const { user, getByTestId } = await openWithKbd({
+		contentProps: {
+			loop: true,
+		},
 	});
+	await sleep(25);
+	await user.keyboard(kbd.ARROW_DOWN);
+	await waitFor(() => expect(getByTestId("sub-trigger")).toHaveFocus());
+	await user.keyboard(kbd.ARROW_DOWN);
+	await waitFor(() => expect(getByTestId("checkbox-item")).toHaveFocus());
+	await user.keyboard(kbd.ARROW_DOWN);
+	await waitFor(() => expect(getByTestId("item-2")).toHaveFocus());
+	await user.keyboard(kbd.ARROW_DOWN);
+	await waitFor(() => expect(getByTestId("radio-item")).toHaveFocus());
+	await user.keyboard(kbd.ARROW_DOWN);
+	await waitFor(() => expect(getByTestId("radio-item-2")).toHaveFocus());
+	await user.keyboard(kbd.ARROW_DOWN);
+	await waitFor(() => expect(getByTestId("checkbox-group-item-1")).toHaveFocus());
+	await user.keyboard(kbd.ARROW_DOWN);
+	await waitFor(() => expect(getByTestId("checkbox-group-item-2")).toHaveFocus());
+	await user.keyboard(kbd.ARROW_DOWN);
+	await waitFor(() => expect(getByTestId("item")).toHaveFocus());
+});
 
-	it.each(OPEN_KEYS)("should open when %s is pressed & respects binding", async (key) => {
-		await openWithKbd({}, key);
+it("should close the menu on escape", async () => {
+	const { queryByTestId, user } = await openWithKbd();
+	await user.keyboard(kbd.ESCAPE);
+	expect(queryByTestId("content")).toBeNull();
+});
+
+it("should respect the `escapeKeydownBehavior` prop", async () => {
+	const { queryByTestId, user } = await openWithKbd({
+		contentProps: {
+			escapeKeydownBehavior: "ignore",
+		},
 	});
+	await user.keyboard(kbd.ESCAPE);
+	expect(queryByTestId("content")).not.toBeNull();
+});
 
-	it("should open when clicked & respects binding", async () => {
-		const { getByTestId, queryByTestId, user, trigger } = setup();
-		const binding = getByTestId("binding");
-		expect(binding).toHaveTextContent("false");
-		await user.click(trigger);
-		expect(queryByTestId("content")).not.toBeNull();
-		expect(binding).toHaveTextContent("true");
+it("should respect the `interactOutsideBehavior` prop", async () => {
+	const { queryByTestId, user, getByTestId } = await openWithPointer({
+		contentProps: {
+			interactOutsideBehavior: "ignore",
+		},
 	});
+	const outside = getByTestId("outside");
+	await user.click(outside);
+	expect(queryByTestId("content")).not.toBeNull();
+});
 
-	it("should manage focus correctly when opened with pointer", async () => {
-		const { getByTestId, user } = await openWithPointer();
+it("should portal to the body if a `portal` prop is not passed", async () => {
+	const { getByTestId } = await openWithPointer();
+	const content = getByTestId("content");
+	expect(content.parentElement?.parentElement).toEqual(document.body);
+});
 
-		const item = getByTestId("item");
-		expect(item).not.toHaveFocus();
-
-		await user.keyboard(kbd.ARROW_DOWN);
-		expect(item).toHaveFocus();
+it("should portal to the portal target if a valid `portal` prop is passed", async () => {
+	const { getByTestId } = await openWithPointer({
+		portalProps: {
+			to: "#portal-target",
+		},
 	});
+	const content = getByTestId("content");
+	const portalTarget = getByTestId("portal-target");
+	expect(content.parentElement?.parentElement).toEqual(portalTarget);
+});
 
-	it("should manage focus correctly when opened with keyboard", async () => {
-		const { user, getByTestId, queryByTestId, trigger } = setup();
-
-		expect(queryByTestId("content")).toBeNull();
-
-		trigger.focus();
-		await user.keyboard(kbd.ENTER);
-
-		expect(queryByTestId("content")).not.toBeNull();
-		const item = getByTestId("item");
-		await waitFor(() => expect(item).toHaveFocus());
+it("should not portal if `disabled` is passed to the portal", async () => {
+	const { getByTestId } = await openWithPointer({
+		portalProps: {
+			disabled: true,
+		},
 	});
+	const content = getByTestId("content");
+	const ogContainer = getByTestId("non-portal-container");
+	const contentWrapper = content.parentElement;
+	expect(contentWrapper?.parentElement).not.toEqual(document.body);
+	expect(contentWrapper?.parentElement).toEqual(ogContainer);
+});
 
-	it("should open submenu with keyboard on subtrigger", async () => {
-		const { getByTestId, queryByTestId, user } = await openWithKbd();
-
-		await user.keyboard(kbd.ARROW_DOWN);
-		const subtrigger = getByTestId("sub-trigger");
-		await waitFor(() => expect(subtrigger).toHaveFocus());
-		expect(queryByTestId("sub-content")).toBeNull();
-		await user.keyboard(kbd.ARROW_RIGHT);
-		expect(queryByTestId("sub-content")).not.toBeNull();
-		await waitFor(() => expect(getByTestId("sub-item")).toHaveFocus());
-	});
-
-	it("should toggle the checkbox item when clicked & respects binding", async () => {
-		const { getByTestId, user, trigger } = await openWithPointer();
-		const checkedBinding = getByTestId("checked-binding");
-		const indicator = getByTestId("checkbox-indicator");
-		expect(indicator).not.toHaveTextContent("checked");
-		expect(checkedBinding).toHaveTextContent("false");
-		const checkbox = getByTestId("checkbox-item");
-		await user.click(checkbox);
-		expect(checkedBinding).toHaveTextContent("true");
-		await user.click(trigger);
-		expect(indicator).toHaveTextContent("true");
-		await user.click(getByTestId("checkbox-item"));
-		expect(checkedBinding).toHaveTextContent("false");
-
-		await user.click(checkedBinding);
-		expect(checkedBinding).toHaveTextContent("true");
-		await user.click(trigger);
-		expect(getByTestId("checkbox-indicator")).toHaveTextContent("true");
-	});
-
-	it("should toggle checkbox items within submenus when clicked & respects binding", async () => {
-		const props = await openWithKbd();
-		const { getByTestId, user, trigger } = props;
-		await openSubmenu(props);
-		const subCheckedBinding = getByTestId("sub-checked-binding");
-		expect(subCheckedBinding).toHaveTextContent("false");
-		const indicator = getByTestId("sub-checkbox-indicator");
-		expect(indicator).not.toHaveTextContent("true");
-		const subCheckbox = getByTestId("sub-checkbox-item");
-		await user.click(subCheckbox);
-		expect(subCheckedBinding).toHaveTextContent("true");
-		trigger.focus();
-		await user.keyboard(kbd.ARROW_DOWN);
-		await openSubmenu(props);
-		expect(getByTestId("sub-checkbox-indicator")).toHaveTextContent("true");
-		await user.click(getByTestId("sub-checkbox-item"));
-		expect(subCheckedBinding).toHaveTextContent("false");
-
-		await user.click(subCheckedBinding);
-		expect(subCheckedBinding).toHaveTextContent("true");
-		trigger.focus();
-		await user.keyboard(kbd.ARROW_DOWN);
-		await openSubmenu(props);
-		expect(getByTestId("sub-checkbox-indicator")).toHaveTextContent("true");
-	});
-
-	it("should check the radio item when clicked & respects binding", async () => {
-		const { getByTestId, queryByTestId, user, trigger } = await openWithPointer();
-		const radioBinding = getByTestId("radio-binding");
-		expect(radioBinding).toHaveTextContent("");
-		const radioItem1 = getByTestId("radio-item");
-		await user.click(radioItem1);
-		expect(radioBinding).toHaveTextContent("1");
-		await user.click(trigger);
-		const radioIndicator1 = getByTestId("radio-indicator-1");
-		expect(radioIndicator1).not.toBeNull();
-		expect(radioIndicator1).toHaveTextContent("true");
-		const radioItem2 = getByTestId("radio-item-2");
-		await user.click(radioItem2);
-		expect(radioBinding).toHaveTextContent("2");
-		await user.click(trigger);
-		expect(queryByTestId("radio-indicator-1")).toHaveTextContent("false");
-		expect(queryByTestId("radio-indicator-2")).toHaveTextContent("true");
-
-		await user.keyboard(kbd.ESCAPE);
-		expect(queryByTestId("content")).toBeNull();
-		await user.click(radioBinding);
-		expect(radioBinding).toHaveTextContent("");
-		await user.click(trigger);
-	});
-
-	it("should skip over disabled items when navigating with the keyboard", async () => {
-		const { user, getByTestId } = await openWithKbd();
-		await user.keyboard(kbd.ARROW_DOWN);
-		await waitFor(() => expect(getByTestId("sub-trigger")).toHaveFocus());
-		await user.keyboard(kbd.ARROW_DOWN);
-		await waitFor(() => expect(getByTestId("checkbox-item")).toHaveFocus());
-		expect(getByTestId("disabled-item")).not.toHaveFocus();
-		expect(getByTestId("disabled-item-2")).not.toHaveFocus();
-	});
-
-	it("should not loop through the menu items when the `loop` prop is set to false/undefined", async () => {
-		const { user, getByTestId } = await openWithKbd({
-			contentProps: {
-				loop: false,
+it("should allow preventing autofocusing first item with `onOpenAutoFocus`  prop", async () => {
+	const { getByTestId } = await openWithKbd({
+		contentProps: {
+			onOpenAutoFocus: (e) => {
+				e.preventDefault();
 			},
-		});
-		await user.keyboard(kbd.ARROW_DOWN);
-		await waitFor(() => expect(getByTestId("sub-trigger")).toHaveFocus());
-		await user.keyboard(kbd.ARROW_DOWN);
-		await waitFor(() => expect(getByTestId("checkbox-item")).toHaveFocus());
-		await user.keyboard(kbd.ARROW_DOWN);
-		await waitFor(() => expect(getByTestId("item-2")).toHaveFocus());
-		await user.keyboard(kbd.ARROW_DOWN);
-		await waitFor(() => expect(getByTestId("radio-item")).toHaveFocus());
-		await user.keyboard(kbd.ARROW_DOWN);
-		await waitFor(() => expect(getByTestId("radio-item-2")).toHaveFocus());
-		await user.keyboard(kbd.ARROW_DOWN);
-		await waitFor(() => expect(getByTestId("item")).not.toHaveFocus());
+		},
 	});
+	await waitFor(() => expect(getByTestId("item")).not.toHaveFocus());
+});
 
-	it("should loop through the menu items when the `loop` prop is set to true", async () => {
-		const { user, getByTestId } = await openWithKbd({
-			contentProps: {
-				loop: true,
-			},
-		});
-		await sleep(25);
-		await user.keyboard(kbd.ARROW_DOWN);
-		await waitFor(() => expect(getByTestId("sub-trigger")).toHaveFocus());
-		await user.keyboard(kbd.ARROW_DOWN);
-		await waitFor(() => expect(getByTestId("checkbox-item")).toHaveFocus());
-		await user.keyboard(kbd.ARROW_DOWN);
-		await waitFor(() => expect(getByTestId("item-2")).toHaveFocus());
-		await user.keyboard(kbd.ARROW_DOWN);
-		await waitFor(() => expect(getByTestId("radio-item")).toHaveFocus());
-		await user.keyboard(kbd.ARROW_DOWN);
-		await waitFor(() => expect(getByTestId("radio-item-2")).toHaveFocus());
-		await user.keyboard(kbd.ARROW_DOWN);
-		await waitFor(() => expect(getByTestId("item")).toHaveFocus());
+it("should forceMount the content when `forceMount` is true", async () => {
+	const { getByTestId } = setup({ component: DropdownMenuForceMountTest });
+
+	expect(getByTestId("content")).toBeVisible();
+});
+
+it("should forceMount the content when `forceMount` is true and the `open` snippet prop is used to conditionally render the content", async () => {
+	const { queryByTestId, getByTestId, user, trigger } = setup({
+		withOpenCheck: true,
+		component: DropdownMenuForceMountTest,
 	});
+	expect(queryByTestId("content")).toBeNull();
 
-	it("should close the menu on escape", async () => {
-		const { queryByTestId, user } = await openWithKbd();
-		await user.keyboard(kbd.ESCAPE);
-		expect(queryByTestId("content")).toBeNull();
-	});
+	await user.click(trigger);
 
-	it("should respect the `escapeKeydownBehavior` prop", async () => {
-		const { queryByTestId, user } = await openWithKbd({
-			contentProps: {
-				escapeKeydownBehavior: "ignore",
-			},
-		});
-		await user.keyboard(kbd.ESCAPE);
-		expect(queryByTestId("content")).not.toBeNull();
-	});
+	const content = getByTestId("content");
+	expect(content).toBeVisible();
+});
 
-	it("should respect the `interactOutsideBehavior` prop", async () => {
-		const { queryByTestId, user, getByTestId } = await openWithPointer({
-			contentProps: {
-				interactOutsideBehavior: "ignore",
-			},
-		});
-		const outside = getByTestId("outside");
-		await user.click(outside);
-		expect(queryByTestId("content")).not.toBeNull();
-	});
-
-	it("should portal to the body if a `portal` prop is not passed", async () => {
-		const { getByTestId } = await openWithPointer();
-		const content = getByTestId("content");
-		expect(content.parentElement?.parentElement).toEqual(document.body);
-	});
-
-	it("should portal to the portal target if a valid `portal` prop is passed", async () => {
-		const { getByTestId } = await openWithPointer({
-			portalProps: {
-				to: "#portal-target",
-			},
-		});
-		const content = getByTestId("content");
-		const portalTarget = getByTestId("portal-target");
-		expect(content.parentElement?.parentElement).toEqual(portalTarget);
-	});
-
-	it("should not portal if `disabled` is passed to the portal", async () => {
-		const { getByTestId } = await openWithPointer({
-			portalProps: {
-				disabled: true,
-			},
-		});
-		const content = getByTestId("content");
-		const ogContainer = getByTestId("non-portal-container");
-		const contentWrapper = content.parentElement;
-		expect(contentWrapper?.parentElement).not.toEqual(document.body);
-		expect(contentWrapper?.parentElement).toEqual(ogContainer);
-	});
-
-	it("should allow preventing autofocusing first item with `onOpenAutoFocus`  prop", async () => {
-		const { getByTestId } = await openWithKbd({
-			contentProps: {
-				onOpenAutoFocus: (e) => {
-					e.preventDefault();
-				},
-			},
-		});
-		await waitFor(() => expect(getByTestId("item")).not.toHaveFocus());
-	});
-
-	it("should forceMount the content when `forceMount` is true", async () => {
-		const { getByTestId } = setup({ component: DropdownMenuForceMountTest });
-
-		expect(getByTestId("content")).toBeVisible();
-	});
-
-	it("should forceMount the content when `forceMount` is true and the `open` snippet prop is used to conditionally render the content", async () => {
-		const { queryByTestId, getByTestId, user, trigger } = setup({
+it.each([DropdownMenuTest, DropdownMenuForceMountTest])(
+	"should close the menu and focus the next tabbable element when `TAB` is pressed while the menu is open",
+	async (component) => {
+		const { trigger, user, getByTestId, queryByTestId } = await openWithKbd({
+			component,
 			withOpenCheck: true,
-			component: DropdownMenuForceMountTest,
 		});
+		const nextButton = getByTestId("next-button");
+		await user.keyboard(kbd.TAB);
+		await waitFor(() => expect(nextButton).toHaveFocus());
+
 		expect(queryByTestId("content")).toBeNull();
-
 		await user.click(trigger);
+		await waitFor(() => expect(queryByTestId("content")).not.toBeNull());
+	}
+);
 
-		const content = getByTestId("content");
-		expect(content).toBeVisible();
-	});
-
-	it.each([DropdownMenuTest, DropdownMenuForceMountTest])(
-		"should close the menu and focus the next tabbable element when `TAB` is pressed while the menu is open",
-		async (component) => {
-			const { trigger, user, getByTestId, queryByTestId } = await openWithKbd({
-				component,
-				withOpenCheck: true,
-			});
-			const nextButton = getByTestId("next-button");
-			await user.keyboard(kbd.TAB);
-			await waitFor(() => expect(nextButton).toHaveFocus());
-
-			expect(queryByTestId("content")).toBeNull();
-			await user.click(trigger);
-			await waitFor(() => expect(queryByTestId("content")).not.toBeNull());
-		}
-	);
-
-	it.each([DropdownMenuTest, DropdownMenuForceMountTest])(
-		"should close the menu and focus the previous tabbable element when `SHIFT+TAB` is pressed while the menu is open",
-		async (component) => {
-			const { user, getByTestId, queryByTestId } = await openWithKbd({
-				component,
-				withOpenCheck: true,
-			});
-			const previousButton = getByTestId("previous-button");
-			await user.keyboard(kbd.SHIFT_TAB);
-			await waitFor(() => expect(previousButton).toHaveFocus());
-			expect(queryByTestId("content")).toBeNull();
-		}
-	);
-
-	it("should respect the `onSelect` prop on SubTrigger", async () => {
-		const onSelect = vi.fn();
-		const { getByTestId, user } = await openWithPointer({
-			subTriggerProps: {
-				onSelect,
-			},
+it.each([DropdownMenuTest, DropdownMenuForceMountTest])(
+	"should close the menu and focus the previous tabbable element when `SHIFT+TAB` is pressed while the menu is open",
+	async (component) => {
+		const { user, getByTestId, queryByTestId } = await openWithKbd({
+			component,
+			withOpenCheck: true,
 		});
+		const previousButton = getByTestId("previous-button");
+		await user.keyboard(kbd.SHIFT_TAB);
+		await waitFor(() => expect(previousButton).toHaveFocus());
+		expect(queryByTestId("content")).toBeNull();
+	}
+);
 
-		await user.click(getByTestId("sub-trigger"));
-		expect(onSelect).toHaveBeenCalled();
-
-		await user.keyboard(kbd.ENTER);
-		expect(onSelect).toHaveBeenCalledTimes(2);
-
-		await user.keyboard(kbd.ARROW_RIGHT);
-		expect(onSelect).toHaveBeenCalledTimes(3);
+it("should respect the `onSelect` prop on SubTrigger", async () => {
+	const onSelect = vi.fn();
+	const { getByTestId, user } = await openWithPointer({
+		subTriggerProps: {
+			onSelect,
+		},
 	});
+
+	await user.click(getByTestId("sub-trigger"));
+	expect(onSelect).toHaveBeenCalled();
+
+	await user.keyboard(kbd.ENTER);
+	expect(onSelect).toHaveBeenCalledTimes(2);
+
+	await user.keyboard(kbd.ARROW_RIGHT);
+	expect(onSelect).toHaveBeenCalledTimes(3);
+});
+
+it("should respect the `value` prop on CheckboxGroup", async () => {
+	const t = await openWithPointer({
+		group: ["1"],
+	});
+
+	const checkboxGroupItem1 = t.getByTestId("checkbox-group-item-1");
+	expect(checkboxGroupItem1).toHaveAttribute("aria-checked", "true");
+
+	expect(t.getByTestId("checkbox-indicator-1")).toHaveTextContent("true");
+	expect(t.queryByTestId("checkbox-indicator-2")).toHaveTextContent("false");
+
+	await t.user.click(checkboxGroupItem1);
+	await t.user.click(t.trigger);
+
+	expect(t.getByTestId("checkbox-indicator-1")).toHaveTextContent("false");
+	expect(t.getByTestId("checkbox-indicator-2")).toHaveTextContent("false");
+
+	await t.user.click(t.getByTestId("checkbox-group-item-2"));
+	await t.user.click(t.trigger);
+
+	expect(t.getByTestId("checkbox-indicator-1")).toHaveTextContent("false");
+	expect(t.getByTestId("checkbox-indicator-2")).toHaveTextContent("true");
+
+	await t.user.click(t.getByTestId("checkbox-group-binding"));
+	expect(t.getByTestId("checkbox-indicator-1")).toHaveTextContent("false");
+	expect(t.getByTestId("checkbox-indicator-2")).toHaveTextContent("false");
 });


### PR DESCRIPTION
Closes #1266 

This pull request introduces a new `CheckboxGroup` component to various menus (`ContextMenu`, `DropdownMenu`, and `Menubar`), along with corresponding documentation and API updates. The changes include the addition of the component, updates to documentation to demonstrate its usage, and modifications to type definitions and exports to support the new functionality.

### New Component Addition

* **`CheckboxGroup` Component**: Added the `CheckboxGroup` component to group multiple `CheckboxItem` components within menus, allowing multiple selections. This includes updates to the `ContextMenu`, `DropdownMenu`, and `Menubar` implementations. 

### Documentation Updates

* **Usage Examples**: Added examples for `CheckboxGroup` and `RadioGroup` in the documentation for `ContextMenu`, `DropdownMenu`, and `Menubar`. These examples demonstrate the binding of state and the structure of grouped menu items. 

### API Updates

* **API Definitions**: Extended the API schemas for `ContextMenu`, `DropdownMenu`, and `Menubar` to include the new `CheckboxGroup` component. This includes updates to type imports, property definitions, and data attributes. 