### PR TITLE
fix(NavigationMenu): submenu/viewport residual transition issues

### DIFF
--- a/.changeset/dry-bees-yawn.md
+++ b/.changeset/dry-bees-yawn.md
@@ -1,0 +1,5 @@
+---
+"bits-ui": patch
+---
+
+fix(NavigationMenu): moving from submenu trigger to menu item in the same menu should close the submenu

--- a/.changeset/moody-carrots-ring.md
+++ b/.changeset/moody-carrots-ring.md
@@ -1,0 +1,5 @@
+---
+"bits-ui": patch
+---
+
+fix(NavigationMenu): issues with non-viewport transitions

--- a/docs/content/components/navigation-menu.md
+++ b/docs/content/components/navigation-menu.md
@@ -4,7 +4,7 @@ description: A list of links that allow users to navigate between pages of a web
 ---
 
 <script>
-	import { APISection, ComponentPreviewV2, NavigationMenuDemo, Callout, NavigationMenuDemoForceMount } from '$lib/components/index.js'
+	import { APISection, ComponentPreviewV2, NavigationMenuDemo, Callout, NavigationMenuDemoForceMount, NavigationMenuDemoSubmenu, NavigationMenuDemoNoViewport } from '$lib/components/index.js'
 	let { schemas } = $props()
 </script>
 
@@ -115,33 +115,25 @@ You can use the optional `Indicator` component to highlight the currently active
 You can create a submenu by nesting your navigation menu and using the `Navigation.Sub` component in place of `NavigationMenu.Root`.
 Submenus work differently than the `Root` menus and are more similar to [Tabs](/docs/components/tabs) in that one item should always be active, so be sure to assign and pass a `value` prop.
 
-```svelte
-<NavigationMenu.Root>
-	<NavigationMenu.List>
-		<NavigationMenu.Item>
-			<NavigationMenu.Trigger>Item one</NavigationMenu.Trigger>
-			<NavigationMenu.Content>Item one content</NavigationMenu.Content>
-		</NavigationMenu.Item>
-		<NavigationMenu.Item>
-			<NavigationMenu.Trigger>Item two</NavigationMenu.Trigger>
-			<NavigationMenu.Content>
-				<NavigationMenu.Sub value="sub1">
-					<NavigationMenu.List>
-						<NavigationMenu.Item value="sub1">
-							<NavigationMenu.Trigger>Sub item one</NavigationMenu.Trigger>
-							<NavigationMenu.Content>Sub item one content</NavigationMenu.Content>
-						</NavigationMenu.Item>
-						<NavigationMenu.Item value="sub2">
-							<NavigationMenu.Trigger>Sub item two</NavigationMenu.Trigger>
-							<NavigationMenu.Content>Sub item two content</NavigationMenu.Content>
-						</NavigationMenu.Item>
-					</NavigationMenu.List>
-				</NavigationMenu.Sub>
-			</NavigationMenu.Content>
-		</NavigationMenu.Item>
-	</NavigationMenu.List>
-</NavigationMenu.Root>
-```
+<ComponentPreviewV2 name="navigation-menu-submenu-demo" componentName="Navigation Menu">
+
+{#snippet preview()}
+<NavigationMenuDemoSubmenu />
+{/snippet}
+
+</ComponentPreviewV2>
+
+### No Viewport
+
+The `NavigationMenu.Viewport` component provides a way to transition between `NavigationMenu.Content` without the need for a full close/open animation between them, however, this is completely optional and you don't need to use it.
+
+<ComponentPreviewV2 name="navigation-menu-no-viewport-demo" componentName="Navigation Menu">
+
+{#snippet preview()}
+<NavigationMenuDemoNoViewport />
+{/snippet}
+
+</ComponentPreviewV2>
 
 ### Advanced Animation
 

--- a/docs/src/lib/components/demos/index.ts
+++ b/docs/src/lib/components/demos/index.ts
@@ -46,6 +46,8 @@ export { default as MeterDemo } from "./meter-demo.svelte";
 export { default as MeterDemoCustom } from "./meter-demo-custom.svelte";
 export { default as NavigationMenuDemo } from "./navigation-menu-demo.svelte";
 export { default as NavigationMenuDemoForceMount } from "./navigation-menu-demo-force-mount.svelte";
+export { default as NavigationMenuDemoSubmenu } from "./navigation-menu-submenu-demo.svelte";
+export { default as NavigationMenuDemoNoViewport } from "./navigation-menu-no-viewport-demo.svelte";
 export { default as PaginationDemo } from "./pagination-demo.svelte";
 export { default as PinInputDemo } from "./pin-input-demo.svelte";
 export { default as PopoverDemo } from "./popover-demo.svelte";

--- a/docs/src/lib/components/demos/navigation-menu-no-viewport-demo.svelte
+++ b/docs/src/lib/components/demos/navigation-menu-no-viewport-demo.svelte
@@ -1,0 +1,153 @@
+<script lang="ts">
+	import { NavigationMenu } from "bits-ui";
+	import CaretDown from "phosphor-svelte/lib/CaretDown";
+	import { cn } from "$lib/utils/styles.js";
+
+	const components: { title: string; href: string; description: string }[] = [
+		{
+			title: "Alert Dialog",
+			href: "/docs/components/alert-dialog",
+			description:
+				"A modal dialog that interrupts the user with important content and expects a response.",
+		},
+		{
+			title: "Link Preview",
+			href: "/docs/components/link-preview",
+			description: "For sighted users to preview content available behind a link.",
+		},
+		{
+			title: "Progress",
+			href: "/docs/components/progress",
+			description:
+				"Displays an indicator showing the completion progress of a task, typically displayed as a progress bar.",
+		},
+		{
+			title: "Scroll Area",
+			href: "/docs/components/scroll-area",
+			description: "Visually or semantically separates content.",
+		},
+		{
+			title: "Tabs",
+			href: "/docs/components/tabs",
+			description:
+				"A set of layered sections of content—known as tab panels—that are displayed one at a time.",
+		},
+		{
+			title: "Tooltip",
+			href: "/docs/components/tooltip",
+			description:
+				"A popup that displays information related to an element when the element receives keyboard focus or the mouse hovers over it.",
+		},
+	];
+
+	type ListItemProps = {
+		className?: string;
+		title: string;
+		href: string;
+		content: string;
+	};
+</script>
+
+{#snippet ListItem({ className, title, content, href }: ListItemProps)}
+	<li>
+		<NavigationMenu.Link
+			class={cn(
+				"hover:bg-muted hover:text-accent-foreground focus:bg-muted focus:text-accent-foreground outline-hidden block select-none space-y-1 rounded-md p-3 leading-none no-underline transition-colors",
+				className
+			)}
+			{href}
+		>
+			<div class="text-sm font-medium leading-none">{title}</div>
+			<p class="text-muted-foreground line-clamp-2 text-sm leading-snug">
+				{content}
+			</p>
+		</NavigationMenu.Link>
+	</li>
+{/snippet}
+
+<NavigationMenu.Root class="relative z-10 flex w-full justify-center">
+	<NavigationMenu.List class="group flex list-none items-center justify-center p-1">
+		<NavigationMenu.Item value="getting-started">
+			<NavigationMenu.Trigger
+				class="hover:text-accent-foreground focus:bg-muted focus:text-accent-foreground data-[state=open]:shadow-mini dark:hover:bg-muted dark:data-[state=open]:bg-muted focus:outline-hidden group inline-flex h-8 w-max items-center justify-center rounded-[7px] bg-transparent px-4 py-2 text-sm font-medium transition-colors hover:bg-white disabled:pointer-events-none disabled:opacity-50 data-[state=open]:bg-white"
+			>
+				Getting started
+				<CaretDown
+					class="relative top-[1px] ml-1 size-3 transition-transform duration-200 group-data-[state=open]:rotate-180"
+					aria-hidden="true"
+				/>
+			</NavigationMenu.Trigger>
+			<NavigationMenu.Content
+				class="data-[motion=from-end]:animate-enter-from-right data-[motion=from-start]:animate-enter-from-left data-[motion=to-end]:animate-exit-to-right data-[motion=to-start]:animate-exit-to-left data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 bg-background absolute left-0 top-full mt-2 w-full rounded-md border shadow-lg sm:w-auto"
+			>
+				<ul
+					class="m-0 grid list-none gap-x-2.5 p-3 sm:w-[600px] sm:grid-flow-col sm:grid-rows-3 sm:p-[22px]"
+				>
+					<li class="row-span-3 mb-2 sm:mb-0">
+						<NavigationMenu.Link
+							href="/"
+							class="from-muted/50 to-muted bg-linear-to-b outline-hidden flex h-full w-full select-none flex-col justify-end rounded-md p-6 no-underline focus:shadow-md"
+						>
+							<!-- <Icons.logo class="h-6 w-6" /> -->
+							<div class="mb-2 mt-4 text-lg font-medium">Bits UI</div>
+							<p class="text-muted-foreground text-sm leading-tight">
+								The headless components for Svelte.
+							</p>
+						</NavigationMenu.Link>
+					</li>
+
+					{@render ListItem({
+						href: "/docs",
+						title: "Introduction",
+						content: "Headless components for Svelte and SvelteKit",
+					})}
+					{@render ListItem({
+						href: "/docs/getting-started",
+						title: "Getting Started",
+						content: "How to install and use Bits UI",
+					})}
+					{@render ListItem({
+						href: "/docs/styling",
+						title: "Styling",
+						content: "How to style Bits UI components",
+					})}
+				</ul>
+			</NavigationMenu.Content>
+		</NavigationMenu.Item>
+		<NavigationMenu.Item>
+			<NavigationMenu.Trigger
+				class="hover:text-accent-foreground focus:bg-muted focus:text-accent-foreground data-[state=open]:shadow-mini dark:hover:bg-muted dark:data-[state=open]:bg-muted focus:outline-hidden group inline-flex h-8 w-max items-center justify-center rounded-[7px] bg-transparent px-4 py-2 text-sm font-medium transition-colors hover:bg-white disabled:pointer-events-none disabled:opacity-50 data-[state=open]:bg-white"
+			>
+				Components
+				<CaretDown
+					class="relative top-[1px] ml-1 size-3 transition-transform duration-200 group-data-[state=open]:rotate-180"
+					aria-hidden="true"
+				/>
+			</NavigationMenu.Trigger>
+			<NavigationMenu.Content
+				class="data-[motion=from-end]:animate-enter-from-right data-[motion=from-start]:animate-enter-from-left data-[motion=to-end]:animate-exit-to-right data-[motion=to-start]:animate-exit-to-left data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 bg-background absolute left-0 top-full mt-2 w-full rounded-md border shadow-lg sm:w-auto"
+			>
+				<ul
+					class="grid gap-3 p-3 sm:w-[400px] sm:p-6 md:w-[500px] md:grid-cols-2 lg:w-[600px]"
+				>
+					{#each components as component (component.title)}
+						{@render ListItem({
+							href: component.href,
+							title: component.title,
+							content: component.description,
+						})}
+					{/each}
+				</ul>
+			</NavigationMenu.Content>
+		</NavigationMenu.Item>
+		<NavigationMenu.Item>
+			<NavigationMenu.Link
+				class="hover:text-accent-foreground focus:bg-muted focus:text-accent-foreground data-[state=open]:shadow-mini dark:hover:bg-muted dark:data-[state=open]:bg-muted focus:outline-hidden group inline-flex h-8 w-max items-center justify-center rounded-[7px] bg-transparent px-4 py-2 text-sm font-medium transition-colors hover:bg-white disabled:pointer-events-none disabled:opacity-50 data-[state=open]:bg-white"
+				href="/docs"
+			>
+				<span class="hidden sm:inline"> Documentation </span>
+				<span class="inline sm:hidden"> Docs </span>
+			</NavigationMenu.Link>
+		</NavigationMenu.Item>
+	</NavigationMenu.List>
+</NavigationMenu.Root>

--- a/docs/src/lib/components/demos/navigation-menu-submenu-demo.svelte
+++ b/docs/src/lib/components/demos/navigation-menu-submenu-demo.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
 	import { NavigationMenu } from "bits-ui";
 	import CaretDown from "phosphor-svelte/lib/CaretDown";
-	import CaretRight from "phosphor-svelte/lib/CaretRight";
 	import { cn } from "$lib/utils/styles.js";
 
 	const components: { title: string; href: string; description: string }[] = [
@@ -91,21 +90,21 @@
 {/snippet}
 
 {#snippet SubmenuItem({ className, title, value, items }: SubmenuItemProps)}
-	<NavigationMenu.Item {value} class="relative">
+	<NavigationMenu.Item {value} class="relative w-full">
 		<NavigationMenu.Trigger
 			class={cn(
-				"hover:bg-muted hover:text-accent-foreground focus:bg-muted focus:text-accent-foreground outline-hidden group flex w-full select-none items-center justify-between space-y-1 rounded-md p-3 leading-none no-underline transition-colors",
+				"hover:bg-muted hover:text-accent-foreground focus:bg-muted focus:text-accent-foreground outline-hidden data-[state=open]:bg-muted group flex w-full select-none items-center justify-between space-y-1 rounded-md p-3 leading-none no-underline transition-colors",
 				className
 			)}
 		>
 			<div class="text-sm font-medium leading-none">{title}</div>
-			<CaretRight
-				class="ml-auto size-4 transition-transform duration-200 group-data-[state=open]:rotate-90"
+			<CaretDown
+				class="ml-auto size-4 transition-transform duration-200 group-data-[state=open]:rotate-180"
 				aria-hidden="true"
 			/>
 		</NavigationMenu.Trigger>
 		<NavigationMenu.Content
-			class="bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-right-1 data-[state=open]:slide-in-from-right-1 absolute left-full top-0 z-50 ml-2 min-w-[300px] rounded-md border shadow-lg transition-all duration-200 ease-out"
+			class="bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-right-1 data-[state=open]:slide-in-from-right-1 absolute left-0 top-full z-50 mt-2 w-full min-w-[300px] rounded-md border shadow-lg transition-all duration-200 ease-out"
 		>
 			<ul class="grid gap-1 p-2">
 				{#each items as item (item.title)}
@@ -200,18 +199,19 @@
 									})}
 								</NavigationMenu.Item>
 							{/each}
+							<div class="flex items-center justify-between">
+								{@render SubmenuItem({
+									title: "Utilities",
+									value: "utilities",
+									items: utilities,
+								})}
 
-							{@render SubmenuItem({
-								title: "Utilities",
-								value: "utilities",
-								items: utilities,
-							})}
-
-							{@render SubmenuItem({
-								title: "Type Helpers",
-								value: "type-helpers",
-								items: typeHelpers,
-							})}
+								{@render SubmenuItem({
+									title: "Type Helpers",
+									value: "type-helpers",
+									items: typeHelpers,
+								})}
+							</div>
 						</NavigationMenu.List>
 					</NavigationMenu.Sub>
 				</div>

--- a/docs/src/lib/components/demos/navigation-menu-submenu-demo.svelte
+++ b/docs/src/lib/components/demos/navigation-menu-submenu-demo.svelte
@@ -24,39 +24,39 @@
 		},
 	];
 
-	const designComponents = [
+	const typeHelpers = [
 		{
-			title: "Colors",
-			href: "/docs/design-system/colors",
-			description: "Curated color palettes and tokens",
+			title: "WithElementRef",
+			href: "/docs/type-helpers/with-element-ref",
+			description: "Expose a ref to the element.",
 		},
 		{
-			title: "Typography",
-			href: "/docs/design-system/typography",
-			description: "Font scales and text styling",
+			title: "WithoutChild",
+			href: "/docs/type-helpers/without-child",
+			description: "Remove the child snippet prop from a props type.",
 		},
 		{
-			title: "Spacing",
-			href: "/docs/design-system/spacing",
-			description: "Consistent spacing patterns",
+			title: "WithoutChildrenOrChild",
+			href: "/docs/type-helpers/without-children-or-child",
+			description: "Remove the children and child snippet props from a props type.",
 		},
 	];
 
-	const advancedComponents = [
+	const utilities = [
 		{
-			title: "Data Table",
-			href: "/docs/components/data-table",
-			description: "Complex data display with sorting and filtering",
+			title: "mergeProps",
+			href: "/docs/utilities/merge-props",
+			description: "Merge multiple objects into a single object",
 		},
 		{
-			title: "Command Palette",
-			href: "/docs/components/command-palette",
-			description: "Fast, accessible command interface",
+			title: "Portal",
+			href: "/docs/utilities/portal",
+			description: "Render a component in a different part of the DOM",
 		},
 		{
-			title: "Calendar",
-			href: "/docs/components/calendar",
-			description: "Date selection and scheduling",
+			title: "IsUsingKeyboard",
+			href: "/docs/utilities/is-using-keyboard",
+			description: "Check if the user is using a keyboard",
 		},
 	];
 
@@ -76,20 +76,18 @@
 </script>
 
 {#snippet ListItem({ className, title, content, href }: ListItemProps)}
-	<li>
-		<NavigationMenu.Link
-			class={cn(
-				"hover:bg-muted hover:text-accent-foreground focus:bg-muted focus:text-accent-foreground outline-hidden block select-none space-y-1 rounded-md p-3 leading-none no-underline transition-colors",
-				className
-			)}
-			{href}
-		>
-			<div class="text-sm font-medium leading-none">{title}</div>
-			<p class="text-muted-foreground line-clamp-2 text-sm leading-snug">
-				{content}
-			</p>
-		</NavigationMenu.Link>
-	</li>
+	<NavigationMenu.Link
+		class={cn(
+			"hover:bg-muted hover:text-accent-foreground focus:bg-muted focus:text-accent-foreground outline-hidden block select-none space-y-1 rounded-md p-3 leading-none no-underline transition-colors",
+			className
+		)}
+		{href}
+	>
+		<div class="text-sm font-medium leading-none">{title}</div>
+		<p class="text-muted-foreground line-clamp-2 text-sm leading-snug">
+			{content}
+		</p>
+	</NavigationMenu.Link>
 {/snippet}
 
 {#snippet SubmenuItem({ className, title, value, items }: SubmenuItemProps)}
@@ -171,11 +169,11 @@
 				</ul>
 			</NavigationMenu.Content>
 		</NavigationMenu.Item>
-		<NavigationMenu.Item value="components">
+		<NavigationMenu.Item value="features">
 			<NavigationMenu.Trigger
 				class="hover:text-accent-foreground focus:bg-muted focus:text-accent-foreground data-[state=open]:shadow-mini dark:hover:bg-muted dark:data-[state=open]:bg-muted focus:outline-hidden group inline-flex h-8 w-max items-center justify-center rounded-[7px] bg-transparent px-4 py-2 text-sm font-medium transition-colors hover:bg-white disabled:pointer-events-none disabled:opacity-50 data-[state=open]:bg-white"
 			>
-				Components
+				Features
 				<CaretDown
 					class="relative top-[1px] ml-1 size-3 transition-transform duration-200 group-data-[state=open]:rotate-180"
 					aria-hidden="true"
@@ -189,29 +187,30 @@
 						<NavigationMenu.List class="flex flex-col space-y-1">
 							<li>
 								<div class="text-muted-foreground px-3 py-2 text-sm font-medium">
-									Basic Components
+									Components
 								</div>
-								<ul class="space-y-1">
-									{#each components as component (component.title)}
-										{@render ListItem({
-											href: component.href,
-											title: component.title,
-											content: component.description,
-										})}
-									{/each}
-								</ul>
 							</li>
 
+							{#each components as component (component.title)}
+								<NavigationMenu.Item>
+									{@render ListItem({
+										href: component.href,
+										title: component.title,
+										content: component.description,
+									})}
+								</NavigationMenu.Item>
+							{/each}
+
 							{@render SubmenuItem({
-								title: "Advanced Components",
-								value: "advanced-components",
-								items: advancedComponents,
+								title: "Utilities",
+								value: "utilities",
+								items: utilities,
 							})}
 
 							{@render SubmenuItem({
-								title: "Design System",
-								value: "design-system",
-								items: designComponents,
+								title: "Type Helpers",
+								value: "type-helpers",
+								items: typeHelpers,
 							})}
 						</NavigationMenu.List>
 					</NavigationMenu.Sub>

--- a/docs/src/lib/components/demos/navigation-menu-submenu-demo.svelte
+++ b/docs/src/lib/components/demos/navigation-menu-submenu-demo.svelte
@@ -1,0 +1,243 @@
+<script lang="ts">
+	import { NavigationMenu } from "bits-ui";
+	import CaretDown from "phosphor-svelte/lib/CaretDown";
+	import CaretRight from "phosphor-svelte/lib/CaretRight";
+	import { cn } from "$lib/utils/styles.js";
+
+	const components: { title: string; href: string; description: string }[] = [
+		{
+			title: "Alert Dialog",
+			href: "/docs/components/alert-dialog",
+			description:
+				"A modal dialog that interrupts the user with important content and expects a response.",
+		},
+		{
+			title: "Link Preview",
+			href: "/docs/components/link-preview",
+			description: "For sighted users to preview content available behind a link.",
+		},
+		{
+			title: "Progress",
+			href: "/docs/components/progress",
+			description:
+				"Displays an indicator showing the completion progress of a task, typically displayed as a progress bar.",
+		},
+	];
+
+	const designComponents = [
+		{
+			title: "Colors",
+			href: "/docs/design-system/colors",
+			description: "Curated color palettes and tokens",
+		},
+		{
+			title: "Typography",
+			href: "/docs/design-system/typography",
+			description: "Font scales and text styling",
+		},
+		{
+			title: "Spacing",
+			href: "/docs/design-system/spacing",
+			description: "Consistent spacing patterns",
+		},
+	];
+
+	const advancedComponents = [
+		{
+			title: "Data Table",
+			href: "/docs/components/data-table",
+			description: "Complex data display with sorting and filtering",
+		},
+		{
+			title: "Command Palette",
+			href: "/docs/components/command-palette",
+			description: "Fast, accessible command interface",
+		},
+		{
+			title: "Calendar",
+			href: "/docs/components/calendar",
+			description: "Date selection and scheduling",
+		},
+	];
+
+	type ListItemProps = {
+		className?: string;
+		title: string;
+		href: string;
+		content: string;
+	};
+
+	type SubmenuItemProps = {
+		className?: string;
+		title: string;
+		value: string;
+		items: { title: string; href: string; description: string }[];
+	};
+</script>
+
+{#snippet ListItem({ className, title, content, href }: ListItemProps)}
+	<li>
+		<NavigationMenu.Link
+			class={cn(
+				"hover:bg-muted hover:text-accent-foreground focus:bg-muted focus:text-accent-foreground outline-hidden block select-none space-y-1 rounded-md p-3 leading-none no-underline transition-colors",
+				className
+			)}
+			{href}
+		>
+			<div class="text-sm font-medium leading-none">{title}</div>
+			<p class="text-muted-foreground line-clamp-2 text-sm leading-snug">
+				{content}
+			</p>
+		</NavigationMenu.Link>
+	</li>
+{/snippet}
+
+{#snippet SubmenuItem({ className, title, value, items }: SubmenuItemProps)}
+	<NavigationMenu.Item {value} class="relative">
+		<NavigationMenu.Trigger
+			class={cn(
+				"hover:bg-muted hover:text-accent-foreground focus:bg-muted focus:text-accent-foreground outline-hidden group flex w-full select-none items-center justify-between space-y-1 rounded-md p-3 leading-none no-underline transition-colors",
+				className
+			)}
+		>
+			<div class="text-sm font-medium leading-none">{title}</div>
+			<CaretRight
+				class="ml-auto size-4 transition-transform duration-200 group-data-[state=open]:rotate-90"
+				aria-hidden="true"
+			/>
+		</NavigationMenu.Trigger>
+		<NavigationMenu.Content
+			class="data-[motion=from-end]:animate-enter-from-right data-[motion=from-start]:animate-enter-from-left data-[motion=to-end]:animate-exit-to-right data-[motion=to-start]:animate-exit-to-left bg-background absolute left-full top-0 z-50 -ml-1 min-w-[300px] rounded-md border shadow-lg"
+		>
+			<ul class="grid gap-1 p-2">
+				{#each items as item (item.title)}
+					{@render ListItem({
+						href: item.href,
+						title: item.title,
+						content: item.description,
+					})}
+				{/each}
+			</ul>
+		</NavigationMenu.Content>
+	</NavigationMenu.Item>
+{/snippet}
+
+<NavigationMenu.Root class="relative z-10 flex w-full justify-center">
+	<NavigationMenu.List class="group flex list-none items-center justify-center p-1">
+		<NavigationMenu.Item value="getting-started">
+			<NavigationMenu.Trigger
+				class="hover:text-accent-foreground focus:bg-muted focus:text-accent-foreground data-[state=open]:shadow-mini dark:hover:bg-muted dark:data-[state=open]:bg-muted focus:outline-hidden group inline-flex h-8 w-max items-center justify-center rounded-[7px] bg-transparent px-4 py-2 text-sm font-medium transition-colors hover:bg-white disabled:pointer-events-none disabled:opacity-50 data-[state=open]:bg-white"
+			>
+				Getting started
+				<CaretDown
+					class="relative top-[1px] ml-1 size-3 transition-transform duration-200 group-data-[state=open]:rotate-180"
+					aria-hidden="true"
+				/>
+			</NavigationMenu.Trigger>
+			<NavigationMenu.Content
+				class="data-[motion=from-end]:animate-enter-from-right data-[motion=from-start]:animate-enter-from-left data-[motion=to-end]:animate-exit-to-right data-[motion=to-start]:animate-exit-to-left absolute left-0 top-0 w-full sm:w-auto"
+			>
+				<ul
+					class="m-0 grid list-none gap-x-2.5 p-3 sm:w-[600px] sm:grid-flow-col sm:grid-rows-3 sm:p-[22px]"
+				>
+					<li class="row-span-3 mb-2 sm:mb-0">
+						<NavigationMenu.Link
+							href="/"
+							class="from-muted/50 to-muted bg-linear-to-b outline-hidden flex h-full w-full select-none flex-col justify-end rounded-md p-6 no-underline focus:shadow-md"
+						>
+							<!-- <Icons.logo class="h-6 w-6" /> -->
+							<div class="mb-2 mt-4 text-lg font-medium">Bits UI</div>
+							<p class="text-muted-foreground text-sm leading-tight">
+								The headless components for Svelte.
+							</p>
+						</NavigationMenu.Link>
+					</li>
+
+					{@render ListItem({
+						href: "/docs",
+						title: "Introduction",
+						content: "Headless components for Svelte and SvelteKit",
+					})}
+					{@render ListItem({
+						href: "/docs/getting-started",
+						title: "Getting Started",
+						content: "How to install and use Bits UI",
+					})}
+					{@render ListItem({
+						href: "/docs/styling",
+						title: "Styling",
+						content: "How to style Bits UI components",
+					})}
+				</ul>
+			</NavigationMenu.Content>
+		</NavigationMenu.Item>
+		<NavigationMenu.Item value="components">
+			<NavigationMenu.Trigger
+				class="hover:text-accent-foreground focus:bg-muted focus:text-accent-foreground data-[state=open]:shadow-mini dark:hover:bg-muted dark:data-[state=open]:bg-muted focus:outline-hidden group inline-flex h-8 w-max items-center justify-center rounded-[7px] bg-transparent px-4 py-2 text-sm font-medium transition-colors hover:bg-white disabled:pointer-events-none disabled:opacity-50 data-[state=open]:bg-white"
+			>
+				Components
+				<CaretDown
+					class="relative top-[1px] ml-1 size-3 transition-transform duration-200 group-data-[state=open]:rotate-180"
+					aria-hidden="true"
+				/>
+			</NavigationMenu.Trigger>
+			<NavigationMenu.Content
+				class="data-[motion=from-end]:animate-enter-from-right data-[motion=from-start]:animate-enter-from-left data-[motion=to-end]:animate-exit-to-right data-[motion=to-start]:animate-exit-to-left absolute left-0 top-0 w-full sm:w-auto"
+			>
+				<div class="relative overflow-visible p-3 sm:w-[500px] sm:p-6">
+					<NavigationMenu.Sub orientation="vertical" class="w-full">
+						<NavigationMenu.List class="flex flex-col space-y-1">
+							<li>
+								<div class="text-muted-foreground px-3 py-2 text-sm font-medium">
+									Basic Components
+								</div>
+								<ul class="space-y-1">
+									{#each components as component (component.title)}
+										{@render ListItem({
+											href: component.href,
+											title: component.title,
+											content: component.description,
+										})}
+									{/each}
+								</ul>
+							</li>
+
+							{@render SubmenuItem({
+								title: "Advanced Components",
+								value: "advanced-components",
+								items: advancedComponents,
+							})}
+
+							{@render SubmenuItem({
+								title: "Design System",
+								value: "design-system",
+								items: designComponents,
+							})}
+						</NavigationMenu.List>
+					</NavigationMenu.Sub>
+				</div>
+			</NavigationMenu.Content>
+		</NavigationMenu.Item>
+		<NavigationMenu.Item>
+			<NavigationMenu.Link
+				class="hover:text-accent-foreground focus:bg-muted focus:text-accent-foreground data-[state=open]:shadow-mini dark:hover:bg-muted dark:data-[state=open]:bg-muted focus:outline-hidden group inline-flex h-8 w-max items-center justify-center rounded-[7px] bg-transparent px-4 py-2 text-sm font-medium transition-colors hover:bg-white disabled:pointer-events-none disabled:opacity-50 data-[state=open]:bg-white"
+				href="/docs"
+			>
+				<span class="hidden sm:inline"> Documentation </span>
+				<span class="inline sm:hidden"> Docs </span>
+			</NavigationMenu.Link>
+		</NavigationMenu.Item>
+		<NavigationMenu.Indicator
+			class="data-[state=hidden]:animate-fade-out data-[state=visible]:animate-fade-in top-full z-10 flex h-2.5 items-end justify-center overflow-hidden opacity-100 transition-[all,transform_250ms_ease] duration-200 data-[state=hidden]:opacity-0"
+		>
+			<div
+				class="bg-border relative top-[70%] size-2.5 rotate-[45deg] rounded-tl-[2px]"
+			></div>
+		</NavigationMenu.Indicator>
+	</NavigationMenu.List>
+	<div class="perspective-[2000px] absolute left-0 top-full flex w-full justify-center">
+		<NavigationMenu.Viewport
+			class="text-popover-foreground bg-background data-[state=closed]:animate-scale-out data-[state=open]:animate-scale-in relative mt-2.5 h-[var(--bits-navigation-menu-viewport-height)] w-full origin-[top_center] overflow-visible rounded-md border shadow-lg transition-[width,_height] duration-200 sm:w-[var(--bits-navigation-menu-viewport-width)]"
+		/>
+	</div>
+</NavigationMenu.Root>

--- a/docs/src/lib/components/demos/navigation-menu-submenu-demo.svelte
+++ b/docs/src/lib/components/demos/navigation-menu-submenu-demo.svelte
@@ -105,7 +105,7 @@
 			/>
 		</NavigationMenu.Trigger>
 		<NavigationMenu.Content
-			class="data-[motion=from-end]:animate-enter-from-right data-[motion=from-start]:animate-enter-from-left data-[motion=to-end]:animate-exit-to-right data-[motion=to-start]:animate-exit-to-left bg-background absolute left-full top-0 z-50 -ml-1 min-w-[300px] rounded-md border shadow-lg"
+			class="bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-right-1 data-[state=open]:slide-in-from-right-1 absolute left-full top-0 z-50 ml-2 min-w-[300px] rounded-md border shadow-lg transition-all duration-200 ease-out"
 		>
 			<ul class="grid gap-1 p-2">
 				{#each items as item (item.title)}

--- a/packages/bits-ui/src/lib/bits/navigation-menu/components/navigation-menu-viewport.svelte
+++ b/packages/bits-ui/src/lib/bits/navigation-menu/components/navigation-menu-viewport.svelte
@@ -4,6 +4,7 @@
 	import { useId } from "$lib/internal/use-id.js";
 	import PresenceLayer from "$lib/bits/utilities/presence-layer/presence-layer.svelte";
 	import { box, mergeProps } from "svelte-toolbelt";
+	import { Mounted } from "$lib/bits/utilities/index.js";
 
 	let {
 		id = useId(),
@@ -34,5 +35,6 @@
 				{@render children?.()}
 			</div>
 		{/if}
+		<Mounted bind:mounted={viewportState.mounted} />
 	{/snippet}
 </PresenceLayer>

--- a/packages/bits-ui/src/lib/bits/navigation-menu/navigation-menu.svelte.ts
+++ b/packages/bits-ui/src/lib/bits/navigation-menu/navigation-menu.svelte.ts
@@ -39,6 +39,7 @@ import { useArrowNavigation } from "$lib/internal/use-arrow-navigation.js";
 import { boxAutoReset } from "$lib/internal/box-auto-reset.svelte.js";
 import { useResizeObserver } from "$lib/internal/use-resize-observer.svelte.js";
 import { isElement } from "$lib/internal/is.js";
+import type { PointerEventHandler } from "svelte/elements";
 
 const NAVIGATION_MENU_ROOT_ATTR = "data-navigation-menu-root";
 const NAVIGATION_MENU_ATTR = "data-navigation-menu";
@@ -570,6 +571,26 @@ class NavigationMenuLinkState {
 		this.isFocused = false;
 	};
 
+	onpointerenter: PointerEventHandler<HTMLAnchorElement> = () => {
+		// only close submenu if this link is not inside the currently open submenu content
+		const currentlyOpenValue = this.context.provider.opts.value.current;
+		const isInsideOpenSubmenu = this.context.item.opts.value.current === currentlyOpenValue;
+
+		if (!isInsideOpenSubmenu && currentlyOpenValue) {
+			this.context.provider.onItemDismiss();
+		}
+	};
+
+	onpointermove = whenMouse(() => {
+		// Only close submenu if this link is not inside the currently open submenu content
+		const currentlyOpenValue = this.context.provider.opts.value.current;
+		const isInsideOpenSubmenu = this.context.item.opts.value.current === currentlyOpenValue;
+
+		if (!isInsideOpenSubmenu && currentlyOpenValue) {
+			this.context.provider.onItemDismiss();
+		}
+	});
+
 	props = $derived.by(
 		() =>
 			({
@@ -581,6 +602,8 @@ class NavigationMenuLinkState {
 				onkeydown: this.onkeydown,
 				onfocus: this.onfocus,
 				onblur: this.onblur,
+				onpointerenter: this.onpointerenter,
+				onpointermove: this.onpointermove,
 				[NAVIGATION_MENU_LINK_ATTR]: "",
 			}) as const
 	);

--- a/packages/bits-ui/src/lib/bits/navigation-menu/navigation-menu.svelte.ts
+++ b/packages/bits-ui/src/lib/bits/navigation-menu/navigation-menu.svelte.ts
@@ -474,7 +474,7 @@ class NavigationMenuTriggerState {
 		this.itemContext.listContext.rovingFocusGroup.handleKeydown(this.opts.ref.current, e);
 	};
 
-	focusProxyOnFocus: FocusEventHandler<HTMLButtonElement> = (e) => {
+	focusProxyOnFocus: FocusEventHandler<HTMLElement> = (e) => {
 		const content = this.itemContext.contentNode;
 		const prevFocusedElement = e.relatedTarget as HTMLElement | null;
 		const wasTriggerFocused =

--- a/packages/bits-ui/src/lib/bits/navigation-menu/navigation-menu.svelte.ts
+++ b/packages/bits-ui/src/lib/bits/navigation-menu/navigation-menu.svelte.ts
@@ -45,7 +45,6 @@ import type {
 	MouseEventHandler,
 	PointerEventHandler,
 } from "svelte/elements";
-import { useGraceArea } from "$lib/internal/use-grace-area.svelte.js";
 
 const NAVIGATION_MENU_ROOT_ATTR = "data-navigation-menu-root";
 const NAVIGATION_MENU_ATTR = "data-navigation-menu";
@@ -218,7 +217,6 @@ class NavigationMenuSubState {
 	readonly opts: NavigationMenuSubStateProps;
 	readonly context: NavigationMenuProviderState;
 	previousValue = box("");
-	isPointerInTransit = $state(false);
 
 	constructor(opts: NavigationMenuSubStateProps, context: NavigationMenuProviderState) {
 		this.opts = opts;

--- a/tests/src/tests/navigation-menu/navigation-menu.test.ts
+++ b/tests/src/tests/navigation-menu/navigation-menu.test.ts
@@ -191,3 +191,24 @@ it("should render subcontent without subviewport", async () => {
 	);
 	expect(queryByTestId("sub-group-item-sub-viewport")).toBeNull();
 });
+
+it("should switch between submenu items on pointer hover", async () => {
+	const { user, getByTestId, queryByTestId } = setup();
+
+	// First open the main submenu
+	const trigger = getByTestId("sub-group-item-trigger");
+	await user.hover(trigger);
+	await waitFor(() => expect(queryByTestId("viewport")).not.toBeNull());
+
+	// Hover over first sub-trigger to open its content
+	const subTrigger1 = getByTestId("sub-group-item-sub-item1-trigger");
+	await user.hover(subTrigger1);
+	await waitFor(() => expect(queryByTestId("sub-group-item-sub-item1-content")).not.toBeNull());
+	expect(queryByTestId("sub-group-item-sub-item2-content")).toBeNull();
+
+	// Hover over second sub-trigger - should close first and open second
+	const subTrigger2 = getByTestId("sub-group-item-sub-item2-trigger");
+	await user.hover(subTrigger2);
+	await waitFor(() => expect(queryByTestId("sub-group-item-sub-item2-content")).not.toBeNull());
+	expect(queryByTestId("sub-group-item-sub-item1-content")).toBeNull();
+});


### PR DESCRIPTION
This pull request introduces bug fixes and enhancements to the `NavigationMenu` component in the `bits-ui` library, along with updates to the documentation and demos. The changes address issues with transitions, improve submenu behavior, and add new demo components for better visualization.

### Bug Fixes:
* Fixed an issue where moving from a submenu trigger to a menu item in the same menu did not close the submenu (`NavigationMenu`).
* Resolved problems with non-viewport transitions in the `NavigationMenu` component.

### Documentation Updates:
* Updated `navigation-menu.md` to include new demos for submenus and non-viewport transitions, replacing code snippets with interactive previews.

#### New Demo Components:
* Added `navigation-menu-no-viewport-demo.svelte` to demonstrate `NavigationMenu` transitions without a viewport.
* Added `navigation-menu-submenu-demo.svelte` to showcase nested submenus with improved interaction.

### Enhancements to NavigationMenu:
* Introduced `Mounted` utility in `navigation-menu-viewport.svelte` to track mounted state for viewport transitions.
* Enhanced `NavigationMenuRootState` to reset `previousValue` when all menus are closed, preventing unwanted transitions.
