### PR TITLE
feat(Combobox): expose `inputValue` prop on `Combobox.Root`

### DIFF
--- a/.changeset/twelve-carpets-juggle.md
+++ b/.changeset/twelve-carpets-juggle.md
@@ -1,0 +1,5 @@
+---
+"bits-ui": minor
+---
+
+feat(Combobox): expose `inputValue` prop on `Combobox.Root` to synchronize input value with programmatic updates to the value from outside Bits UI

--- a/docs/src/lib/content/api-reference/combobox.api.ts
+++ b/docs/src/lib/content/api-reference/combobox.api.ts
@@ -120,7 +120,6 @@ export const root = createApiSchema<ComboboxRootPropsWithoutHTML>({
 			description:
 				"Whether or not the user can deselect the selected item by pressing it in a single select.",
 		}),
-
 		items: createPropSchema({
 			type: {
 				type: "array",
@@ -129,6 +128,10 @@ export const root = createApiSchema<ComboboxRootPropsWithoutHTML>({
 			},
 			description:
 				"Optionally provide an array of objects representing the items in the select for autofill capabilities. Only applicable to combobox's with type `single`",
+		}),
+		inputValue: createStringProp({
+			description:
+				"A read-only value that controls the text displayed in the combobox input. Use this to programmatically update the input value when the selection changes outside the component, ensuring the displayed text stays in sync with the actual value.",
 		}),
 		children: childrenSnippet(),
 	},

--- a/docs/src/routes/(docs)/sink/+page.svelte
+++ b/docs/src/routes/(docs)/sink/+page.svelte
@@ -1,53 +1,15 @@
 <script lang="ts">
-	import { Select } from "bits-ui";
-	import Check from "phosphor-svelte/lib/Check";
-	import Palette from "phosphor-svelte/lib/Palette";
-	import CaretUpDown from "phosphor-svelte/lib/CaretUpDown";
-	import CaretDoubleUp from "phosphor-svelte/lib/CaretDoubleUp";
-	import CaretDoubleDown from "phosphor-svelte/lib/CaretDoubleDown";
+	import Combobox from "./combobox.svelte";
 
-	let value = $state<string>("");
+	let myValue = $state("");
+	const testItems = [
+		{ value: "mango", label: "Mango" },
+		{ value: "watermelon", label: "Watermelon" },
+		{ value: "apple", label: "Apple" },
+	];
 </script>
 
-<Select.Root type="single" onValueChange={(v) => (value = v)}>
-	<Select.Trigger
-		class="h-input rounded-9px border-border-input bg-background data-placeholder:text-foreground-alt/50 inline-flex w-[296px] select-none items-center border px-[11px] text-sm transition-colors"
-		aria-label="Select a theme"
-	>
-		<Palette class="text-muted-foreground mr-[9px] size-6" />
-		{value}
-		<CaretUpDown class="text-muted-foreground ml-auto size-6" />
-	</Select.Trigger>
-	<Select.Portal>
-		<Select.Content
-			class="focus-override border-muted bg-background shadow-popover data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 outline-hidden z-50 max-h-[var(--bits-select-content-available-height)] w-[var(--bits-select-anchor-width)] min-w-[var(--bits-select-anchor-width)] select-none rounded-xl border px-1 py-3 data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1"
-			sideOffset={10}
-		>
-			<Select.ScrollUpButton class="flex w-full items-center justify-center">
-				<CaretDoubleUp class="size-3" />
-			</Select.ScrollUpButton>
-			<Select.Viewport class="p-1">
-				{#each { length: 100 } as _, i (i)}
-					<Select.Item
-						class="rounded-button data-highlighted:bg-muted outline-hidden data-disabled:opacity-50 flex h-10 w-full select-none items-center py-3 pl-5 pr-1.5 text-sm capitalize"
-						value={`${i}`}
-						label={`${i}`}
-						disabled={false}
-					>
-						{#snippet children({ selected })}
-							{i}
-							{#if selected}
-								<div class="ml-auto">
-									<Check aria-label="check" />
-								</div>
-							{/if}
-						{/snippet}
-					</Select.Item>
-				{/each}
-			</Select.Viewport>
-			<Select.ScrollDownButton class="flex w-full items-center justify-center">
-				<CaretDoubleDown class="size-3" />
-			</Select.ScrollDownButton>
-		</Select.Content>
-	</Select.Portal>
-</Select.Root>
+<div class="mt-4">
+	<button onclick={() => (myValue = "apple")}> Select Apple </button>
+	<Combobox items={testItems} type="single" bind:value={myValue} />
+</div>

--- a/docs/src/routes/(docs)/sink/combobox.svelte
+++ b/docs/src/routes/(docs)/sink/combobox.svelte
@@ -1,0 +1,79 @@
+<script lang="ts">
+	import { Combobox, type WithoutChildrenOrChild, mergeProps } from "bits-ui";
+	import ChevronUpDown from "phosphor-svelte/lib/CaretUpDown";
+	type Item = { value: string; label: string };
+	type Props = Combobox.RootProps & {
+		items: Item[];
+		inputProps?: WithoutChildrenOrChild<Combobox.InputProps>;
+		contentProps?: WithoutChildrenOrChild<Combobox.ContentProps>;
+	};
+	let {
+		items,
+		value = $bindable(),
+		open = $bindable(false),
+		inputProps,
+		contentProps,
+		type,
+		...restProps
+	}: Props = $props();
+	let searchValue = $state("");
+	const filteredItems = $derived.by(() => {
+		if (searchValue === "") return items;
+		return items.filter((item) => item.label.toLowerCase().includes(searchValue.toLowerCase()));
+	});
+	function handleInput(e: Event & { currentTarget: HTMLInputElement }) {
+		searchValue = e.currentTarget.value;
+	}
+	function handleOpenChange(newOpen: boolean) {
+		if (!newOpen) searchValue = "";
+	}
+	const mergedRootProps = $derived(mergeProps(restProps, { onOpenChange: handleOpenChange }));
+	const mergedInputProps = $derived(mergeProps(inputProps, { oninput: handleInput }));
+
+	let inputValue = $derived.by(() => {
+		return items.find((item) => item.value === value)?.label;
+	});
+</script>
+
+<Combobox.Root
+	{inputValue}
+	bind:value={value as never}
+	bind:open
+	{...mergedRootProps}
+	{type}
+	{items}
+>
+	<div class="relative">
+		<Combobox.Input
+			{...mergedInputProps}
+			class="border-input bg-background placeholder:text-muted-foreground flex h-10 w-full rounded-md border px-3 py-2 text-base file:border-0 file:bg-transparent file:text-sm file:font-medium focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm"
+		/>
+		<Combobox.Trigger class="absolute end-3 top-1/2 size-6 -translate-y-1/2"
+			><ChevronUpDown class="text-muted-foreground h-5 w-5" /></Combobox.Trigger
+		>
+	</div>
+	<Combobox.Portal>
+		<Combobox.Content
+			{...contentProps}
+			class="z-50  mt-2 w-[var(--bits-combobox-anchor-width)] min-w-[var(--bits-combobox-anchor-width)]  rounded-md border bg-white p-1 shadow-md outline-none"
+		>
+			{#each filteredItems as item (item.value)}
+				<Combobox.Item
+					value={item.value}
+					label={item.label}
+					class="relative flex w-full cursor-pointer select-none items-center rounded-sm p-1.5 text-sm outline-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50"
+				>
+					{#snippet children({ selected })}
+						<div class="flex w-full flex-col">
+							<span class={selected ? "font-medium text-red-500" : ""}
+								>{item.label}</span
+							>
+						</div>
+					{/snippet}
+				</Combobox.Item>
+			{:else}
+				<span> No results found </span>
+			{/each}
+		</Combobox.Content>
+	</Combobox.Portal>
+</Combobox.Root>

--- a/packages/bits-ui/src/lib/bits/combobox/components/combobox-input.svelte
+++ b/packages/bits-ui/src/lib/bits/combobox/components/combobox-input.svelte
@@ -24,11 +24,11 @@
 	});
 
 	if (defaultValue) {
-		inputState.root.inputValue = defaultValue;
+		inputState.root.opts.inputValue.current = defaultValue;
 	}
 
 	const mergedProps = $derived(
-		mergeProps(restProps, inputState.props, { value: inputState.root.inputValue })
+		mergeProps(restProps, inputState.props, { value: inputState.root.opts.inputValue.current })
 	);
 </script>
 

--- a/packages/bits-ui/src/lib/bits/combobox/components/combobox.svelte
+++ b/packages/bits-ui/src/lib/bits/combobox/components/combobox.svelte
@@ -20,6 +20,7 @@
 		required = false,
 		items = [],
 		allowDeselect = true,
+		inputValue = "",
 		children,
 	}: ComboboxRootProps = $props();
 
@@ -61,6 +62,10 @@
 		isCombobox: true,
 		items: box.with(() => items),
 		allowDeselect: box.with(() => allowDeselect),
+		inputValue: box.with(
+			() => inputValue,
+			(v) => (inputValue = v)
+		),
 	});
 </script>
 

--- a/packages/bits-ui/src/lib/bits/combobox/types.ts
+++ b/packages/bits-ui/src/lib/bits/combobox/types.ts
@@ -1,8 +1,37 @@
 import type { BitsPrimitiveInputAttributes } from "$lib/shared/attributes.js";
+import type {
+	SelectBaseRootPropsWithoutHTML,
+	SelectMultipleRootPropsWithoutHTML,
+	SelectSingleRootPropsWithoutHTML,
+} from "$lib/bits/select/types.js";
 import type { WithChild, Without } from "$lib/internal/types.js";
 
+export type ComboboxBaseRootPropsWithoutHTML = SelectBaseRootPropsWithoutHTML & {
+	/**
+	 * A read-only value that can be used to programmatically
+	 * update the input value.
+	 *
+	 * This is useful for updating the displayed label/input
+	 * when the value changes outside of Bits UI.
+	 */
+	inputValue?: string;
+};
+
+export type ComboboxSingleRootPropsWithoutHTML = ComboboxBaseRootPropsWithoutHTML &
+	SelectSingleRootPropsWithoutHTML;
+
+export type ComboboxSingleRootProps = ComboboxSingleRootPropsWithoutHTML;
+
+export type ComboboxMultipleRootPropsWithoutHTML = ComboboxBaseRootPropsWithoutHTML &
+	SelectMultipleRootPropsWithoutHTML;
+export type ComboboxMultipleRootProps = ComboboxMultipleRootPropsWithoutHTML;
+
+export type ComboboxRootPropsWithoutHTML = ComboboxBaseRootPropsWithoutHTML &
+	(ComboboxSingleRootPropsWithoutHTML | ComboboxMultipleRootPropsWithoutHTML);
+
+export type ComboboxRootProps = ComboboxRootPropsWithoutHTML;
+
 export type {
-	SelectBaseRootPropsWithoutHTML as ComboboxBaseRootPropsWithoutHTML,
 	SelectContentProps as ComboboxContentProps,
 	SelectContentPropsWithoutHTML as ComboboxContentPropsWithoutHTML,
 	SelectContentStaticProps as ComboboxContentStaticProps,
@@ -10,12 +39,6 @@ export type {
 	SelectItemProps as ComboboxItemProps,
 	SelectItemPropsWithoutHTML as ComboboxItemPropsWithoutHTML,
 	SelectItemSnippetProps as ComboboxItemSnippetProps,
-	SelectMultipleRootProps as ComboboxMultipleRootProps,
-	SelectMultipleRootPropsWithoutHTML as ComboboxMultipleRootPropsWithoutHTML,
-	SelectRootProps as ComboboxRootProps,
-	SelectRootPropsWithoutHTML as ComboboxRootPropsWithoutHTML,
-	SelectSingleRootProps as ComboboxSingleRootProps,
-	SelectSingleRootPropsWithoutHTML as ComboboxSingleRootPropsWithoutHTML,
 	SelectTriggerProps as ComboboxTriggerProps,
 	SelectTriggerPropsWithoutHTML as ComboboxTriggerPropsWithoutHTML,
 	SelectGroupPropsWithoutHTML as ComboboxGroupPropsWithoutHTML,

--- a/packages/bits-ui/src/lib/bits/select/components/select.svelte
+++ b/packages/bits-ui/src/lib/bits/select/components/select.svelte
@@ -38,6 +38,8 @@
 		}
 	);
 
+	let inputValue = $state("");
+
 	const rootState = useSelectRoot({
 		type,
 		value: box.with(
@@ -63,6 +65,10 @@
 		isCombobox: false,
 		items: box.with(() => items),
 		allowDeselect: box.with(() => allowDeselect),
+		inputValue: box.with(
+			() => inputValue,
+			(v) => (inputValue = v)
+		),
 	});
 </script>
 

--- a/packages/bits-ui/src/lib/bits/select/select.svelte.ts
+++ b/packages/bits-ui/src/lib/bits/select/select.svelte.ts
@@ -46,6 +46,7 @@ type SelectBaseRootStateProps = ReadableBoxedValues<{
 }> &
 	WritableBoxedValues<{
 		open: boolean;
+		inputValue: string;
 	}> & {
 		isCombobox: boolean;
 	};
@@ -53,7 +54,6 @@ type SelectBaseRootStateProps = ReadableBoxedValues<{
 class SelectBaseRootState {
 	readonly opts: SelectBaseRootStateProps;
 	touchedInput = $state(false);
-	inputValue = $state<string>("");
 	inputNode = $state<HTMLElement | null>(null);
 	contentNode = $state<HTMLElement | null>(null);
 	triggerNode = $state<HTMLElement | null>(null);
@@ -189,7 +189,7 @@ class SelectSingleRootState extends SelectBaseRootState {
 
 	toggleItem(itemValue: string, itemLabel: string = itemValue) {
 		this.opts.value.current = this.includesItem(itemValue) ? "" : itemValue;
-		this.inputValue = itemLabel;
+		this.opts.inputValue.current = itemLabel;
 	}
 
 	setInitialHighlightedNode() {
@@ -254,7 +254,7 @@ class SelectMultipleRootState extends SelectBaseRootState {
 		} else {
 			this.opts.value.current = [...this.opts.value.current, itemValue];
 		}
-		this.inputValue = itemLabel;
+		this.opts.inputValue.current = itemLabel;
 	}
 
 	setInitialHighlightedNode() {
@@ -305,10 +305,10 @@ class SelectInputState {
 				if (!clearOnDeselect) return;
 				if (Array.isArray(value) && Array.isArray(prevValue)) {
 					if (value.length === 0 && prevValue.length !== 0) {
-						this.root.inputValue = "";
+						this.root.opts.inputValue.current = "";
 					}
 				} else if (value === "" && prevValue !== "") {
-					this.root.inputValue = "";
+					this.root.opts.inputValue.current = "";
 				}
 			}
 		);
@@ -323,7 +323,7 @@ class SelectInputState {
 		if (!this.root.opts.open.current) {
 			if (INTERACTION_KEYS.includes(e.key)) return;
 			if (e.key === kbd.TAB) return;
-			if (e.key === kbd.BACKSPACE && this.root.inputValue === "") return;
+			if (e.key === kbd.BACKSPACE && this.root.opts.inputValue.current === "") return;
 			this.root.handleOpen();
 			// we need to wait for a tick after the menu opens to ensure the highlighted nodes are
 			// set correctly.
@@ -412,7 +412,7 @@ class SelectInputState {
 	}
 
 	oninput(e: BitsEvent<Event, HTMLInputElement>) {
-		this.root.inputValue = e.currentTarget.value;
+		this.root.opts.inputValue.current = e.currentTarget.value;
 		this.root.setHighlightedToFirstCandidate();
 	}
 
@@ -1354,6 +1354,7 @@ type InitSelectProps = {
 }> &
 	WritableBoxedValues<{
 		open: boolean;
+		inputValue: string;
 	}> & {
 		isCombobox: boolean;
 	};

--- a/tests/src/tests/combobox/combobox-test.svelte
+++ b/tests/src/tests/combobox/combobox-test.svelte
@@ -24,7 +24,7 @@
 	let {
 		contentProps,
 		portalProps,
-		items,
+		items = [],
 		value = "",
 		open = false,
 		searchValue = "",
@@ -38,11 +38,16 @@
 			? items
 			: items.filter((item) => item.label.includes(searchValue.toLowerCase()))
 	);
+
+	const inputValue = $derived.by(() => {
+		return items.find((item) => item.value === value)?.label;
+	});
 </script>
 
 <main data-testid="main">
 	<Combobox.Root
 		type="single"
+		{inputValue}
 		bind:value
 		bind:open
 		{...restProps}
@@ -94,5 +99,6 @@
 			{value}
 		{/if}
 	</button>
+	<button data-testid="value-binding-3" onclick={() => (value = "3")}> set 3 </button>
 </main>
 <div data-testid="portal-target" id="portal-target"></div>

--- a/tests/src/tests/combobox/combobox.test.ts
+++ b/tests/src/tests/combobox/combobox.test.ts
@@ -473,6 +473,13 @@ describe("combobox - single", () => {
 		expect(t.input).toHaveValue("");
 		expect(t.input).not.toHaveValue("A");
 	});
+
+	it("should allow programmatic updates to the value alongside `inputValue`", async () => {
+		const t = setupSingle();
+		const setter = t.getByTestId("value-binding-3");
+		await t.user.click(setter);
+		expect(t.input).toHaveValue("C");
+	});
 });
 
 ////////////////////////////////////


### PR DESCRIPTION
Closes #1317 

This pull request introduces a new feature to the `Combobox` component, allowing programmatic synchronization of the input value via the `inputValue` prop.

### New Feature: Programmatic Synchronization of Input Value
* **`Combobox` Enhancements:**
  - Added a new `inputValue` prop to `Combobox.Root` for synchronizing the displayed input value with external updates. 