### PR TITLE
fix(Tooltip): `Tooltip.Trigger` composition

### DIFF
--- a/.changeset/clear-drinks-scream.md
+++ b/.changeset/clear-drinks-scream.md
@@ -1,0 +1,5 @@
+---
+"bits-ui": patch
+---
+
+fix(Tooltip): ensure `Tooltip.Trigger`s can be composed with other floating component triggers

--- a/packages/bits-ui/src/lib/bits/tooltip/components/tooltip-content-static.svelte
+++ b/packages/bits-ui/src/lib/bits/tooltip/components/tooltip-content-static.svelte
@@ -46,6 +46,7 @@
 		preventScroll={false}
 		forceMount={true}
 		ref={contentState.opts.ref}
+		tooltip={true}
 	>
 		{#snippet popper({ props })}
 			{@const mergedProps = mergeProps(props, {
@@ -64,6 +65,7 @@
 	<PopperLayer
 		{...mergedProps}
 		{...contentState.popperProps}
+		tooltip={true}
 		isStatic
 		present={contentState.root.opts.open.current}
 		{id}

--- a/packages/bits-ui/src/lib/bits/tooltip/components/tooltip-content.svelte
+++ b/packages/bits-ui/src/lib/bits/tooltip/components/tooltip-content.svelte
@@ -64,6 +64,7 @@
 		preventScroll={false}
 		forceMount={true}
 		ref={contentState.opts.ref}
+		tooltip={true}
 	>
 		{#snippet popper({ props, wrapperProps })}
 			{@const mergedProps = mergeProps(props, {
@@ -91,6 +92,7 @@
 		preventScroll={false}
 		forceMount={false}
 		ref={contentState.opts.ref}
+		tooltip={true}
 	>
 		{#snippet popper({ props, wrapperProps })}
 			{@const mergedProps = mergeProps(props, {

--- a/packages/bits-ui/src/lib/bits/tooltip/components/tooltip-trigger.svelte
+++ b/packages/bits-ui/src/lib/bits/tooltip/components/tooltip-trigger.svelte
@@ -29,7 +29,7 @@
 	const mergedProps = $derived(mergeProps(restProps, triggerState.props, { type }));
 </script>
 
-<FloatingLayerAnchor {id} ref={triggerState.opts.ref}>
+<FloatingLayerAnchor {id} ref={triggerState.opts.ref} tooltip={true}>
 	{#if child}
 		{@render child({ props: mergedProps })}
 	{:else}

--- a/packages/bits-ui/src/lib/bits/tooltip/components/tooltip.svelte
+++ b/packages/bits-ui/src/lib/bits/tooltip/components/tooltip.svelte
@@ -32,6 +32,6 @@
 	});
 </script>
 
-<FloatingLayer>
+<FloatingLayer tooltip>
 	{@render children?.()}
 </FloatingLayer>

--- a/packages/bits-ui/src/lib/bits/tooltip/tooltip.svelte.ts
+++ b/packages/bits-ui/src/lib/bits/tooltip/tooltip.svelte.ts
@@ -7,7 +7,7 @@ import { isElement, isFocusVisible } from "$lib/internal/is.js";
 import { useGraceArea } from "$lib/internal/use-grace-area.svelte.js";
 import { getDataDisabled } from "$lib/internal/attrs.js";
 import type { WithRefProps } from "$lib/internal/types.js";
-import type { PointerEventHandler } from "svelte/elements";
+import type { FocusEventHandler, MouseEventHandler, PointerEventHandler } from "svelte/elements";
 
 const TOOLTIP_CONTENT_ATTR = "data-tooltip-content";
 const TOOLTIP_TRIGGER_ATTR = "data-tooltip-trigger";
@@ -220,12 +220,12 @@ class TooltipTriggerState {
 		this.#isPointerDown.current = false;
 	};
 
-	#onpointerup = () => {
+	#onpointerup: PointerEventHandler<HTMLElement> = () => {
 		if (this.#isDisabled) return;
 		this.#isPointerDown.current = false;
 	};
 
-	#onpointerdown = () => {
+	#onpointerdown: PointerEventHandler<HTMLElement> = () => {
 		if (this.#isDisabled) return;
 		this.#isPointerDown.current = true;
 
@@ -249,47 +249,52 @@ class TooltipTriggerState {
 		this.#hasPointerMoveOpened = true;
 	};
 
-	#onpointerleave = () => {
+	#onpointerleave: PointerEventHandler<HTMLElement> = () => {
 		if (this.#isDisabled) return;
 		this.root.onTriggerLeave();
 		this.#hasPointerMoveOpened = false;
 	};
 
-	#onfocus = (e: FocusEvent & { currentTarget: HTMLElement }) => {
+	#onfocus: FocusEventHandler<HTMLElement> = (e) => {
 		if (this.#isPointerDown.current || this.#isDisabled) return;
 
 		if (this.root.ignoreNonKeyboardFocus && !isFocusVisible(e.currentTarget)) return;
 		this.root.handleOpen();
 	};
 
-	#onblur = () => {
+	#onblur: FocusEventHandler<HTMLElement> = () => {
 		if (this.#isDisabled) return;
 		this.root.handleClose();
 	};
 
-	#onclick = () => {
+	#onclick: MouseEventHandler<HTMLElement> = () => {
 		if (this.root.disableCloseOnTriggerClick || this.#isDisabled) return;
 		this.root.handleClose();
 	};
 
-	props = $derived.by(() => ({
-		id: this.opts.id.current,
-		"aria-describedby": this.root.opts.open.current ? this.root.contentNode?.id : undefined,
-		"data-state": this.root.stateAttr,
-		"data-disabled": getDataDisabled(this.#isDisabled),
-		"data-delay-duration": `${this.root.delayDuration}`,
-		[TOOLTIP_TRIGGER_ATTR]: "",
-		tabindex: this.#isDisabled ? undefined : 0,
-		disabled: this.opts.disabled.current,
-		onpointerup: this.#onpointerup,
-		onpointerdown: this.#onpointerdown,
-		onpointermove: this.#onpointermove,
-		onpointerleave: this.#onpointerleave,
-		onfocus: this.#onfocus,
-		onblur: this.#onblur,
-		onclick: this.#onclick,
-		...attachRef(this.opts.ref, (v) => (this.root.triggerNode = v)),
-	}));
+	props = $derived.by(
+		() =>
+			({
+				id: this.opts.id.current,
+				"aria-describedby": this.root.opts.open.current
+					? this.root.contentNode?.id
+					: undefined,
+				"data-state": this.root.stateAttr,
+				"data-disabled": getDataDisabled(this.#isDisabled),
+				"data-delay-duration": `${this.root.delayDuration}`,
+				[TOOLTIP_TRIGGER_ATTR]: "",
+				tabindex: this.#isDisabled ? undefined : 0,
+				disabled: this.opts.disabled.current,
+				onpointerup: this.#onpointerup,
+				onpointerdown: this.#onpointerdown,
+				onpointermove: this.#onpointermove,
+				onpointerleave: this.#onpointerleave,
+				onfocus: this.#onfocus,
+				onblur: this.#onblur,
+				onclick: this.#onclick,
+				...attachRef(this.opts.ref, (v) => (this.root.triggerNode = v)),
+			}) as const
+	);
 }
 
 type TooltipContentStateProps = WithRefProps &

--- a/packages/bits-ui/src/lib/bits/utilities/floating-layer/components/floating-layer-anchor.svelte
+++ b/packages/bits-ui/src/lib/bits/utilities/floating-layer/components/floating-layer-anchor.svelte
@@ -4,13 +4,16 @@
 	import type { AnchorProps } from "./index.js";
 	import type { Measurable } from "$lib/internal/floating-svelte/types.js";
 
-	let { id, children, virtualEl, ref }: AnchorProps = $props();
+	let { id, children, virtualEl, ref, tooltip = false }: AnchorProps = $props();
 
-	useFloatingAnchorState({
-		id: box.with(() => id),
-		virtualEl: box.with(() => virtualEl as unknown as Measurable | null),
-		ref,
-	});
+	useFloatingAnchorState(
+		{
+			id: box.with(() => id),
+			virtualEl: box.with(() => virtualEl as unknown as Measurable | null),
+			ref,
+		},
+		tooltip
+	);
 </script>
 
 {@render children?.()}

--- a/packages/bits-ui/src/lib/bits/utilities/floating-layer/components/floating-layer-content.svelte
+++ b/packages/bits-ui/src/lib/bits/utilities/floating-layer/components/floating-layer-content.svelte
@@ -25,29 +25,33 @@
 		wrapperId = useId(),
 		customAnchor = null,
 		enabled,
+		tooltip = false,
 	}: ContentImplProps = $props();
 
-	const contentState = useFloatingContentState({
-		side: box.with(() => side),
-		sideOffset: box.with(() => sideOffset),
-		align: box.with(() => align),
-		alignOffset: box.with(() => alignOffset),
-		id: box.with(() => id),
-		arrowPadding: box.with(() => arrowPadding),
-		avoidCollisions: box.with(() => avoidCollisions),
-		collisionBoundary: box.with(() => collisionBoundary),
-		collisionPadding: box.with(() => collisionPadding),
-		hideWhenDetached: box.with(() => hideWhenDetached),
-		onPlaced: box.with(() => onPlaced),
-		sticky: box.with(() => sticky),
-		updatePositionStrategy: box.with(() => updatePositionStrategy),
-		strategy: box.with(() => strategy),
-		dir: box.with(() => dir),
-		style: box.with(() => style),
-		enabled: box.with(() => enabled),
-		wrapperId: box.with(() => wrapperId),
-		customAnchor: box.with(() => customAnchor),
-	});
+	const contentState = useFloatingContentState(
+		{
+			side: box.with(() => side),
+			sideOffset: box.with(() => sideOffset),
+			align: box.with(() => align),
+			alignOffset: box.with(() => alignOffset),
+			id: box.with(() => id),
+			arrowPadding: box.with(() => arrowPadding),
+			avoidCollisions: box.with(() => avoidCollisions),
+			collisionBoundary: box.with(() => collisionBoundary),
+			collisionPadding: box.with(() => collisionPadding),
+			hideWhenDetached: box.with(() => hideWhenDetached),
+			onPlaced: box.with(() => onPlaced),
+			sticky: box.with(() => sticky),
+			updatePositionStrategy: box.with(() => updatePositionStrategy),
+			strategy: box.with(() => strategy),
+			dir: box.with(() => dir),
+			style: box.with(() => style),
+			enabled: box.with(() => enabled),
+			wrapperId: box.with(() => wrapperId),
+			customAnchor: box.with(() => customAnchor),
+		},
+		tooltip
+	);
 
 	const mergedProps = $derived(
 		mergeProps(contentState.wrapperProps, {

--- a/packages/bits-ui/src/lib/bits/utilities/floating-layer/components/floating-layer.svelte
+++ b/packages/bits-ui/src/lib/bits/utilities/floating-layer/components/floating-layer.svelte
@@ -2,9 +2,9 @@
 	import type { Snippet } from "svelte";
 	import { useFloatingRootState } from "../use-floating-layer.svelte.js";
 
-	let { children }: { children?: Snippet } = $props();
+	let { children, tooltip = false }: { children?: Snippet; tooltip?: boolean } = $props();
 
-	useFloatingRootState();
+	useFloatingRootState(tooltip);
 </script>
 
 {@render children?.()}

--- a/packages/bits-ui/src/lib/bits/utilities/floating-layer/types.ts
+++ b/packages/bits-ui/src/lib/bits/utilities/floating-layer/types.ts
@@ -124,6 +124,15 @@ export type FloatingLayerContentImplProps = {
 	 */
 	onPlaced?: () => void;
 	enabled: boolean;
+	/**
+	 * Tooltips are special in that they are commonly composed
+	 * with other floating components, where the same trigger is
+	 * used for both the tooltip and the popover.
+	 *
+	 * For situations like this, we need to use a different context
+	 * symbol so that conflicts don't occur.
+	 */
+	tooltip?: boolean;
 } & FloatingLayerContentProps;
 
 export type FloatingLayerAnchorProps = {
@@ -131,4 +140,13 @@ export type FloatingLayerAnchorProps = {
 	children?: Snippet;
 	virtualEl?: ReadableBox<Measurable | null>;
 	ref: ReadableBox<HTMLElement | null>;
+	/**
+	 * Tooltips are special in that they are commonly composed
+	 * with other floating components, where the same trigger is
+	 * used for both the tooltip and the popover.
+	 *
+	 * For situations like this, we need to use a different context
+	 * symbol so that conflicts don't occur.
+	 */
+	tooltip?: boolean;
 };

--- a/packages/bits-ui/src/lib/bits/utilities/floating-layer/use-floating-layer.svelte.ts
+++ b/packages/bits-ui/src/lib/bits/utilities/floating-layer/use-floating-layer.svelte.ts
@@ -208,9 +208,6 @@ class FloatingContentState {
 				"data-align": this.placedAlign,
 				style: styleToString({
 					...this.#transformedStyle,
-					// if the FloatingContent hasn't been placed yet (not all measurements done)
-					// we prevent animations so that users's animation don't kick in too early referring wrong sides
-					// animation: !this.floating.isPositioned ? "none" : undefined,
 				}),
 				...attachRef(this.contentRef),
 			}) as const
@@ -331,21 +328,36 @@ class FloatingAnchorState {
 
 const FloatingRootContext = new Context<FloatingRootState>("Floating.Root");
 const FloatingContentContext = new Context<FloatingContentState>("Floating.Content");
+const FloatingTooltipRootContext = new Context<FloatingRootState>("Floating.Root");
 
-export function useFloatingRootState() {
-	return FloatingRootContext.set(new FloatingRootState());
+export function useFloatingRootState(tooltip: boolean = false) {
+	return tooltip
+		? FloatingTooltipRootContext.set(new FloatingRootState())
+		: FloatingRootContext.set(new FloatingRootState());
 }
 
-export function useFloatingContentState(props: FloatingContentStateProps): FloatingContentState {
-	return FloatingContentContext.set(new FloatingContentState(props, FloatingRootContext.get()));
+export function useFloatingContentState(
+	props: FloatingContentStateProps,
+	tooltip: boolean = false
+): FloatingContentState {
+	return tooltip
+		? FloatingContentContext.set(
+				new FloatingContentState(props, FloatingTooltipRootContext.get())
+			)
+		: FloatingContentContext.set(new FloatingContentState(props, FloatingRootContext.get()));
 }
 
 export function useFloatingArrowState(props: FloatingArrowStateProps): FloatingArrowState {
 	return new FloatingArrowState(props, FloatingContentContext.get());
 }
 
-export function useFloatingAnchorState(props: FloatingAnchorStateProps): FloatingAnchorState {
-	return new FloatingAnchorState(props, FloatingRootContext.get());
+export function useFloatingAnchorState(
+	props: FloatingAnchorStateProps,
+	tooltip = false
+): FloatingAnchorState {
+	return tooltip
+		? new FloatingAnchorState(props, FloatingTooltipRootContext.get())
+		: new FloatingAnchorState(props, FloatingRootContext.get());
 }
 
 //

--- a/packages/bits-ui/src/lib/bits/utilities/popper-layer/popper-layer-inner.svelte
+++ b/packages/bits-ui/src/lib/bits/utilities/popper-layer/popper-layer-inner.svelte
@@ -45,6 +45,7 @@
 		isStatic = false,
 		enabled,
 		ref,
+		tooltip = false,
 		...restProps
 	}: Omit<PopperLayerImplProps, "present" | "children"> & {
 		enabled: boolean;
@@ -72,6 +73,7 @@
 	{onPlaced}
 	{customAnchor}
 	{enabled}
+	{tooltip}
 >
 	{#snippet content({ props: floatingProps, wrapperProps })}
 		{#if restProps.forceMount && enabled}

--- a/packages/bits-ui/src/lib/bits/utilities/popper-layer/types.ts
+++ b/packages/bits-ui/src/lib/bits/utilities/popper-layer/types.ts
@@ -46,6 +46,15 @@ export type PopperLayerImplProps = Omit<
 				[{ props: Record<string, unknown>; wrapperProps: Record<string, unknown> }]
 			>;
 			isStatic?: boolean;
+			/**
+			 * Tooltips are special in that they are commonly composed
+			 * with other floating components, where the same trigger is
+			 * used for both the tooltip and the popover.
+			 *
+			 * For situations like this, we need to use a different context
+			 * symbol so that conflicts don't occur.
+			 */
+			tooltip?: boolean;
 		},
 	"enabled"
 >;

--- a/tests/src/tests/tooltip/tooltip-popover-test.svelte
+++ b/tests/src/tests/tooltip/tooltip-popover-test.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+	import { Popover, Tooltip } from "bits-ui";
+</script>
+
+<Tooltip.Provider>
+	<Tooltip.Root>
+		<Popover.Root>
+			<Tooltip.Trigger data-testid="trigger">
+				{#snippet child({ props })}
+					<Popover.Trigger {...props}>Resize</Popover.Trigger>
+				{/snippet}
+			</Tooltip.Trigger>
+			<Popover.Portal>
+				<Popover.Content data-testid="popover-content"></Popover.Content>
+			</Popover.Portal>
+		</Popover.Root>
+		<Tooltip.Portal>
+			<Tooltip.Content data-testid="tooltip-content">Hello World!</Tooltip.Content>
+		</Tooltip.Portal>
+	</Tooltip.Root>
+</Tooltip.Provider>

--- a/tests/src/tests/tooltip/tooltip.test.ts
+++ b/tests/src/tests/tooltip/tooltip.test.ts
@@ -6,6 +6,7 @@ import { getTestKbd, setupUserEvents, sleep } from "../utils.js";
 import TooltipTest, { type TooltipTestProps } from "./tooltip-test.svelte";
 import type { TooltipForceMountTestProps } from "./tooltip-force-mount-test.svelte";
 import TooltipForceMountTest from "./tooltip-force-mount-test.svelte";
+import TooltipPopoverTest from "./tooltip-popover-test.svelte";
 
 const kbd = getTestKbd();
 
@@ -160,4 +161,14 @@ it("should use the custom anchor element when `customAnchor` is provided", async
 	const { trigger, user, queryByTestId } = setup();
 	await user.hover(trigger);
 	await waitFor(() => expect(queryByTestId("content")).not.toBeNull());
+});
+
+it("should open when composed with another floating trigger", async () => {
+	const user = setupUserEvents();
+	const t = render(TooltipPopoverTest);
+	await user.hover(t.getByTestId("trigger"));
+	await waitFor(() => expect(t.queryByTestId("tooltip-content")).not.toBeNull());
+	await user.click(t.getByTestId("trigger"));
+	await waitFor(() => expect(t.queryByTestId("popover-content")).not.toBeNull());
+	await waitFor(() => expect(t.queryByTestId("tooltip-content")).toBeNull());
 });


### PR DESCRIPTION
Closes #1523 

This pull request introduces changes to the `bits-ui` library to enhance the behavior of tooltips, specifically enabling them to be composed with other floating components like popovers. The update includes modifications to the tooltip and floating layer components, as well as the addition of new tests to ensure the functionality works as expected.

### Enhancements to Tooltip Composition:

* **Tooltip Composition with Floating Components**: Updated `Tooltip.Trigger` and related components to support composition with other floating component triggers, such as popovers.


### Testing Additions:

* **New Test for Tooltip and Popover Composition**: Added a test case to validate that tooltips can be composed with popovers, ensuring correct behavior when the same trigger is used for both components.