### PR TITLE
fix(rating-group): Ensure data-state reflects value correctly when showing preview

### DIFF
--- a/.changeset/old-clocks-stare.md
+++ b/.changeset/old-clocks-stare.md
@@ -1,0 +1,5 @@
+---
+"bits-ui": patch
+---
+
+fix(rating-group): Ensure `data-state` reflects value when showing preview

--- a/packages/bits-ui/src/lib/bits/rating-group/rating-group.svelte.ts
+++ b/packages/bits-ui/src/lib/bits/rating-group/rating-group.svelte.ts
@@ -140,22 +140,42 @@ class RatingGroupRootState {
 	}
 
 	readonly handlers: Record<string, () => void> = {
-		[kbd.ARROW_UP]: () => this.#adjustValue(this.opts.allowHalf.current ? 0.5 : 1),
+		[kbd.ARROW_UP]: () => {
+			this.setHoverValue(null);
+			this.#adjustValue(this.opts.allowHalf.current ? 0.5 : 1);
+		},
 		[kbd.ARROW_RIGHT]: () => {
+			this.setHoverValue(null);
 			const increment = this.opts.allowHalf.current ? 0.5 : 1;
 			// in RTL mode, right arrow should decrement
 			this.#adjustValue(this.isRTL ? -increment : increment);
 		},
-		[kbd.ARROW_DOWN]: () => this.#adjustValue(this.opts.allowHalf.current ? -0.5 : -1),
+		[kbd.ARROW_DOWN]: () => {
+			this.setHoverValue(null);
+			this.#adjustValue(this.opts.allowHalf.current ? -0.5 : -1);
+		},
 		[kbd.ARROW_LEFT]: () => {
+			this.setHoverValue(null);
 			const increment = this.opts.allowHalf.current ? 0.5 : 1;
 			// in RTL mode, left arrow should increment
 			this.#adjustValue(this.isRTL ? increment : -increment);
 		},
-		[kbd.HOME]: () => this.setValue(this.opts.min.current),
-		[kbd.END]: () => this.setValue(this.opts.max.current),
-		[kbd.PAGE_UP]: () => this.#adjustValue(1),
-		[kbd.PAGE_DOWN]: () => this.#adjustValue(-1),
+		[kbd.HOME]: () => {
+			this.setHoverValue(null);
+			this.setValue(this.opts.min.current);
+		},
+		[kbd.END]: () => {
+			this.setHoverValue(null);
+			this.setValue(this.opts.max.current);
+		},
+		[kbd.PAGE_UP]: () => {
+			this.setHoverValue(null);
+			this.#adjustValue(1);
+		},
+		[kbd.PAGE_DOWN]: () => {
+			this.setHoverValue(null);
+			this.#adjustValue(-1);
+		},
 	};
 
 	onkeydown(e: BitsKeyboardEvent): void {


### PR DESCRIPTION
This PR fixes an issue where the rating group `data-state` would not reflect the current value when showing the preview. This is obvious when you hover the input while using the arrow keys. 

We can fix this by resetting the `#hoverValue` to null when navigating with the keyboard.

Broken Example:
![broken example](https://cdn.discordapp.com/attachments/1343688761195630643/1377611536805400677/CleanShot_2025-05-29_at_06.35.18.gif?ex=68399839&is=683846b9&hm=45d7227bfeeca68df51ca5237ec7099544bd422997e74f50a61452d633986382&)