### PR TITLE
feat(Select): expose `autocomplete` attribute on `Select.Root`

### DIFF
--- a/.changeset/weak-kings-wish.md
+++ b/.changeset/weak-kings-wish.md
@@ -1,0 +1,5 @@
+---
+"bits-ui": minor
+---
+
+feat(Select): expose `autocomplete` prop on `Select.Root` for passing `autocomplete` attribute to the hidden input

--- a/packages/bits-ui/src/lib/bits/select/components/select-hidden-input.svelte
+++ b/packages/bits-ui/src/lib/bits/select/components/select-hidden-input.svelte
@@ -1,9 +1,13 @@
 <script lang="ts">
 	import { box } from "svelte-toolbelt";
 	import { useSelectHiddenInput } from "../select.svelte.js";
+	import type { HTMLInputAttributes } from "svelte/elements";
 	import HiddenInput from "$lib/bits/utilities/hidden-input.svelte";
 
-	let { value = $bindable("") }: { value?: string } = $props();
+	let {
+		value = $bindable(""),
+		autocomplete,
+	}: { value?: string } & Omit<HTMLInputAttributes, "value"> = $props();
 
 	const hiddenInputState = useSelectHiddenInput({
 		value: box.with(() => value),
@@ -11,5 +15,5 @@
 </script>
 
 {#if hiddenInputState.shouldRender}
-	<HiddenInput {...hiddenInputState.props} bind:value />
+	<HiddenInput {...hiddenInputState.props} bind:value {autocomplete} />
 {/if}

--- a/packages/bits-ui/src/lib/bits/select/components/select.svelte
+++ b/packages/bits-ui/src/lib/bits/select/components/select.svelte
@@ -20,6 +20,7 @@
 		required = false,
 		items = [],
 		allowDeselect = false,
+		autocomplete,
 		children,
 	}: SelectRootProps = $props();
 
@@ -79,9 +80,9 @@
 {#if Array.isArray(rootState.opts.value.current)}
 	{#if rootState.opts.value.current.length}
 		{#each rootState.opts.value.current as item (item)}
-			<SelectHiddenInput value={item} />
+			<SelectHiddenInput value={item} {autocomplete} />
 		{/each}
 	{/if}
 {:else}
-	<SelectHiddenInput bind:value={rootState.opts.value.current as string} />
+	<SelectHiddenInput bind:value={rootState.opts.value.current as string} {autocomplete} />
 {/if}

--- a/packages/bits-ui/src/lib/bits/select/types.ts
+++ b/packages/bits-ui/src/lib/bits/select/types.ts
@@ -14,6 +14,7 @@ import type {
 	Without,
 } from "$lib/internal/types.js";
 import type { FloatingContentSnippetProps, StaticContentSnippetProps } from "$lib/shared/types.js";
+import type { HTMLInputAttributes } from "svelte/elements";
 
 export type SelectBaseRootPropsWithoutHTML = WithChildren<{
 	/**
@@ -88,6 +89,11 @@ export type SelectBaseRootPropsWithoutHTML = WithChildren<{
 	 * This is only applicable to `type="single"` selects/comboboxes.
 	 */
 	allowDeselect?: boolean;
+
+	/**
+	 * The autocomplete attribute to forward to the hidden input element.
+	 */
+	autocomplete?: HTMLInputAttributes["autocomplete"];
 }>;
 
 export type SelectSingleRootPropsWithoutHTML = {


### PR DESCRIPTION
Closes #1543 