### PR TITLE
fix(dialog-close): add explicit type="button"

### DIFF
--- a/packages/bits-ui/src/lib/bits/dialog/components/dialog-close.svelte
+++ b/packages/bits-ui/src/lib/bits/dialog/components/dialog-close.svelte
@@ -12,6 +12,7 @@
 		id = createId(uid),
 		ref = $bindable(null),
 		disabled = false,
+		type = "button",
 		...restProps
 	}: DialogCloseProps = $props();
 
@@ -31,7 +32,7 @@
 {#if child}
 	{@render child({ props: mergedProps })}
 {:else}
-	<button {...mergedProps}>
+	<button {type} {...mergedProps}>
 		{@render children?.()}
 	</button>
 {/if}


### PR DESCRIPTION
Kind of makes sense to have this as the default, but happy to close this out if not. 🙂 

Closes: #1552 