### PR TITLE
fix: Expose `data-orientation` on `Tabs.Content`

### DIFF
--- a/.changeset/short-candles-clap.md
+++ b/.changeset/short-candles-clap.md
@@ -1,0 +1,5 @@
+---
+"bits-ui": patch
+---
+
+fix: Expose `data-orientation` on `Tabs.Content`

--- a/packages/bits-ui/src/lib/bits/tabs/tabs.svelte.ts
+++ b/packages/bits-ui/src/lib/bits/tabs/tabs.svelte.ts
@@ -258,6 +258,7 @@ class TabsContentState {
 				"data-value": this.opts.value.current,
 				"data-state": getTabDataState(this.#isActive),
 				"aria-labelledby": this.#ariaLabelledBy,
+				"data-orientation": getDataOrientation(this.root.opts.orientation.current),
 				[tabsAttrs.content]: "",
 				...attachRef(this.opts.ref),
 			}) as const


### PR DESCRIPTION
Fixes #1570 