### PR TITLE
fix: body styles aren't touched when `preventScroll={false}`

### DIFF
--- a/.changeset/slimy-beers-train.md
+++ b/.changeset/slimy-beers-train.md
@@ -1,0 +1,5 @@
+---
+"bits-ui": patch
+---
+
+fix: ensure body styles aren't touched when `preventScroll={false}`

--- a/packages/bits-ui/src/lib/bits/utilities/scroll-lock/scroll-lock.svelte
+++ b/packages/bits-ui/src/lib/bits/utilities/scroll-lock/scroll-lock.svelte
@@ -4,5 +4,7 @@
 
 	let { preventScroll = true, restoreScrollDelay = null }: ScrollLockProps = $props();
 
-	useBodyScrollLock(preventScroll, () => restoreScrollDelay);
+	if (preventScroll) {
+		useBodyScrollLock(preventScroll, () => restoreScrollDelay);
+	}
 </script>


### PR DESCRIPTION
Closes #1569 