### PR TITLE
feat(RadioGroup): add `readonly` prop

### DIFF
--- a/.changeset/gold-crews-argue.md
+++ b/.changeset/gold-crews-argue.md
@@ -1,0 +1,5 @@
+---
+"bits-ui": minor
+---
+
+feat(RadioGroup): add `readonly` prop to make the `RadioGroup` readonly

--- a/docs/content/components/radio-group.md
+++ b/docs/content/components/radio-group.md
@@ -4,7 +4,7 @@ description: Allows users to select a single option from a list of mutually excl
 ---
 
 <script>
-	import { APISection, ComponentPreviewV2, RadioGroupDemo, Callout } from '$lib/components/index.js'
+	import { APISection, ComponentPreviewV2, RadioGroupDemo, RadioGroupDemoReadonly, RadioGroupDemoDisabled, Callout } from '$lib/components/index.js'
 	let { schemas } = $props()
 </script>
 
@@ -174,6 +174,44 @@ When the `orientation` is set to `'vertical'`, the radio group will navigate thr
 </RadioGroup.Root>
 
 <RadioGroup.Root orientation="horizontal">
+	<!-- ... -->
+</RadioGroup.Root>
+```
+
+## Examples
+
+### Readonly
+
+When a radio group is readonly, users can focus and navigate through the items but cannot change the selection. This is useful for displaying information that should be visible but not editable.
+
+<ComponentPreviewV2 name="radio-group-demo-readonly" componentName="Radio Group Readonly">
+
+{#snippet preview()}
+<RadioGroupDemoReadonly />
+{/snippet}
+
+</ComponentPreviewV2>
+
+```svelte /readonly/
+<RadioGroup.Root readonly>
+	<!-- ... -->
+</RadioGroup.Root>
+```
+
+### Disabled
+
+When a radio group is disabled, users cannot interact with it at all. The entire group becomes non-focusable and non-interactive.
+
+<ComponentPreviewV2 name="radio-group-demo-disabled" componentName="Radio Group Disabled">
+
+{#snippet preview()}
+<RadioGroupDemoDisabled />
+{/snippet}
+
+</ComponentPreviewV2>
+
+```svelte /disabled/
+<RadioGroup.Root disabled>
 	<!-- ... -->
 </RadioGroup.Root>
 ```

--- a/docs/src/lib/components/demos/index.ts
+++ b/docs/src/lib/components/demos/index.ts
@@ -59,6 +59,8 @@ export { default as PortalDemo } from "./portal-demo.svelte";
 export { default as ProgressDemo } from "./progress-demo.svelte";
 export { default as ProgressDemoCustom } from "./progress-demo-custom.svelte";
 export { default as RadioGroupDemo } from "./radio-group-demo.svelte";
+export { default as RadioGroupDemoReadonly } from "./radio-group-demo-readonly.svelte";
+export { default as RadioGroupDemoDisabled } from "./radio-group-demo-disabled.svelte";
 export { default as RangeCalendarDemo } from "./range-calendar-demo.svelte";
 export { default as ScrollAreaDemo } from "./scroll-area-demo.svelte";
 export { default as ScrollAreaDemoCustom } from "./scroll-area-demo-custom.svelte";

--- a/docs/src/lib/components/demos/radio-group-demo-disabled.svelte
+++ b/docs/src/lib/components/demos/radio-group-demo-disabled.svelte
@@ -1,0 +1,34 @@
+<script lang="ts">
+	import { Label, RadioGroup } from "bits-ui";
+</script>
+
+<RadioGroup.Root
+	value="average"
+	disabled
+	class="flex flex-col gap-4 text-sm font-medium opacity-50"
+>
+	<div class="text-foreground group flex select-none items-center transition-all">
+		<RadioGroup.Item
+			id="disabled-amazing"
+			value="amazing"
+			class="border-border-input bg-background hover:border-dark-40 data-[state=checked]:border-6 data-[state=checked]:border-foreground size-5 shrink-0 cursor-default rounded-full border transition-all duration-100 ease-in-out"
+		/>
+		<Label.Root for="disabled-amazing" class="pl-3">Amazing</Label.Root>
+	</div>
+	<div class="text-foreground group flex select-none items-center transition-all">
+		<RadioGroup.Item
+			id="disabled-average"
+			value="average"
+			class="border-border-input bg-background hover:border-dark-40 data-[state=checked]:border-6 data-[state=checked]:border-foreground size-5 shrink-0 cursor-default rounded-full border transition-all duration-100 ease-in-out"
+		/>
+		<Label.Root for="disabled-average" class="pl-3">Average</Label.Root>
+	</div>
+	<div class="text-foreground group flex select-none items-center transition-all">
+		<RadioGroup.Item
+			id="disabled-terrible"
+			value="terrible"
+			class="border-border-input bg-background hover:border-dark-40 data-[state=checked]:border-6 data-[state=checked]:border-foreground size-5 shrink-0 cursor-default rounded-full border transition-all duration-100 ease-in-out"
+		/>
+		<Label.Root for="disabled-terrible" class="pl-3">Terrible</Label.Root>
+	</div>
+</RadioGroup.Root>

--- a/docs/src/lib/components/demos/radio-group-demo-readonly.svelte
+++ b/docs/src/lib/components/demos/radio-group-demo-readonly.svelte
@@ -1,0 +1,34 @@
+<script lang="ts">
+	import { Label, RadioGroup } from "bits-ui";
+</script>
+
+<RadioGroup.Root
+	value="average"
+	readonly
+	class="flex flex-col gap-4 text-sm font-medium opacity-75"
+>
+	<div class="text-foreground group flex select-none items-center transition-all">
+		<RadioGroup.Item
+			id="readonly-amazing"
+			value="amazing"
+			class="border-border-input bg-background hover:border-dark-40 data-[state=checked]:border-6 data-[state=checked]:border-foreground size-5 shrink-0 cursor-default rounded-full border transition-all duration-100 ease-in-out"
+		/>
+		<Label.Root for="readonly-amazing" class="pl-3">Amazing</Label.Root>
+	</div>
+	<div class="text-foreground group flex select-none items-center transition-all">
+		<RadioGroup.Item
+			id="readonly-average"
+			value="average"
+			class="border-border-input bg-background hover:border-dark-40 data-[state=checked]:border-6 data-[state=checked]:border-foreground size-5 shrink-0 cursor-default rounded-full border transition-all duration-100 ease-in-out"
+		/>
+		<Label.Root for="readonly-average" class="pl-3">Average</Label.Root>
+	</div>
+	<div class="text-foreground group flex select-none items-center transition-all">
+		<RadioGroup.Item
+			id="readonly-terrible"
+			value="terrible"
+			class="border-border-input bg-background hover:border-dark-40 data-[state=checked]:border-6 data-[state=checked]:border-foreground size-5 shrink-0 cursor-default rounded-full border transition-all duration-100 ease-in-out"
+		/>
+		<Label.Root for="readonly-terrible" class="pl-3">Terrible</Label.Root>
+	</div>
+</RadioGroup.Root>

--- a/docs/src/lib/content/api-reference/radio-group.api.ts
+++ b/docs/src/lib/content/api-reference/radio-group.api.ts
@@ -52,6 +52,11 @@ export const root = defineComponentApiSchema<RadioGroupRootPropsWithoutHTML>({
 				"The orientation of the radio group. This will determine how keyboard navigation will work within the component.",
 			definition: OrientationProp,
 		}),
+		readonly: defineBooleanProp({
+			default: false,
+			description:
+				"Whether or not the radio group is readonly. When readonly, users can focus and navigate through items but cannot change the value.",
+		}),
 		...withChildProps({ elType: "HTMLDivElement" }),
 	},
 	dataAttributes: [
@@ -60,6 +65,14 @@ export const root = defineComponentApiSchema<RadioGroupRootPropsWithoutHTML>({
 			description: "The orientation of the radio group.",
 			options: ["vertical", "horizontal"],
 			value: OrientationProp,
+		}),
+		defineSimpleDataAttr({
+			name: "disabled",
+			description: "Present when the radio group is disabled.",
+		}),
+		defineSimpleDataAttr({
+			name: "readonly",
+			description: "Present when the radio group is readonly.",
 		}),
 		defineSimpleDataAttr({
 			name: "radio-group-root",
@@ -87,6 +100,10 @@ export const item = defineComponentApiSchema<RadioGroupItemPropsWithoutHTML>({
 		defineSimpleDataAttr({
 			name: "disabled",
 			description: "Present when the radio item is disabled.",
+		}),
+		defineSimpleDataAttr({
+			name: "readonly",
+			description: "Present when the radio group is readonly.",
 		}),
 		defineSimpleDataAttr({
 			name: "value",

--- a/docs/src/lib/content/utils.ts
+++ b/docs/src/lib/content/utils.ts
@@ -140,12 +140,13 @@ export function defineSimplePropSchema(_opts: DefineSimplePropSchemaOpts) {
 	const opts = { ...defaults, ..._opts };
 	return definePropSchema({
 		...opts,
-		default: opts.default
-			? {
-					variant: "simple",
-					value: `${opts.default}`,
-				}
-			: undefined,
+		default:
+			opts.default !== undefined
+				? {
+						variant: "simple",
+						value: `${opts.default}`,
+					}
+				: undefined,
 		type: {
 			variant: "simple",
 			type: opts.type,

--- a/packages/bits-ui/src/lib/bits/radio-group/components/radio-group.svelte
+++ b/packages/bits-ui/src/lib/bits/radio-group/components/radio-group.svelte
@@ -18,6 +18,7 @@
 		loop = true,
 		name = undefined,
 		required = false,
+		readonly = false,
 		id = createId(uid),
 		onValueChange = noop,
 		...restProps
@@ -29,6 +30,7 @@
 		loop: box.with(() => loop),
 		name: box.with(() => name),
 		required: box.with(() => required),
+		readonly: box.with(() => readonly),
 		id: box.with(() => id),
 		value: box.with(
 			() => value,

--- a/packages/bits-ui/src/lib/bits/radio-group/types.ts
+++ b/packages/bits-ui/src/lib/bits/radio-group/types.ts
@@ -10,7 +10,7 @@ export type RadioGroupRootPropsWithoutHTML = WithChild<{
 	 * The orientation of the radio group. Used to determine
 	 * how keyboard navigation should work.
 	 *
-	 * @defaultValue "vertical"
+	 * @default "vertical"
 	 */
 	orientation?: Orientation;
 
@@ -18,14 +18,14 @@ export type RadioGroupRootPropsWithoutHTML = WithChild<{
 	 * Whether to loop around the radio items when navigating
 	 * with the keyboard.
 	 *
-	 * @defaultValue true
+	 * @default true
 	 */
 	loop?: boolean;
 
 	/**
 	 * The value of the selected radio item.
 	 *
-	 * @defaultValue ""
+	 * @default ""
 	 */
 	value?: string;
 
@@ -39,14 +39,14 @@ export type RadioGroupRootPropsWithoutHTML = WithChild<{
 	 * form submission. If not provided, a hidden input will not
 	 * be rendered and the radio group will not be part of a form.
 	 *
-	 * @defaultValue undefined
+	 * @default undefined
 	 */
 	name?: string;
 
 	/**
 	 * Whether the radio group is disabled.
 	 *
-	 * @defaultValue false
+	 * @default false
 	 */
 	disabled?: boolean;
 
@@ -56,6 +56,14 @@ export type RadioGroupRootPropsWithoutHTML = WithChild<{
 	 * input is rendered.
 	 */
 	required?: boolean;
+
+	/**
+	 * Whether the radio group is readonly. When readonly, users can
+	 * focus and navigate through items but cannot change the value.
+	 *
+	 * @default false
+	 */
+	readonly?: boolean;
 }>;
 
 export type RadioGroupRootProps = RadioGroupRootPropsWithoutHTML &
@@ -73,7 +81,7 @@ export type RadioGroupItemPropsWithoutHTML = WithChild<
 		/**
 		 * Whether the radio item is disabled.
 		 *
-		 * @defaultValue false
+		 * @default false
 		 */
 		disabled?: boolean | null | undefined;
 	},

--- a/tests/src/tests/radio-group/radio-group.test.ts
+++ b/tests/src/tests/radio-group/radio-group.test.ts
@@ -220,6 +220,121 @@ describe("Input Behavior", () => {
 	});
 });
 
+describe("Readonly Behavior", () => {
+	it("should not have accessibility violations", async () => {
+		const t = setup({ readonly: true });
+		expect(await axe(t.container)).toHaveNoViolations();
+	});
+
+	it("should have readonly data attribute when readonly prop is true", async () => {
+		const t = setup({ readonly: true });
+		const item = t.getByTestId("a-item");
+		expect(item).toHaveAttribute("data-readonly");
+	});
+
+	it("should not have readonly data attribute when readonly prop is false", async () => {
+		const t = setup({ readonly: false });
+		const item = t.getByTestId("a-item");
+		expect(item).not.toHaveAttribute("data-readonly");
+	});
+
+	it("should have aria-readonly on root when readonly prop is true", async () => {
+		const t = setup({ readonly: true });
+		const root = t.getByTestId("root");
+		expect(root).toHaveAttribute("aria-readonly", "true");
+	});
+
+	it("should not have aria-readonly on root when readonly prop is false", async () => {
+		const t = setup({ readonly: false });
+		const root = t.getByTestId("root");
+		expect(root).not.toHaveAttribute("aria-readonly");
+	});
+
+	it("should not change value when readonly and item is clicked", async () => {
+		const t = setup({ readonly: true, value: "b" });
+
+		// verify initial state
+		expect(t.getByTestId("b-indicator")).toHaveTextContent("true");
+		expect(t.getByTestId("a-indicator")).toHaveTextContent("false");
+
+		// click on different item
+		await t.user.click(t.getByTestId("a-item"));
+
+		// value should not change
+		expect(t.getByTestId("b-indicator")).toHaveTextContent("true");
+		expect(t.getByTestId("a-indicator")).toHaveTextContent("false");
+	});
+
+	it("should not change value when readonly and space key is pressed", async () => {
+		const t = setup({ readonly: true, value: "b" });
+
+		// verify initial state
+		expect(t.getByTestId("b-indicator")).toHaveTextContent("true");
+		expect(t.getByTestId("a-indicator")).toHaveTextContent("false");
+
+		// focus and press space on different item
+		const aItem = t.getByTestId("a-item");
+		aItem.focus();
+		await t.user.keyboard(kbd.SPACE);
+
+		// value should not change
+		expect(t.getByTestId("b-indicator")).toHaveTextContent("true");
+		expect(t.getByTestId("a-indicator")).toHaveTextContent("false");
+	});
+
+	it("should not change value when readonly and focus moves to different item", async () => {
+		const t = setup({ readonly: true, value: "b" });
+
+		// verify initial state
+		expect(t.getByTestId("b-indicator")).toHaveTextContent("true");
+		expect(t.getByTestId("a-indicator")).toHaveTextContent("false");
+
+		// focus on different item
+		const aItem = t.getByTestId("a-item");
+		aItem.focus();
+
+		// value should not change
+		expect(t.getByTestId("b-indicator")).toHaveTextContent("true");
+		expect(t.getByTestId("a-indicator")).toHaveTextContent("false");
+	});
+
+	it("should allow keyboard navigation when readonly", async () => {
+		const t = setup({ readonly: true, value: "b" });
+		const [item0, item1, item2] = ITEM_IDS.map((id) => t.getByTestId(id as string));
+
+		item0.focus();
+		expect(item0).toHaveFocus();
+		await t.user.keyboard(kbd.ARROW_DOWN);
+		expect(item1).toHaveFocus();
+		await t.user.keyboard(kbd.ARROW_DOWN);
+		expect(item2).toHaveFocus();
+		await t.user.keyboard(kbd.ARROW_UP);
+		expect(item1).toHaveFocus();
+	});
+
+	it("should allow focus when readonly", async () => {
+		const t = setup({ readonly: true, value: "b" });
+
+		await t.user.keyboard(kbd.TAB);
+		await waitFor(() => expect(t.getByTestId("b-item")).toHaveFocus());
+	});
+
+	it("should not change value when readonly and label is clicked", async () => {
+		const t = setup({ readonly: true, value: "b" });
+
+		// verify initial state
+		expect(t.getByTestId("b-indicator")).toHaveTextContent("true");
+		expect(t.getByTestId("a-indicator")).toHaveTextContent("false");
+
+		// click on label of different item
+		await t.user.click(t.getByTestId("a-label"));
+
+		// value should not change
+		expect(t.getByTestId("b-indicator")).toHaveTextContent("true");
+		expect(t.getByTestId("a-indicator")).toHaveTextContent("false");
+	});
+});
+
 describe("Focus Management", () => {
 	it("should focus the first item when no value is set and focus enters the group", async () => {
 		const t = setup();


### PR DESCRIPTION
This pull request introduces a new `readonly` property to the `RadioGroup` component.

### New Feature: `readonly` Property for `RadioGroup`

* Added a `readonly` prop to the `RadioGroup.Root` component to make it readonly, preventing value changes while still allowing focus and navigation.
* Updated the `RadioGroup` state and behavior to respect the `readonly` property, including preventing value changes on clicks, focus, or keyboard interactions when `readonly` is true. 