### PR TITLE
fix(Select): ensure `disabled` prop is respected for touch

### DIFF
--- a/.changeset/many-feet-clean.md
+++ b/.changeset/many-feet-clean.md
@@ -1,0 +1,5 @@
+---
+"bits-ui": patch
+---
+
+fix(Select): ensure the disabled prop is respect for touch events

--- a/docs/src/lib/components/demos/combobox-demo.svelte
+++ b/docs/src/lib/components/demos/combobox-demo.svelte
@@ -51,11 +51,11 @@
 		/>
 		<Combobox.Input
 			oninput={(e) => (searchValue = e.currentTarget.value)}
-			class="h-input rounded-9px border-border-input bg-background placeholder:text-foreground-alt/50 focus:ring-foreground focus:ring-offset-background focus:outline-hidden inline-flex w-[296px] truncate border px-11 text-base transition-colors focus:ring-2 focus:ring-offset-2 sm:text-sm"
+			class="h-input rounded-9px border-border-input bg-background placeholder:text-foreground-alt/50 focus:ring-foreground focus:ring-offset-background focus:outline-hidden inline-flex w-[296px] touch-none truncate border px-11 text-base transition-colors focus:ring-2 focus:ring-offset-2 sm:text-sm"
 			placeholder="Search a fruit"
 			aria-label="Search a fruit"
 		/>
-		<Combobox.Trigger class="absolute end-3 top-1/2 size-6 -translate-y-1/2">
+		<Combobox.Trigger class="absolute end-3 top-1/2 size-6 -translate-y-1/2 touch-none">
 			<CaretUpDown class="text-muted-foreground size-6" />
 		</Combobox.Trigger>
 	</div>

--- a/docs/src/lib/components/demos/select-demo-auto-scroll-delay.svelte
+++ b/docs/src/lib/components/demos/select-demo-auto-scroll-delay.svelte
@@ -57,7 +57,7 @@
 
 <Select.Root type="single" onValueChange={(v) => (value = v)} items={themes}>
 	<Select.Trigger
-		class="h-input rounded-9px border-border-input bg-background data-placeholder:text-foreground-alt/50 inline-flex w-[296px] select-none items-center border px-[11px] text-sm transition-colors"
+		class="h-input rounded-9px border-border-input bg-background data-placeholder:text-foreground-alt/50 inline-flex w-[296px] touch-none select-none items-center border px-[11px] text-sm transition-colors"
 		aria-label="Select a theme"
 	>
 		<Palette class="text-muted-foreground mr-[9px] size-6" />

--- a/docs/src/lib/components/demos/select-demo-custom.svelte
+++ b/docs/src/lib/components/demos/select-demo-custom.svelte
@@ -42,7 +42,7 @@
 
 <Select.Root {...restProps} type="single" bind:value items={themes}>
 	<Select.Trigger
-		class="h-input rounded-9px border-border-input bg-background placeholder:text-foreground-alt/50 inline-flex w-[296px] select-none items-center border px-[11px] text-sm transition-colors"
+		class="h-input rounded-9px border-border-input bg-background placeholder:text-foreground-alt/50 inline-flex w-[296px] touch-none select-none items-center border px-[11px] text-sm transition-colors"
 		aria-label="Select a theme"
 	>
 		<Palette class="text-muted-foreground mr-[9px] size-6" />

--- a/docs/src/lib/components/demos/select-demo-multiple.svelte
+++ b/docs/src/lib/components/demos/select-demo-multiple.svelte
@@ -42,7 +42,7 @@
 
 <Select.Root type="multiple" bind:value>
 	<Select.Trigger
-		class="h-input rounded-9px border-border-input bg-background data-placeholder:text-foreground-alt/50 inline-flex w-[296px] select-none items-center border px-[11px] text-sm transition-colors"
+		class="h-input rounded-9px border-border-input bg-background data-placeholder:text-foreground-alt/50 inline-flex w-[296px] touch-none select-none items-center border px-[11px] text-sm transition-colors"
 		aria-label="Select a theme"
 	>
 		<Palette class="text-muted-foreground mr-[9px] size-6" />

--- a/docs/src/lib/components/demos/select-demo-transition.svelte
+++ b/docs/src/lib/components/demos/select-demo-transition.svelte
@@ -38,7 +38,7 @@
 
 <Select.Root type="single" bind:value items={themes}>
 	<Select.Trigger
-		class="h-input rounded-9px border-border-input bg-background placeholder:text-foreground-alt/50 inline-flex w-[296px] select-none items-center border px-[11px] text-sm transition-colors"
+		class="h-input rounded-9px border-border-input bg-background placeholder:text-foreground-alt/50 inline-flex w-[296px] touch-none select-none items-center border px-[11px] text-sm transition-colors"
 		aria-label="Select a theme"
 	>
 		<Palette class="text-muted-foreground mr-[9px] size-6" />

--- a/docs/src/lib/components/demos/select-demo.svelte
+++ b/docs/src/lib/components/demos/select-demo.svelte
@@ -38,7 +38,7 @@
 
 <Select.Root type="single" onValueChange={(v) => (value = v)} items={themes}>
 	<Select.Trigger
-		class="h-input rounded-9px border-border-input bg-background data-placeholder:text-foreground-alt/50 inline-flex w-[296px] select-none items-center border px-[11px] text-sm transition-colors"
+		class="h-input rounded-9px border-border-input bg-background data-placeholder:text-foreground-alt/50 inline-flex w-[296px] touch-none select-none items-center border px-[11px] text-sm transition-colors"
 		aria-label="Select a theme"
 	>
 		<Palette class="text-muted-foreground mr-[9px] size-6" />

--- a/packages/bits-ui/src/lib/bits/select/select.svelte.ts
+++ b/packages/bits-ui/src/lib/bits/select/select.svelte.ts
@@ -741,6 +741,7 @@ class SelectTriggerState {
 	}
 
 	onpointerup(e: BitsPointerEvent) {
+		if (this.root.opts.disabled.current) return;
 		e.preventDefault();
 		if (e.pointerType === "touch") {
 			if (this.root.opts.open.current === false) {

--- a/tests/src/tests/select/select.test.ts
+++ b/tests/src/tests/select/select.test.ts
@@ -548,6 +548,30 @@ describe("select - single", () => {
 		});
 		expect(getHiddenInput()).toHaveAttribute("autocomplete", "one-time-code");
 	});
+
+	it("should not open when disabled on touch devices", async () => {
+		const { trigger, queryByTestId } = setupSingle({ disabled: true });
+
+		// simulate touch pointerup event (which is what touch devices use)
+		const touchEvent = new PointerEvent("pointerup", {
+			pointerType: "touch",
+		});
+		trigger.dispatchEvent(touchEvent);
+
+		expect(queryByTestId("content")).toBeNull();
+	});
+
+	it("should not open when disabled on mouse/pointer devices", async () => {
+		const { trigger, queryByTestId } = setupSingle({ disabled: true });
+
+		// simulate mouse pointerdown event
+		const mouseEvent = new PointerEvent("pointerdown", {
+			pointerType: "mouse",
+		});
+		trigger.dispatchEvent(mouseEvent);
+
+		expect(queryByTestId("content")).toBeNull();
+	});
 });
 
 ////////////////////////////////////
@@ -838,6 +862,30 @@ describe("select - multiple", () => {
 
 		await user.click(submit);
 		expect(submittedValues).toHaveLength(0);
+	});
+
+	it("should not open when disabled on touch devices", async () => {
+		const { trigger, queryByTestId } = setupMultiple({ disabled: true });
+
+		// simulate touch pointerup event (which is what touch devices use)
+		const touchEvent = new PointerEvent("pointerup", {
+			pointerType: "touch",
+		});
+		trigger.dispatchEvent(touchEvent);
+
+		expect(queryByTestId("content")).toBeNull();
+	});
+
+	it("should not open when disabled on mouse/pointer devices", async () => {
+		const { trigger, queryByTestId } = setupMultiple({ disabled: true });
+
+		// simulate mouse pointerdown event
+		const mouseEvent = new PointerEvent("pointerdown", {
+			pointerType: "mouse",
+		});
+		trigger.dispatchEvent(mouseEvent);
+
+		expect(queryByTestId("content")).toBeNull();
 	});
 });
 


### PR DESCRIPTION
Closes #1580 

This pull request addresses a bug in the `Select` component where the `disabled` property was not properly respected for touch events. It ensures consistent behavior across different input methods (e.g., touch, mouse) and updates documentation and tests accordingly.

### Bug Fixes and Behavior Adjustments:
* Updated `SelectTriggerState` in `select.svelte.ts` to prevent the `pointerup` event from opening the dropdown when the `disabled` property is set.
* Added test cases in `select.test.ts` to verify that the `Select` component does not open on touch or mouse events when disabled, for both single and multiple selection modes.