### PR TITLE
fix: replace `css.escape` to prevent `this` issue

### DIFF
--- a/.changeset/orange-friends-say.md
+++ b/.changeset/orange-friends-say.md
@@ -1,0 +1,5 @@
+---
+"bits-ui": patch
+---
+
+fix: replace `css.escape` to prevent `this` issue

--- a/packages/bits-ui/package.json
+++ b/packages/bits-ui/package.json
@@ -32,7 +32,6 @@
 		"@sveltejs/kit": "^2.21.5",
 		"@sveltejs/package": "^2.3.11",
 		"@sveltejs/vite-plugin-svelte": "^5.1.0",
-		"@types/css.escape": "^1.5.2",
 		"@types/node": "^20.17.6",
 		"@types/resize-observer-browser": "^0.1.11",
 		"csstype": "^3.1.3",
@@ -50,7 +49,6 @@
 	"dependencies": {
 		"@floating-ui/core": "^1.7.1",
 		"@floating-ui/dom": "^1.7.1",
-		"css.escape": "^1.5.1",
 		"esm-env": "^1.1.2",
 		"runed": "^0.28.0",
 		"svelte-toolbelt": "^0.9.2",

--- a/packages/bits-ui/src/lib/bits/command/command.svelte.ts
+++ b/packages/bits-ui/src/lib/bits/command/command.svelte.ts
@@ -27,7 +27,7 @@ import {
 } from "$lib/internal/attrs.js";
 import { getFirstNonCommentChild } from "$lib/internal/dom.js";
 import { computeCommandScore } from "./index.js";
-import cssesc from "css.escape";
+import { cssEscape } from "$lib/internal/css-escape.js";
 
 const COMMAND_VALUE_ATTR = "data-value";
 
@@ -262,7 +262,7 @@ export class CommandRootState {
 
 		for (const group of sortedGroups) {
 			const element = listInsertionElement?.querySelector(
-				`${COMMAND_GROUP_SELECTOR}[${COMMAND_VALUE_ATTR}="${cssesc(group[0])}"]`
+				`${COMMAND_GROUP_SELECTOR}[${COMMAND_VALUE_ATTR}="${cssEscape(group[0])}"]`
 			);
 			element?.parentElement?.appendChild(element);
 		}
@@ -1301,7 +1301,7 @@ export class CommandInputState {
 	readonly attachment: RefAttachment;
 	readonly #selectedItemId = $derived.by(() => {
 		const item = this.root.viewportNode?.querySelector<HTMLElement>(
-			`${COMMAND_ITEM_SELECTOR}[${COMMAND_VALUE_ATTR}="${cssesc(this.root.opts.value.current)}"]`
+			`${COMMAND_ITEM_SELECTOR}[${COMMAND_VALUE_ATTR}="${cssEscape(this.root.opts.value.current)}"]`
 		);
 		if (item === undefined || item === null) return;
 		return item.getAttribute("id") ?? undefined;

--- a/packages/bits-ui/src/lib/internal/css-escape.test.ts
+++ b/packages/bits-ui/src/lib/internal/css-escape.test.ts
@@ -16,14 +16,6 @@ describe("cssEscape", () => {
 		expect(cssEscape("a\uFFFDb")).toBe("a\uFFFDb");
 	});
 
-	it("should handle type coercion", () => {
-		expect(cssEscape(undefined)).toBe("undefined");
-		expect(cssEscape(true)).toBe("true");
-		expect(cssEscape(false)).toBe("false");
-		expect(cssEscape(null)).toBe("null");
-		expect(cssEscape("")).toBe("");
-	});
-
 	it("should escape control characters", () => {
 		expect(cssEscape("\x01\x02\x1E\x1F")).toBe("\\1 \\2 \\1e \\1f ");
 	});

--- a/packages/bits-ui/src/lib/internal/css-escape.test.ts
+++ b/packages/bits-ui/src/lib/internal/css-escape.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect } from "vitest";
+import { cssEscape } from "./css-escape.js";
+
+describe("cssEscape", () => {
+	it("should handle null characters", () => {
+		expect(cssEscape("\0")).toBe("\uFFFD");
+		expect(cssEscape("a\0")).toBe("a\uFFFD");
+		expect(cssEscape("\0b")).toBe("\uFFFDb");
+		expect(cssEscape("a\0b")).toBe("a\uFFFDb");
+	});
+
+	it("should handle replacement characters", () => {
+		expect(cssEscape("\uFFFD")).toBe("\uFFFD");
+		expect(cssEscape("a\uFFFD")).toBe("a\uFFFD");
+		expect(cssEscape("\uFFFDb")).toBe("\uFFFDb");
+		expect(cssEscape("a\uFFFDb")).toBe("a\uFFFDb");
+	});
+
+	it("should handle type coercion", () => {
+		expect(cssEscape(undefined)).toBe("undefined");
+		expect(cssEscape(true)).toBe("true");
+		expect(cssEscape(false)).toBe("false");
+		expect(cssEscape(null)).toBe("null");
+		expect(cssEscape("")).toBe("");
+	});
+
+	it("should escape control characters", () => {
+		expect(cssEscape("\x01\x02\x1E\x1F")).toBe("\\1 \\2 \\1e \\1f ");
+	});
+
+	it("should escape digits at start", () => {
+		expect(cssEscape("0a")).toBe("\\30 a");
+		expect(cssEscape("1a")).toBe("\\31 a");
+		expect(cssEscape("2a")).toBe("\\32 a");
+		expect(cssEscape("3a")).toBe("\\33 a");
+		expect(cssEscape("4a")).toBe("\\34 a");
+		expect(cssEscape("5a")).toBe("\\35 a");
+		expect(cssEscape("6a")).toBe("\\36 a");
+		expect(cssEscape("7a")).toBe("\\37 a");
+		expect(cssEscape("8a")).toBe("\\38 a");
+		expect(cssEscape("9a")).toBe("\\39 a");
+	});
+
+	it("should not escape digits in middle", () => {
+		expect(cssEscape("a0b")).toBe("a0b");
+		expect(cssEscape("a1b")).toBe("a1b");
+		expect(cssEscape("a2b")).toBe("a2b");
+		expect(cssEscape("a3b")).toBe("a3b");
+		expect(cssEscape("a4b")).toBe("a4b");
+		expect(cssEscape("a5b")).toBe("a5b");
+		expect(cssEscape("a6b")).toBe("a6b");
+		expect(cssEscape("a7b")).toBe("a7b");
+		expect(cssEscape("a8b")).toBe("a8b");
+		expect(cssEscape("a9b")).toBe("a9b");
+	});
+
+	it("should handle hyphen with digits", () => {
+		expect(cssEscape("-0a")).toBe("-\\30 a");
+		expect(cssEscape("-1a")).toBe("-\\31 a");
+		expect(cssEscape("-2a")).toBe("-\\32 a");
+		expect(cssEscape("-3a")).toBe("-\\33 a");
+		expect(cssEscape("-4a")).toBe("-\\34 a");
+		expect(cssEscape("-5a")).toBe("-\\35 a");
+		expect(cssEscape("-6a")).toBe("-\\36 a");
+		expect(cssEscape("-7a")).toBe("-\\37 a");
+		expect(cssEscape("-8a")).toBe("-\\38 a");
+		expect(cssEscape("-9a")).toBe("-\\39 a");
+	});
+
+	it("should handle hyphens", () => {
+		expect(cssEscape("-")).toBe("\\-");
+		expect(cssEscape("-a")).toBe("-a");
+		expect(cssEscape("--")).toBe("--");
+		expect(cssEscape("--a")).toBe("--a");
+	});
+
+	it("should handle various characters", () => {
+		expect(cssEscape("\x80\x2D\x5F\xA9")).toBe("\x80\x2D\x5F\xA9");
+		expect(
+			cssEscape(
+				"\x7F\x80\x81\x82\x83\x84\x85\x86\x87\x88\x89\x8A\x8B\x8C\x8D\x8E\x8F\x90\x91\x92\x93\x94\x95\x96\x97\x98\x99\x9A\x9B\x9C\x9D\x9E\x9F"
+			)
+		).toBe(
+			"\\7f \x80\x81\x82\x83\x84\x85\x86\x87\x88\x89\x8A\x8B\x8C\x8D\x8E\x8F\x90\x91\x92\x93\x94\x95\x96\x97\x98\x99\x9A\x9B\x9C\x9D\x9E\x9F"
+		);
+		expect(cssEscape("\xA0\xA1\xA2")).toBe("\xA0\xA1\xA2");
+		expect(cssEscape("a0123456789b")).toBe("a0123456789b");
+		expect(cssEscape("abcdefghijklmnopqrstuvwxyz")).toBe("abcdefghijklmnopqrstuvwxyz");
+		expect(cssEscape("ABCDEFGHIJKLMNOPQRSTUVWXYZ")).toBe("ABCDEFGHIJKLMNOPQRSTUVWXYZ");
+	});
+
+	it("should escape special characters", () => {
+		expect(cssEscape("\x20\x21\x78\x79")).toBe("\\ \\!xy");
+	});
+
+	it("should handle unicode surrogates", () => {
+		// astral symbol (U+1D306 TETRAGRAM FOR CENTRE)
+		expect(cssEscape("\uD834\uDF06")).toBe("\uD834\uDF06");
+		// lone surrogates
+		expect(cssEscape("\uDF06")).toBe("\uDF06");
+		expect(cssEscape("\uD834")).toBe("\uD834");
+	});
+});

--- a/packages/bits-ui/src/lib/internal/css-escape.ts
+++ b/packages/bits-ui/src/lib/internal/css-escape.ts
@@ -6,6 +6,9 @@
  */
 export function cssEscape(value: unknown): string {
 	const str = `${value}`;
+	if (typeof CSS !== "undefined" && typeof CSS.escape === "function") {
+		return CSS.escape(str);
+	}
 	const length = str.length;
 	let index = -1;
 	let codeUnit: number;

--- a/packages/bits-ui/src/lib/internal/css-escape.ts
+++ b/packages/bits-ui/src/lib/internal/css-escape.ts
@@ -1,0 +1,66 @@
+/**
+ * https://github.com/mathiasbynens/CSS.escape
+ *
+ * @param value - The value to escape for use as a CSS identifier
+ * @returns The escaped CSS identifier string
+ */
+export function cssEscape(value: unknown): string {
+	const str = `${value}`;
+	const length = str.length;
+	let index = -1;
+	let codeUnit: number;
+	let result = "";
+	const firstCodeUnit = str.charCodeAt(0);
+
+	// If the character is the first character and is a `-` (U+002D), and
+	// there is no second character, escape it
+	if (length === 1 && firstCodeUnit === 0x002d) return "\\" + str;
+
+	while (++index < length) {
+		codeUnit = str.charCodeAt(index);
+
+		// If the character is NULL (U+0000), then the REPLACEMENT CHARACTER (U+FFFD)
+		if (codeUnit === 0x0000) {
+			result += "\uFFFD";
+			continue;
+		}
+
+		if (
+			// If the character is in the range [\1-\1F] (U+0001 to U+001F) or is U+007F
+			(codeUnit >= 0x0001 && codeUnit <= 0x001f) ||
+			codeUnit === 0x007f ||
+			// If the character is the first character and is in the range [0-9] (U+0030 to U+0039)
+			(index === 0 && codeUnit >= 0x0030 && codeUnit <= 0x0039) ||
+			// If the character is the second character and is in the range [0-9] (U+0030 to U+0039)
+			// and the first character is a `-` (U+002D)
+			(index === 1 && codeUnit >= 0x0030 && codeUnit <= 0x0039 && firstCodeUnit === 0x002d)
+		) {
+			// https://drafts.csswg.org/cssom/#escape-a-character-as-code-point
+			result += "\\" + codeUnit.toString(16) + " ";
+			continue;
+		}
+
+		// If the character is not handled by one of the above rules and is
+		// greater than or equal to U+0080, is `-` (U+002D) or `_` (U+005F), or
+		// is in one of the ranges [0-9] (U+0030 to U+0039), [A-Z] (U+0041 to U+005A),
+		// or [a-z] (U+0061 to U+007A)
+		if (
+			codeUnit >= 0x0080 ||
+			codeUnit === 0x002d ||
+			codeUnit === 0x005f ||
+			(codeUnit >= 0x0030 && codeUnit <= 0x0039) ||
+			(codeUnit >= 0x0041 && codeUnit <= 0x005a) ||
+			(codeUnit >= 0x0061 && codeUnit <= 0x007a)
+		) {
+			// Use the character itself
+			result += str.charAt(index);
+			continue;
+		}
+
+		// Otherwise, escape the character
+		// https://drafts.csswg.org/cssom/#escape-a-character
+		result += "\\" + str.charAt(index);
+	}
+
+	return result;
+}

--- a/packages/bits-ui/src/lib/internal/css-escape.ts
+++ b/packages/bits-ui/src/lib/internal/css-escape.ts
@@ -4,23 +4,22 @@
  * @param value - The value to escape for use as a CSS identifier
  * @returns The escaped CSS identifier string
  */
-export function cssEscape(value: unknown): string {
-	const str = `${value}`;
+export function cssEscape(value: string): string {
 	if (typeof CSS !== "undefined" && typeof CSS.escape === "function") {
-		return CSS.escape(str);
+		return CSS.escape(value);
 	}
-	const length = str.length;
+	const length = value.length;
 	let index = -1;
 	let codeUnit: number;
 	let result = "";
-	const firstCodeUnit = str.charCodeAt(0);
+	const firstCodeUnit = value.charCodeAt(0);
 
 	// If the character is the first character and is a `-` (U+002D), and
 	// there is no second character, escape it
-	if (length === 1 && firstCodeUnit === 0x002d) return "\\" + str;
+	if (length === 1 && firstCodeUnit === 0x002d) return "\\" + value;
 
 	while (++index < length) {
-		codeUnit = str.charCodeAt(index);
+		codeUnit = value.charCodeAt(index);
 
 		// If the character is NULL (U+0000), then the REPLACEMENT CHARACTER (U+FFFD)
 		if (codeUnit === 0x0000) {
@@ -56,13 +55,13 @@ export function cssEscape(value: unknown): string {
 			(codeUnit >= 0x0061 && codeUnit <= 0x007a)
 		) {
 			// Use the character itself
-			result += str.charAt(index);
+			result += value.charAt(index);
 			continue;
 		}
 
 		// Otherwise, escape the character
 		// https://drafts.csswg.org/cssom/#escape-a-character
-		result += "\\" + str.charAt(index);
+		result += "\\" + value.charAt(index);
 	}
 
 	return result;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -197,9 +197,6 @@ importers:
       '@floating-ui/dom':
         specifier: ^1.7.1
         version: 1.7.1
-      css.escape:
-        specifier: ^1.5.1
-        version: 1.5.1
       esm-env:
         specifier: ^1.1.2
         version: 1.2.2
@@ -225,9 +222,6 @@ importers:
       '@sveltejs/vite-plugin-svelte':
         specifier: ^5.1.0
         version: 5.1.0(svelte@5.33.2)(vite@6.3.5(@types/node@20.17.6)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.39.2)(yaml@2.4.5))
-      '@types/css.escape':
-        specifier: ^1.5.2
-        version: 1.5.2
       '@types/node':
         specifier: ^20.17.6
         version: 20.17.6
@@ -1298,9 +1292,6 @@ packages:
 
   '@types/cookie@0.6.0':
     resolution: {integrity: sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==}
-
-  '@types/css.escape@1.5.2':
-    resolution: {integrity: sha512-sq0h0y8i83T20MB434AZWgK3byezbBG48jllitFpVXlPOjHc5RNs3bg6rUen/EtMUjM4ZJjD4x+0aik9AXqLdQ==}
 
   '@types/debug@4.1.12':
     resolution: {integrity: sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==}
@@ -4615,8 +4606,6 @@ snapshots:
       '@types/deep-eql': 4.0.2
 
   '@types/cookie@0.6.0': {}
-
-  '@types/css.escape@1.5.2': {}
 
   '@types/debug@4.1.12':
     dependencies:


### PR DESCRIPTION
This pull request addresses a bug related to the use of `css.escape` in `bits-ui` by replacing it with an alternative approach. 

Fixes #1607 