### PR TITLE
fix(Command): Ensure selected item is visible when command is in grid mode

### DIFF
--- a/.changeset/loose-dogs-rule.md
+++ b/.changeset/loose-dogs-rule.md
@@ -1,0 +1,5 @@
+---
+"bits-ui": patch
+---
+
+fix(Command): Ensure selected item is visible when command is in grid mode

--- a/packages/bits-ui/src/lib/bits/command/command.svelte.ts
+++ b/packages/bits-ui/src/lib/bits/command/command.svelte.ts
@@ -446,6 +446,9 @@ export class CommandRootState {
 			if (this.isGrid) {
 				const isFirstRowOfGroup = this.#itemIsFirstRowOfGroup(item);
 
+				// ensure item is visible
+				item.scrollIntoView({ block: "nearest" });
+
 				if (isFirstRowOfGroup) {
 					const closestGroupHeader = item
 						?.closest(COMMAND_GROUP_SELECTOR)


### PR DESCRIPTION
Kinda a weird hack but it works better than only scrolling to the item itself.