### PR TITLE
fix(Checkbox): ensure   isn't called more than once per change

### DIFF
--- a/.changeset/every-snails-clean.md
+++ b/.changeset/every-snails-clean.md
@@ -1,0 +1,5 @@
+---
+"bits-ui": patch
+---
+
+fix(Checkbox): ensure `Checkbox.Group` `onValueChange` isn't called more than once per change

--- a/docs/src/lib/components/demos/checkbox-demo-group.svelte
+++ b/docs/src/lib/components/demos/checkbox-demo-group.svelte
@@ -6,7 +6,12 @@
 	let myValue = $state<string[]>(["marketing", "news"]);
 </script>
 
-<Checkbox.Group class="flex flex-col gap-3" bind:value={myValue} name="notifications">
+<Checkbox.Group
+	class="flex flex-col gap-3"
+	bind:value={myValue}
+	name="notifications"
+	onValueChange={console.log}
+>
 	<Checkbox.GroupLabel class="text-foreground-alt text-sm font-medium">
 		Notifications
 	</Checkbox.GroupLabel>

--- a/packages/bits-ui/src/lib/bits/checkbox/checkbox.svelte.ts
+++ b/packages/bits-ui/src/lib/bits/checkbox/checkbox.svelte.ts
@@ -15,6 +15,7 @@ import {
 	getDataDisabled,
 } from "$lib/internal/attrs.js";
 import { kbd } from "$lib/internal/kbd.js";
+import { arraysAreEqual } from "$lib/internal/arrays.js";
 
 const checkboxAttrs = createBitsAttrs({
 	component: "checkbox",
@@ -54,6 +55,7 @@ export class CheckboxGroupState {
 		if (!this.opts.value.current.includes(checkboxValue)) {
 			const newValue = [...$state.snapshot(this.opts.value.current), checkboxValue];
 			this.opts.value.current = newValue;
+			if (arraysAreEqual(this.opts.value.current, newValue)) return;
 			this.opts.onValueChange.current(newValue);
 		}
 	}

--- a/packages/bits-ui/src/lib/bits/checkbox/components/checkbox-group.svelte
+++ b/packages/bits-ui/src/lib/bits/checkbox/components/checkbox-group.svelte
@@ -4,6 +4,7 @@
 	import { CheckboxGroupState } from "../checkbox.svelte.js";
 	import { noop } from "$lib/internal/noop.js";
 	import { createId } from "$lib/internal/create-id.js";
+	import { arraysAreEqual } from "$lib/internal/arrays.js";
 
 	const uid = $props.id();
 
@@ -32,6 +33,7 @@
 		value: box.with(
 			() => $state.snapshot(value),
 			(v) => {
+				if (arraysAreEqual(value, v)) return;
 				value = $state.snapshot(v);
 				onValueChange(v);
 			}


### PR DESCRIPTION
Fixes #1613 

Ensure's `onValueChange` is called only once per change for checkbox groups.