### PR TITLE
fix(Calendar): ensure `disableDaysOutsideMonth` is respected

### DIFF
--- a/.changeset/breezy-plums-relax.md
+++ b/.changeset/breezy-plums-relax.md
@@ -1,0 +1,5 @@
+---
+"bits-ui": patch
+---
+
+fix(Calendar): ensure days are disabled when outside month and `disableDaysOutsideMonth`

--- a/packages/bits-ui/src/lib/bits/calendar/calendar.svelte.ts
+++ b/packages/bits-ui/src/lib/bits/calendar/calendar.svelte.ts
@@ -593,7 +593,6 @@ export class CalendarCellState {
 	readonly opts: CalendarCellStateOpts;
 	readonly root: CalendarRootState;
 	readonly cellDate = $derived.by(() => toDate(this.opts.date.current));
-	readonly isDisabled = $derived.by(() => this.root.isDateDisabled(this.opts.date.current));
 	readonly isUnavailable = $derived.by(() =>
 		this.root.opts.isDateUnavailable.current(this.opts.date.current)
 	);
@@ -603,6 +602,11 @@ export class CalendarCellState {
 	);
 	readonly isOutsideVisibleMonths = $derived.by(() =>
 		this.root.isOutsideVisibleMonths(this.opts.date.current)
+	);
+	readonly isDisabled = $derived.by(
+		() =>
+			this.root.isDateDisabled(this.opts.date.current) ||
+			(this.isOutsideMonth && this.root.opts.disableDaysOutsideMonth.current)
 	);
 	readonly isFocusedDate = $derived.by(() =>
 		isSameDay(this.opts.date.current, this.root.opts.placeholder.current)
@@ -628,6 +632,7 @@ export class CalendarCellState {
 		disabled: this.isDisabled,
 		unavailable: this.isUnavailable,
 		selected: this.isSelectedDate,
+		day: `${this.opts.date.current.day}`,
 	}));
 
 	readonly ariaDisabled = $derived.by(() => {

--- a/packages/bits-ui/src/lib/bits/range-calendar/range-calendar.svelte.ts
+++ b/packages/bits-ui/src/lib/bits/range-calendar/range-calendar.svelte.ts
@@ -732,14 +732,19 @@ export class RangeCalendarCellState {
 	readonly root: RangeCalendarRootState;
 	readonly attachment: RefAttachment;
 	readonly cellDate = $derived.by(() => toDate(this.opts.date.current));
-	readonly isDisabled = $derived.by(() => this.root.isDateDisabled(this.opts.date.current));
+	readonly isOutsideMonth = $derived.by(
+		() => !isSameMonth(this.opts.date.current, this.opts.month.current)
+	);
+	readonly isDisabled = $derived.by(
+		() =>
+			this.root.isDateDisabled(this.opts.date.current) ||
+			(this.isOutsideMonth && this.root.opts.disableDaysOutsideMonth.current)
+	);
 	readonly isUnavailable = $derived.by(() =>
 		this.root.opts.isDateUnavailable.current(this.opts.date.current)
 	);
 	readonly isDateToday = $derived.by(() => isToday(this.opts.date.current, getLocalTimeZone()));
-	readonly isOutsideMonth = $derived.by(
-		() => !isSameMonth(this.opts.date.current, this.opts.month.current)
-	);
+
 	readonly isOutsideVisibleMonths = $derived.by(() =>
 		this.root.isOutsideVisibleMonths(this.opts.date.current)
 	);


### PR DESCRIPTION
This pull request introduces a fix to ensure that days outside the current month are properly disabled when the `disableDaysOutsideMonth` option is enabled. The changes primarily affect the behavior of calendar components.

Fixes #1611 