### PR TITLE
Docs: Fix non-functional accordion example in getting started guide

### DIFF
--- a/docs/content/getting-started.md
+++ b/docs/content/getting-started.md
@@ -22,18 +22,22 @@ After installation, you can import and use Bits UI components in your Svelte fil
   import { Accordion } from "bits-ui";
 </script>
 
-<Accordion.Root>
-  <Accordion.Item>
+<Accordion.Root type="single">
+  <Accordion.Item value="item-1">
     <Accordion.Header>
-      <Accordion.Trigger>First</Accordion.Trigger>
+      <Accordion.Trigger>Item 1 Title</Accordion.Trigger>
     </Accordion.Header>
-    <Accordion.Content>First accordion content</Accordion.Content>
+    <Accordion.Content
+      >This is the collapsible content for this section.</Accordion.Content
+    >
   </Accordion.Item>
-  <Accordion.Item>
+  <Accordion.Item value="item-2">
     <Accordion.Header>
-      <Accordion.Trigger>Second</Accordion.Trigger>
+      <Accordion.Trigger>Item 2 Title</Accordion.Trigger>
     </Accordion.Header>
-    <Accordion.Content>Second accordion content</Accordion.Content>
+    <Accordion.Content
+      >This is the collapsible content for this section.</Accordion.Content
+    >
   </Accordion.Item>
 </Accordion.Root>
 ```


### PR DESCRIPTION
Getting-started accordion example missing the required `type` prop, non-functional when copied directly. Replaced with working example from the accordion component docs.

Discouraging for new devs when their first copy-paste doesn't work.