### PR TITLE
fix(Combobox): prevent selection of last highlighted item on invalid input (#1644)

### DIFF
--- a/.changeset/green-pugs-applaud.md
+++ b/.changeset/green-pugs-applaud.md
@@ -1,0 +1,5 @@
+---
+"bits-ui": patch
+---
+
+fix(Combobox): prevent selection of last highlighted item on invalid input (#1644)

--- a/packages/bits-ui/src/lib/bits/select/select.svelte.ts
+++ b/packages/bits-ui/src/lib/bits/select/select.svelte.ts
@@ -3,6 +3,7 @@ import {
 	afterSleep,
 	afterTick,
 	onDestroyEffect,
+	onMountEffect,
 	attachRef,
 	DOMContext,
 	type ReadableBoxedValues,
@@ -38,6 +39,7 @@ import { getFloatingContentCSSVars } from "$lib/internal/floating-svelte/floatin
 import { DataTypeahead } from "$lib/internal/data-typeahead.svelte.js";
 import { DOMTypeahead } from "$lib/internal/dom-typeahead.svelte.js";
 import { OpenChangeComplete } from "$lib/internal/open-change-complete.js";
+import { debounce } from "$lib/internal/debounce.js";
 
 // prettier-ignore
 export const INTERACTION_KEYS = [kbd.ARROW_LEFT, kbd.ESCAPE, kbd.ARROW_RIGHT, kbd.SHIFT, kbd.CAPS_LOCK, kbd.CONTROL, kbd.ALT, kbd.META, kbd.ENTER, kbd.F1, kbd.F2, kbd.F3, kbd.F4, kbd.F5, kbd.F6, kbd.F7, kbd.F8, kbd.F9, kbd.F10, kbd.F11, kbd.F12];
@@ -134,6 +136,11 @@ abstract class SelectBaseRootState {
 		});
 	}
 
+	#debouncedSetHighlightedToFirstCandidate = debounce(
+		this.setHighlightedToFirstCandidate.bind(this),
+		20
+	);
+
 	setHighlightedNode(node: HTMLElement | null, initial = false) {
 		this.highlightedNode = node;
 		if (node && (this.isUsingKeyboard || initial)) {
@@ -149,7 +156,11 @@ abstract class SelectBaseRootState {
 		);
 	}
 
-	setHighlightedToFirstCandidate() {
+	setHighlightedToFirstCandidate(options: { debounced: boolean } = { debounced: false }) {
+		if (options.debounced) {
+			this.#debouncedSetHighlightedToFirstCandidate();
+			return;
+		}
 		this.setHighlightedNode(null);
 		const candidateNodes = this.getCandidateNodes();
 		if (!candidateNodes.length) return;
@@ -505,7 +516,6 @@ export class SelectInputState {
 
 	oninput(e: BitsEvent<Event, HTMLInputElement>) {
 		this.root.opts.inputValue.current = e.currentTarget.value;
-		this.root.setHighlightedToFirstCandidate();
 	}
 
 	readonly props = $derived.by(
@@ -993,6 +1003,14 @@ export class SelectItemState {
 		this.opts = opts;
 		this.root = root;
 		this.attachment = attachRef(opts.ref);
+
+		onMountEffect(() => {
+			this.root.setHighlightedToFirstCandidate({ debounced: true });
+		});
+
+		onDestroyEffect(() => {
+			this.root.setHighlightedToFirstCandidate({ debounced: true });
+		});
 
 		watch([() => this.isHighlighted, () => this.prevHighlighted.current], () => {
 			if (this.isHighlighted) {


### PR DESCRIPTION
This PR fixes an issue where pressing `Enter` after typing a value that doesn't match any `Combobox` item would still select the last highlighted item, even though it was no longer visible. (See #1644)

## Root Cause
The issue occurred because highlight candidates were being collected **_before_** the `Combobox` content was updated. This led to stale items being highlighted, even when no matching items were shown.

## Solution
The highlight logic has been refactored to rely on the actual mounted content of the `Select`, rather than attempting to collect candidates immediately when the input value changes.

This is a more reliable approach because the timing of content updates is entirely up to the developer and it can vary depending on how filtering and rendering are implemented.

Changes:
- The logic to update the highlighted item is now triggered inside each item's `onMount` and `onDestroy` effects.
- A new `debounced` option has been added to the `setHighlightedToFirstCandidate` function to avoid multiple redundant calls when several items mount or unmount at once (e.g., during filtering).

Closes #1644