### PR TITLE
Add labelText to code sample

### DIFF
--- a/docs/content/components/switch.md
+++ b/docs/content/components/switch.md
@@ -62,6 +62,7 @@ In the example below, we're using the `Checkbox` and [`Label`](/docs/components/
     id = useId(),
     checked = $bindable(false),
     ref = $bindable(null),
+    labelText,
     ...restProps
   }: WithoutChildrenOrChild<Switch.RootProps> & {
     labelText: string;


### PR DESCRIPTION
A one-line change. I noticed when copying this example into my editor, the props did not define `labelText` which is expected later in the file. Thank you for all your hard work! Loving the library!