### PR TITLE
fix(Checkbox): prevent default `onclick` to support labels

### DIFF
--- a/.changeset/plain-radios-eat.md
+++ b/.changeset/plain-radios-eat.md
@@ -1,0 +1,5 @@
+---
+"bits-ui": patch
+---
+
+fix(Checkbox): prevent default onclick to support wrapping checkboxes with labels

--- a/docs/src/lib/components/demos/checkbox-demo.svelte
+++ b/docs/src/lib/components/demos/checkbox-demo.svelte
@@ -4,7 +4,7 @@
 	import Minus from "phosphor-svelte/lib/Minus";
 </script>
 
-<label for="terms" class="flex items-center space-x-3">
+<div class="flex items-center space-x-3">
 	<Checkbox.Root
 		id="terms"
 		aria-labelledby="terms-label"
@@ -22,10 +22,11 @@
 			</div>
 		{/snippet}
 	</Checkbox.Root>
-	<div
+	<Label.Root
 		id="terms-label"
+		for="terms"
 		class="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
 	>
 		Accept terms and conditions
-	</div>
-</label>
+	</Label.Root>
+</div>

--- a/docs/src/lib/components/demos/checkbox-demo.svelte
+++ b/docs/src/lib/components/demos/checkbox-demo.svelte
@@ -4,7 +4,7 @@
 	import Minus from "phosphor-svelte/lib/Minus";
 </script>
 
-<div class="flex items-center space-x-3">
+<label for="terms" class="flex items-center space-x-3">
 	<Checkbox.Root
 		id="terms"
 		aria-labelledby="terms-label"
@@ -22,11 +22,10 @@
 			</div>
 		{/snippet}
 	</Checkbox.Root>
-	<Label.Root
+	<div
 		id="terms-label"
-		for="terms"
 		class="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
 	>
 		Accept terms and conditions
-	</Label.Root>
-</div>
+	</div>
+</label>

--- a/packages/bits-ui/src/lib/bits/checkbox/checkbox.svelte.ts
+++ b/packages/bits-ui/src/lib/bits/checkbox/checkbox.svelte.ts
@@ -209,8 +209,9 @@ export class CheckboxRootState {
 		}
 	}
 
-	onclick(_: BitsMouseEvent) {
+	onclick(e: BitsMouseEvent) {
 		if (this.opts.disabled.current) return;
+		e.preventDefault();
 		this.#toggle();
 	}
 

--- a/tests/vite.config.ts
+++ b/tests/vite.config.ts
@@ -52,11 +52,7 @@ export default defineConfig({
 						headless: true,
 						provider: "playwright",
 						isolate: true,
-						instances: [
-							{ browser: "chromium" },
-							{ browser: "firefox" },
-							{ browser: "webkit" },
-						],
+						instances: [{ browser: "chromium" }, { browser: "webkit" }],
 					},
 				},
 			},


### PR DESCRIPTION
Fixes #1670 