### PR TITLE
Fix "onCloseAutoFocus.current is not a function"

### DIFF
--- a/.changeset/short-lights-beg.md
+++ b/.changeset/short-lights-beg.md
@@ -1,0 +1,8 @@
+---
+"bits-ui": patch
+---
+
+fix: only call onCloseAutoFocus handler if defined
+
+If popovers or other elements have been removed from the DOM, then
+onCloseAutoFocus.current may be undefined.

--- a/packages/bits-ui/src/lib/bits/menu/menu.svelte.ts
+++ b/packages/bits-ui/src/lib/bits/menu/menu.svelte.ts
@@ -282,7 +282,7 @@ export class MenuContentState {
 	}
 
 	onCloseAutoFocus = (e: Event) => {
-		this.opts.onCloseAutoFocus.current(e);
+		this.opts.onCloseAutoFocus.current?.(e);
 		if (e.defaultPrevented || this.#isSub) return;
 
 		if (this.parentMenu.triggerNode && isTabbable(this.parentMenu.triggerNode)) {

--- a/packages/bits-ui/src/lib/bits/menubar/menubar.svelte.ts
+++ b/packages/bits-ui/src/lib/bits/menubar/menubar.svelte.ts
@@ -319,7 +319,7 @@ export class MenubarContentState {
 	}
 
 	onCloseAutoFocus = (e: Event) => {
-		this.opts.onCloseAutoFocus.current(e);
+		this.opts.onCloseAutoFocus.current?.(e);
 		if (e.defaultPrevented) return;
 	};
 

--- a/packages/bits-ui/src/lib/bits/popover/popover.svelte.ts
+++ b/packages/bits-ui/src/lib/bits/popover/popover.svelte.ts
@@ -162,7 +162,7 @@ export class PopoverContentState {
 	};
 
 	onCloseAutoFocus = (e: Event) => {
-		this.opts.onCloseAutoFocus.current(e);
+		this.opts.onCloseAutoFocus.current?.(e);
 		if (e.defaultPrevented) return;
 		e.preventDefault();
 		this.root.triggerNode?.focus();

--- a/packages/bits-ui/src/lib/bits/utilities/focus-scope/focus-scope.svelte.ts
+++ b/packages/bits-ui/src/lib/bits/utilities/focus-scope/focus-scope.svelte.ts
@@ -103,7 +103,7 @@ export class FocusScope {
 			cancelable: true,
 		});
 
-		this.#opts.onCloseAutoFocus.current(event);
+		this.#opts.onCloseAutoFocus.current?.(event);
 
 		if (!event.defaultPrevented) {
 			// return focus to previously focused element


### PR DESCRIPTION
Fixes #1673.

When dialogs are removed from the DOM, it can sometimes happen that onCloseAutoFocus.current is undefined, resulting in this error. Changing the function call from`.current(event)` to `.current.?(event)` will remove the error.