### PR TITLE
fix(Popover): custom anchor outside interaction handling

### DIFF
--- a/.changeset/eight-houses-take.md
+++ b/.changeset/eight-houses-take.md
@@ -1,0 +1,5 @@
+---
+"bits-ui": patch
+---
+
+fix(Popover): ensure when using a `customAnchor`, outside interactions are properly handled

--- a/docs/src/lib/components/demos/popover-demo.svelte
+++ b/docs/src/lib/components/demos/popover-demo.svelte
@@ -5,17 +5,22 @@
 
 	let width = $state(1024);
 	let height = $state(768);
+	let customAnchor = $state<HTMLElement | null>(null!);
+	let open = $state(false);
 </script>
 
-<Popover.Root>
-	<Popover.Trigger
+<button bind:this={customAnchor} onclick={() => (open = !open)}> Click me </button>
+
+<Popover.Root bind:open>
+	<!-- <Popover.Trigger
 		class="rounded-input bg-dark
 	text-background shadow-mini hover:bg-dark/95 inline-flex h-10 select-none items-center justify-center whitespace-nowrap px-[21px] text-[15px] font-medium transition-all hover:cursor-pointer active:scale-[0.98]"
 	>
 		Resize
-	</Popover.Trigger>
+	</Popover.Trigger> -->
 	<Popover.Portal>
 		<Popover.Content
+			{customAnchor}
 			class="border-dark-10 bg-background shadow-popover data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-(--bits-popover-content-transform-origin) z-30 w-full max-w-[328px] rounded-[12px] border p-4"
 			sideOffset={8}
 		>

--- a/docs/src/lib/components/demos/popover-demo.svelte
+++ b/docs/src/lib/components/demos/popover-demo.svelte
@@ -5,22 +5,17 @@
 
 	let width = $state(1024);
 	let height = $state(768);
-	let customAnchor = $state<HTMLElement | null>(null!);
-	let open = $state(false);
 </script>
 
-<button bind:this={customAnchor} onclick={() => (open = !open)}> Click me </button>
-
-<Popover.Root bind:open>
-	<!-- <Popover.Trigger
+<Popover.Root>
+	<Popover.Trigger
 		class="rounded-input bg-dark
 	text-background shadow-mini hover:bg-dark/95 inline-flex h-10 select-none items-center justify-center whitespace-nowrap px-[21px] text-[15px] font-medium transition-all hover:cursor-pointer active:scale-[0.98]"
 	>
 		Resize
-	</Popover.Trigger> -->
+	</Popover.Trigger>
 	<Popover.Portal>
 		<Popover.Content
-			{customAnchor}
 			class="border-dark-10 bg-background shadow-popover data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-(--bits-popover-content-transform-origin) z-30 w-full max-w-[328px] rounded-[12px] border p-4"
 			sideOffset={8}
 		>

--- a/packages/bits-ui/src/lib/bits/popover/components/popover-content-static.svelte
+++ b/packages/bits-ui/src/lib/bits/popover/components/popover-content-static.svelte
@@ -21,6 +21,7 @@
 		onInteractOutside = noop,
 		trapFocus = true,
 		preventScroll = false,
+
 		...restProps
 	}: PopoverContentStaticProps = $props();
 
@@ -33,6 +34,7 @@
 		onInteractOutside: box.with(() => onInteractOutside),
 		onEscapeKeydown: box.with(() => onEscapeKeydown),
 		onCloseAutoFocus: box.with(() => onCloseAutoFocus),
+		customAnchor: box.with(() => null),
 	});
 
 	const mergedProps = $derived(mergeProps(restProps, contentState.props));

--- a/packages/bits-ui/src/lib/bits/popover/components/popover-content.svelte
+++ b/packages/bits-ui/src/lib/bits/popover/components/popover-content.svelte
@@ -21,6 +21,7 @@
 		onInteractOutside = noop,
 		trapFocus = true,
 		preventScroll = false,
+		customAnchor = null,
 		...restProps
 	}: PopoverContentProps = $props();
 
@@ -33,6 +34,7 @@
 		onInteractOutside: box.with(() => onInteractOutside),
 		onEscapeKeydown: box.with(() => onEscapeKeydown),
 		onCloseAutoFocus: box.with(() => onCloseAutoFocus),
+		customAnchor: box.with(() => customAnchor),
 	});
 
 	const mergedProps = $derived(mergeProps(restProps, contentState.props));
@@ -49,6 +51,7 @@
 		{preventScroll}
 		loop
 		forceMount={true}
+		{customAnchor}
 	>
 		{#snippet popper({ props, wrapperProps })}
 			{@const finalProps = mergeProps(props, {
@@ -76,6 +79,7 @@
 		{preventScroll}
 		loop
 		forceMount={false}
+		{customAnchor}
 	>
 		{#snippet popper({ props, wrapperProps })}
 			{@const finalProps = mergeProps(props, {

--- a/packages/bits-ui/src/lib/bits/popover/popover.svelte.ts
+++ b/packages/bits-ui/src/lib/bits/popover/popover.svelte.ts
@@ -151,7 +151,7 @@ export class PopoverContentState {
 		if (!isElement(e.target)) return;
 
 		const closestTrigger = e.target.closest(popoverAttrs.selector("trigger"));
-		if (closestTrigger === this.root.triggerNode) return;
+		if (closestTrigger && closestTrigger === this.root.triggerNode) return;
 		this.root.handleClose();
 	};
 

--- a/packages/bits-ui/src/lib/bits/popover/popover.svelte.ts
+++ b/packages/bits-ui/src/lib/bits/popover/popover.svelte.ts
@@ -17,6 +17,7 @@ import type {
 } from "$lib/internal/types.js";
 import { isElement } from "$lib/internal/is.js";
 import { OpenChangeComplete } from "$lib/internal/open-change-complete.js";
+import type { Measurable } from "$lib/internal/floating-svelte/types.js";
 
 const popoverAttrs = createBitsAttrs({
 	component: "popover",
@@ -128,6 +129,7 @@ interface PopoverContentStateOpts
 			onInteractOutside: (e: PointerEvent) => void;
 			onEscapeKeydown: (e: KeyboardEvent) => void;
 			onCloseAutoFocus: (e: Event) => void;
+			customAnchor: string | HTMLElement | null | Measurable;
 		}> {}
 
 export class PopoverContentState {
@@ -152,6 +154,14 @@ export class PopoverContentState {
 
 		const closestTrigger = e.target.closest(popoverAttrs.selector("trigger"));
 		if (closestTrigger && closestTrigger === this.root.triggerNode) return;
+		if (this.opts.customAnchor.current) {
+			if (isElement(this.opts.customAnchor.current)) {
+				if (this.opts.customAnchor.current.contains(e.target)) return;
+			} else if (typeof this.opts.customAnchor.current === "string") {
+				const el = document.querySelector(this.opts.customAnchor.current);
+				if (el && el.contains(e.target)) return;
+			}
+		}
 		this.root.handleClose();
 	};
 


### PR DESCRIPTION
This pull request addresses a bug in the `Popover` component to ensure proper handling of outside interactions when using a `customAnchor`.

* Updated the `PopoverContentState` class to add a null check for `closestTrigger` before comparing it with `this.root.triggerNode`, ensuring proper behavior when interacting outside the popover.