### PR TITLE
fix(LinkPreview): ensure grace area exists when `forceMount=true`

### DIFF
--- a/.changeset/poor-comics-help.md
+++ b/.changeset/poor-comics-help.md
@@ -1,0 +1,5 @@
+---
+"bits-ui": patch
+---
+
+fix(LinkPreview): ensure grace area exists when `forceMount=true`

--- a/packages/bits-ui/src/lib/bits/link-preview/components/link-preview-content-static.svelte
+++ b/packages/bits-ui/src/lib/bits/link-preview/components/link-preview-content-static.svelte
@@ -6,6 +6,7 @@
 	import PopperLayer from "$lib/bits/utilities/popper-layer/popper-layer.svelte";
 	import { getFloatingContentCSSVars } from "$lib/internal/floating-svelte/floating-utils.svelte.js";
 	import PopperLayerForceMount from "$lib/bits/utilities/popper-layer/popper-layer-force-mount.svelte";
+	import Mounted from "$lib/bits/utilities/mounted.svelte";
 	import { noop } from "$lib/internal/noop.js";
 
 	const uid = $props.id();
@@ -58,6 +59,7 @@
 					{@render children?.()}
 				</div>
 			{/if}
+			<Mounted bind:mounted={contentState.root.contentMounted} />
 		{/snippet}
 	</PopperLayerForceMount>
 {:else if !forceMount}

--- a/packages/bits-ui/src/lib/bits/link-preview/components/link-preview-content.svelte
+++ b/packages/bits-ui/src/lib/bits/link-preview/components/link-preview-content.svelte
@@ -79,6 +79,7 @@
 					</div>
 				</div>
 			{/if}
+			<Mounted bind:mounted={contentState.root.contentMounted} />
 		{/snippet}
 	</PopperLayerForceMount>
 {:else if !forceMount}


### PR DESCRIPTION
Closes #1697 