### PR TITLE
fix: handle race conditions in scroll lock / restore

### DIFF
--- a/.changeset/calm-peas-glow.md
+++ b/.changeset/calm-peas-glow.md
@@ -1,0 +1,5 @@
+---
+"bits-ui": patch
+---
+
+fix: handle race conditions in scroll lock / restore


### PR DESCRIPTION
Closes #1639 

This pull request addresses a race condition in the scroll lock and restore logic. The core improvement is a more robust mechanism for handling the timing of scroll lock cleanup, ensuring that the body style is not reset prematurely when multiple scroll locks are created or destroyed in quick succession. 

**Scroll Lock Race Condition Fixes:**

* Introduced a scheduling system (`scheduleCleanupIfNoNewLocks`) to delay and coordinate cleanup of scroll lock, preventing the body style from being reset if a new lock is added immediately after one is removed. This addresses issues where overlays/menus could break due to premature cleanup. 
* Added logic to cancel any pending cleanup when a new lock is created, ensuring that only the most recent cleanup is executed.
* Ensured initial body styles are captured only once per locking session, preventing style loss during rapid lock/unlock cycles.