### PR TITLE
docs: Fix menu data attributes in API Reference

### DIFF
--- a/docs/src/lib/content/api-reference/context-menu.api.ts
+++ b/docs/src/lib/content/api-reference/context-menu.api.ts
@@ -34,7 +34,7 @@ import {
 } from "./shared.js";
 import { menu } from "./menu.api.js";
 import { omit } from "$lib/utils/omit.js";
-import { defineBooleanProp, defineComponentApiSchema } from "../utils.js";
+import { defineBooleanProp, defineComponentApiSchema, defineSimpleDataAttr } from "../utils.js";
 
 export const root = defineComponentApiSchema<ContextMenuRootPropsWithoutHTML>({
 	title: "Root",
@@ -45,11 +45,17 @@ export const root = defineComponentApiSchema<ContextMenuRootPropsWithoutHTML>({
 export const trigger = defineComponentApiSchema<ContextMenuTriggerPropsWithoutHTML>({
 	title: "Trigger",
 	description: "The element which when right-clicked, opens the context menu.",
-	...menu.trigger,
 	props: {
 		...menu.trigger.props,
 		ref: refProp({ elType: "HTMLDivElement" }),
 	},
+	dataAttributes: [
+		...menu.trigger.dataAttributes,
+		defineSimpleDataAttr({
+			name: "context-menu-trigger",
+			description: "Present on the trigger element.",
+		}),
+	],
 });
 
 const portal = defineComponentApiSchema<ContextMenuPortalPropsWithoutHTML>({
@@ -77,7 +83,13 @@ export const content = defineComponentApiSchema<ContextMenuContentPropsWithoutHT
 		}),
 		...withChildProps({ elType: "HTMLDivElement", child: floatingContentChildDefinition }),
 	},
-	dataAttributes: menu.content.dataAttributes,
+	dataAttributes: [
+		...menu.content.dataAttributes,
+		defineSimpleDataAttr({
+			name: "context-menu-content",
+			description: "Present on the content element.",
+		}),
+	],
 	cssVars: floatingContentCSSVars("context-menu"),
 });
 
@@ -99,43 +111,89 @@ export const contentStatic = defineComponentApiSchema<ContextMenuContentStaticPr
 		}),
 		...withChildProps({ elType: "HTMLDivElement" }),
 	},
-	dataAttributes: menu.content.dataAttributes,
+	dataAttributes: [
+		...menu.content.dataAttributes,
+		defineSimpleDataAttr({
+			name: "context-menu-content",
+			description: "Present on the content element.",
+		}),
+	],
 });
 
 export const item = defineComponentApiSchema<ContextMenuItemPropsWithoutHTML>({
 	title: "Item",
 	description: "A menu item within the context menu.",
 	...menu.item,
+	dataAttributes: [
+		...menu.item.dataAttributes,
+		defineSimpleDataAttr({
+			name: "context-menu-item",
+			description: "Present on the item element.",
+		}),
+	],
 });
 
 export const separator = defineComponentApiSchema<ContextMenuSeparatorPropsWithoutHTML>({
 	title: "Separator",
 	description: "A horizontal line to visually separate menu items.",
 	...menu.separator,
+	dataAttributes: [
+		...menu.separator.dataAttributes,
+		defineSimpleDataAttr({
+			name: "context-menu-separator",
+			description: "Present on the separator element.",
+		}),
+	],
 });
 
 export const arrow = defineComponentApiSchema<ContextMenuArrowPropsWithoutHTML>({
 	title: "Arrow",
 	description: "An optional arrow which points to the context menu's anchor/trigger point.",
 	...menu.arrow,
+	dataAttributes: [
+		...menu.arrow.dataAttributes,
+		defineSimpleDataAttr({
+			name: "context-menu-arrow",
+			description: "Present on the arrow element.",
+		}),
+	],
 });
 
 export const checkboxItem = defineComponentApiSchema<ContextMenuCheckboxItemPropsWithoutHTML>({
 	title: "CheckboxItem",
 	description: "A menu item that can be controlled and toggled like a checkbox.",
 	...menu.checkboxItem,
+	dataAttributes: [
+		...menu.checkboxItem.dataAttributes,
+		defineSimpleDataAttr({
+			name: "context-menu-checkbox-item",
+			description: "Present on the checkbox item element.",
+		}),
+	],
 });
 
 export const checkboxGroup = defineComponentApiSchema<ContextMenuCheckboxGroupPropsWithoutHTML>({
 	title: "CheckboxGroup",
 	description: "A group of checkbox menu items, where multiple can be checked at a time.",
 	...menu.checkboxGroup,
+	dataAttributes: [
+		defineSimpleDataAttr({
+			name: "context-menu-checkbox-group",
+			description: "Present on the checkbox group element.",
+		}),
+	],
 });
 
 export const radioGroup = defineComponentApiSchema<ContextMenuRadioGroupPropsWithoutHTML>({
 	title: "RadioGroup",
 	description: "A group of radio menu items, where only one can be checked at a time.",
 	...menu.radioGroup,
+	dataAttributes: [
+		defineSimpleDataAttr({
+			name: "context-menu-radio-group",
+			description: "Present on the radio group element.",
+		}),
+	],
 });
 
 export const radioItem = defineComponentApiSchema<ContextMenuRadioItemPropsWithoutHTML>({
@@ -143,6 +201,13 @@ export const radioItem = defineComponentApiSchema<ContextMenuRadioItemPropsWitho
 	description:
 		"A menu item that can be controlled and toggled like a radio button. It must be a child of a `RadioGroup`.",
 	...menu.radioItem,
+	dataAttributes: [
+		...menu.radioItem.dataAttributes,
+		defineSimpleDataAttr({
+			name: "context-menu-radio-item",
+			description: "Present on the radio item element.",
+		}),
+	],
 });
 
 export const sub = defineComponentApiSchema<ContextMenuSubPropsWithoutHTML>({
@@ -156,12 +221,26 @@ export const subTrigger = defineComponentApiSchema<ContextMenuSubTriggerPropsWit
 	title: "SubTrigger",
 	description: "A menu item which when pressed or hovered, opens the submenu it is a child of.",
 	...menu.subTrigger,
+	dataAttributes: [
+		...menu.subTrigger.dataAttributes,
+		defineSimpleDataAttr({
+			name: "context-menu-sub-trigger",
+			description: "Present on the submenu trigger element.",
+		}),
+	],
 });
 
 export const subContent = defineComponentApiSchema<ContextMenuSubContentPropsWithoutHTML>({
 	title: "SubContent",
 	description: "The submenu content displayed when the parent submenu is open.",
 	...menu.subContent,
+	dataAttributes: [
+		...menu.subContent.dataAttributes,
+		defineSimpleDataAttr({
+			name: "context-menu-sub-content",
+			description: "Present on the submenu content element.",
+		}),
+	],
 });
 
 export const subContentStatic =
@@ -170,6 +249,13 @@ export const subContentStatic =
 		description:
 			"The submenu content displayed when the parent submenu menu is open. (Static/No Floating UI)",
 		...menu.subContentStatic,
+		dataAttributes: [
+			...menu.subContent.dataAttributes,
+			defineSimpleDataAttr({
+				name: "context-menu-sub-content",
+				description: "Present on the submenu content element.",
+			}),
+		],
 	});
 
 export const group = defineComponentApiSchema<ContextMenuGroupPropsWithoutHTML>({
@@ -177,6 +263,12 @@ export const group = defineComponentApiSchema<ContextMenuGroupPropsWithoutHTML>(
 	description:
 		"A group of menu items. It should be passed an `aria-label` or have a child `ContextMenu.GroupHeading` component to provide a label for a group of menu items.",
 	...menu.group,
+	dataAttributes: [
+		defineSimpleDataAttr({
+			name: "context-menu-group",
+			description: "Present on the group element.",
+		}),
+	],
 });
 
 export const groupHeading = defineComponentApiSchema<ContextMenuGroupHeadingPropsWithoutHTML>({
@@ -184,6 +276,12 @@ export const groupHeading = defineComponentApiSchema<ContextMenuGroupHeadingProp
 	description:
 		"A heading for a group which will be skipped when navigating with the keyboard. It is used to provide a visual label for a group of menu items and must be a child of either a `ContextMenu.Group` or `ContextMenu.RadioGroup` component.",
 	...menu.label,
+	dataAttributes: [
+		defineSimpleDataAttr({
+			name: "menu-group-heading",
+			description: "Present on the group heading element.",
+		}),
+	],
 });
 
 export const contextMenu = [

--- a/docs/src/lib/content/api-reference/dropdown-menu.api.ts
+++ b/docs/src/lib/content/api-reference/dropdown-menu.api.ts
@@ -19,7 +19,7 @@ import type {
 	DropdownMenuTriggerPropsWithoutHTML,
 } from "bits-ui";
 import { menu } from "./menu.api.js";
-import { defineComponentApiSchema } from "../utils.js";
+import { defineComponentApiSchema, defineSimpleDataAttr } from "../utils.js";
 import { floatingContentCSSVars } from "./shared.js";
 
 export const root = defineComponentApiSchema<DropdownMenuRootPropsWithoutHTML>({
@@ -32,6 +32,13 @@ export const trigger = defineComponentApiSchema<DropdownMenuTriggerPropsWithoutH
 	title: "Trigger",
 	description: "The button element which toggles the dropdown menu.",
 	...menu.trigger,
+	dataAttributes: [
+		...menu.trigger.dataAttributes,
+		defineSimpleDataAttr({
+			name: "dropdown-menu-trigger",
+			description: "Present on the trigger element.",
+		}),
+	],
 });
 
 const portal = defineComponentApiSchema<DropdownMenuPortalPropsWithoutHTML>({
@@ -46,48 +53,102 @@ export const content = defineComponentApiSchema<DropdownMenuContentPropsWithoutH
 	description: "The content displayed when the dropdown menu is open.",
 	...menu.content,
 	cssVars: floatingContentCSSVars("dropdown-menu"),
+	dataAttributes: [
+		...menu.content.dataAttributes,
+		defineSimpleDataAttr({
+			name: "dropdown-menu-content",
+			description: "Present on the content element.",
+		}),
+	],
 });
 
 export const contentStatic = defineComponentApiSchema<DropdownMenuContentStaticPropsWithoutHTML>({
 	title: "ContentStatic",
 	description: "The content displayed when the dropdown menu is open. (Static/No Floating UI)",
 	...menu.contentStatic,
+	dataAttributes: [
+		...menu.content.dataAttributes,
+		defineSimpleDataAttr({
+			name: "dropdown-menu-content",
+			description: "Present on the content element.",
+		}),
+	],
 });
 
 export const item = defineComponentApiSchema<DropdownMenuItemPropsWithoutHTML>({
 	title: "Item",
 	description: "A menu item within the dropdown menu.",
 	...menu.item,
+	dataAttributes: [
+		...menu.item.dataAttributes,
+		defineSimpleDataAttr({
+			name: "dropdown-menu-item",
+			description: "Present on the item element.",
+		}),
+	],
 });
 
 export const separator = defineComponentApiSchema<DropdownMenuSeparatorPropsWithoutHTML>({
 	title: "Separator",
 	description: "A horizontal line to visually separate menu items.",
 	...menu.separator,
+	dataAttributes: [
+		...menu.separator.dataAttributes,
+		defineSimpleDataAttr({
+			name: "dropdown-menu-separator",
+			description: "Present on the separator element.",
+		}),
+	],
 });
 
 export const arrow = defineComponentApiSchema<DropdownMenuArrowPropsWithoutHTML>({
 	title: "Arrow",
 	description: "An optional arrow which points to the dropdown menu's anchor/trigger point.",
 	...menu.arrow,
+	dataAttributes: [
+		...menu.arrow.dataAttributes,
+		defineSimpleDataAttr({
+			name: "dropdown-menu-arrow",
+			description: "Present on the arrow element.",
+		}),
+	],
 });
 
 export const checkboxGroup = defineComponentApiSchema<DropdownMenuCheckboxGroupPropsWithoutHTML>({
 	title: "CheckboxGroup",
 	description: "A group of checkbox menu items, where multiple can be checked at a time.",
 	...menu.checkboxGroup,
+	dataAttributes: [
+		defineSimpleDataAttr({
+			name: "dropdown-menu-checkbox-group",
+			description: "Present on the checkbox group element.",
+		}),
+	],
 });
 
 export const checkboxItem = defineComponentApiSchema<DropdownMenuCheckboxItemPropsWithoutHTML>({
 	title: "CheckboxItem",
 	description: "A menu item that can be controlled and toggled like a checkbox.",
 	...menu.checkboxItem,
+	dataAttributes: [
+		...menu.checkboxItem.dataAttributes,
+		defineSimpleDataAttr({
+			name: "dropdown-menu-checkbox-item",
+			description: "Present on the checkbox item element.",
+		}),
+	],
 });
 
 export const radioGroup = defineComponentApiSchema<DropdownMenuRadioGroupPropsWithoutHTML>({
 	title: "RadioGroup",
 	description: "A group of radio menu items, where only one can be checked at a time.",
 	...menu.radioGroup,
+	dataAttributes: [
+		defineSimpleDataAttr({
+			name: "dropdown-menu-radio-group",
+			description: "Present on the radio group element.",
+		}),
+	],
 });
 
 export const radioItem = defineComponentApiSchema<DropdownMenuRadioItemPropsWithoutHTML>({
@@ -95,6 +156,13 @@ export const radioItem = defineComponentApiSchema<DropdownMenuRadioItemPropsWith
 	description:
 		"A menu item that can be controlled and toggled like a radio button. It must be a child of a `RadioGroup`.",
 	...menu.radioItem,
+	dataAttributes: [
+		...menu.radioItem.dataAttributes,
+		defineSimpleDataAttr({
+			name: "dropdown-menu-radio-item",
+			description: "Present on the radio item element.",
+		}),
+	],
 });
 
 export const sub = defineComponentApiSchema<DropdownMenuSubPropsWithoutHTML>({
@@ -108,12 +176,26 @@ export const subTrigger = defineComponentApiSchema<DropdownMenuSubTriggerPropsWi
 	title: "SubTrigger",
 	description: "A menu item which when pressed or hovered, opens the submenu it is a child of.",
 	...menu.subTrigger,
+	dataAttributes: [
+		...menu.subTrigger.dataAttributes,
+		defineSimpleDataAttr({
+			name: "dropdown-menu-sub-trigger",
+			description: "Present on the submenu trigger element.",
+		}),
+	],
 });
 
 export const subContent = defineComponentApiSchema<DropdownMenuSubContentPropsWithoutHTML>({
 	title: "SubContent",
 	description: "The submenu content displayed when the parent submenu is open.",
 	...menu.subContent,
+	dataAttributes: [
+		...menu.subContent.dataAttributes,
+		defineSimpleDataAttr({
+			name: "dropdown-menu-sub-content",
+			description: "Present on the submenu content element.",
+		}),
+	],
 });
 
 export const subContentStatic =
@@ -122,6 +204,13 @@ export const subContentStatic =
 		description:
 			"The submenu content displayed when the parent submenu menu is open. (Static/No Floating UI)",
 		...menu.subContentStatic,
+		dataAttributes: [
+			...menu.subContentStatic.dataAttributes,
+			defineSimpleDataAttr({
+				name: "dropdown-menu-sub-content",
+				description: "Present on the submenu content element.",
+			}),
+		],
 	});
 
 export const group = defineComponentApiSchema<DropdownMenuGroupPropsWithoutHTML>({
@@ -129,6 +218,12 @@ export const group = defineComponentApiSchema<DropdownMenuGroupPropsWithoutHTML>
 	description:
 		"A group of menu items. It should be passed an `aria-label` or have a child `DropdownMenu.GroupHeading` component to provide a label for a group of menu items.",
 	...menu.group,
+	dataAttributes: [
+		defineSimpleDataAttr({
+			name: "dropdown-menu-group",
+			description: "Present on the group element.",
+		}),
+	],
 });
 
 export const groupHeading = defineComponentApiSchema<DropdownMenuGroupHeadingPropsWithoutHTML>({
@@ -136,6 +231,12 @@ export const groupHeading = defineComponentApiSchema<DropdownMenuGroupHeadingPro
 	description:
 		"A heading for a group which will be skipped when navigating with the keyboard. It is used to provide a description for a group of menu items and must be a child of either a `DropdownMenu.Group` or `DropdownMenu.RadioGroup` component.",
 	...menu.label,
+	dataAttributes: [
+		defineSimpleDataAttr({
+			name: "dropdown-menu-group-heading",
+			description: "Present on the group heading element.",
+		}),
+	],
 });
 
 export const dropdownMenu = [

--- a/docs/src/lib/content/api-reference/menu.api.ts
+++ b/docs/src/lib/content/api-reference/menu.api.ts
@@ -275,27 +275,15 @@ const STATE = defineEnumDataAttr({
 type DataAttrs = ComponentAPISchema["dataAttributes"];
 
 const triggerAttrs: DataAttrs = [
-	STATE,
-	defineSimpleDataAttr({
-		name: "menu-trigger",
-		description: "Present on the trigger element.",
-	}),
+	STATE
 ];
 
 const contentAttrs: DataAttrs = [
-	STATE,
-	defineSimpleDataAttr({
-		name: "menu-content",
-		description: "Present on the content element.",
-	}),
+	STATE
 ];
 
 const arrowAttrs: DataAttrs = [
-	STATE,
-	defineSimpleDataAttr({
-		name: "menu-arrow",
-		description: "Present on the arrow element.",
-	}),
+	STATE
 ];
 
 const sharedItemAttrs: DataAttrs = [
@@ -315,32 +303,7 @@ const sharedItemAttrs: DataAttrs = [
 ];
 
 const itemAttrs: DataAttrs = [
-	...sharedItemAttrs,
-	defineSimpleDataAttr({
-		name: "menu-item",
-		description: "Present on the item element.",
-	}),
-];
-
-const groupAttrs: DataAttrs = [
-	defineSimpleDataAttr({
-		name: "menu-group",
-		description: "Present on the group element.",
-	}),
-];
-
-const labelAttrs: DataAttrs = [
-	defineSimpleDataAttr({
-		name: "menu-group-heading",
-		description: "Present on the group heading element.",
-	}),
-];
-
-const checkboxGroupAttrs: DataAttrs = [
-	defineSimpleDataAttr({
-		name: "menu-checkbox-group",
-		description: "Present on the checkbox group element.",
-	}),
+	...sharedItemAttrs
 ];
 
 const checkboxItemAttrs: DataAttrs = [
@@ -350,13 +313,6 @@ const checkboxItemAttrs: DataAttrs = [
 		value: MenuCheckedStateAttr,
 		options: ["checked", "unchecked", "indeterminate"],
 		description: "The checkbox menu item's checked state.",
-	}),
-];
-
-const radioGroupAttrs: DataAttrs = [
-	defineSimpleDataAttr({
-		name: "menu-radio-group",
-		description: "Present on the radio group element.",
 	}),
 ];
 
@@ -371,10 +327,6 @@ const radioItemAttrs: DataAttrs = [
 	defineSimpleDataAttr({
 		name: "value",
 		description: "The value of the radio item.",
-	}),
-	defineSimpleDataAttr({
-		name: "menu-radio-item",
-		description: "Present on the radio item element.",
 	}),
 ];
 
@@ -391,20 +343,12 @@ const separatorAttrs: DataAttrs = [
 ];
 
 const subContentAttrs: DataAttrs = [
-	STATE,
-	defineSimpleDataAttr({
-		name: "menu-sub-content",
-		description: "Present on the submenu content element.",
-	}),
+	STATE
 ];
 
 const subTriggerAttrs: DataAttrs = [
 	...sharedItemAttrs,
-	STATE,
-	defineSimpleDataAttr({
-		name: "menu-sub-trigger",
-		description: "Present on the submenu trigger element.",
-	}),
+	STATE
 ];
 
 export const trigger = {
@@ -434,12 +378,10 @@ export const item = {
 
 export const group = {
 	props: groupProps,
-	dataAttributes: groupAttrs,
 };
 
 export const label = {
 	props: groupHeadingProps,
-	dataAttributes: labelAttrs,
 };
 
 export const separator = {
@@ -454,7 +396,6 @@ export const checkboxItem = {
 
 export const radioGroup = {
 	props: radioGroupProps,
-	dataAttributes: radioGroupAttrs,
 };
 
 export const radioItem = {
@@ -491,7 +432,6 @@ const portal = {
 
 const checkboxGroup = {
 	props: checkboxGroupProps,
-	dataAttributes: checkboxGroupAttrs,
 };
 
 export const menu = {

--- a/docs/src/lib/content/api-reference/menu.api.ts
+++ b/docs/src/lib/content/api-reference/menu.api.ts
@@ -274,17 +274,11 @@ const STATE = defineEnumDataAttr({
 
 type DataAttrs = ComponentAPISchema["dataAttributes"];
 
-const triggerAttrs: DataAttrs = [
-	STATE
-];
+const triggerAttrs: DataAttrs = [STATE];
 
-const contentAttrs: DataAttrs = [
-	STATE
-];
+const contentAttrs: DataAttrs = [STATE];
 
-const arrowAttrs: DataAttrs = [
-	STATE
-];
+const arrowAttrs: DataAttrs = [STATE];
 
 const sharedItemAttrs: DataAttrs = [
 	defineSimpleDataAttr({
@@ -302,9 +296,7 @@ const sharedItemAttrs: DataAttrs = [
 	}),
 ];
 
-const itemAttrs: DataAttrs = [
-	...sharedItemAttrs
-];
+const itemAttrs: DataAttrs = [...sharedItemAttrs];
 
 const checkboxItemAttrs: DataAttrs = [
 	...sharedItemAttrs,
@@ -342,14 +334,9 @@ const separatorAttrs: DataAttrs = [
 	}),
 ];
 
-const subContentAttrs: DataAttrs = [
-	STATE
-];
+const subContentAttrs: DataAttrs = [STATE];
 
-const subTriggerAttrs: DataAttrs = [
-	...sharedItemAttrs,
-	STATE
-];
+const subTriggerAttrs: DataAttrs = [...sharedItemAttrs, STATE];
 
 export const trigger = {
 	props: triggerProps,

--- a/docs/src/lib/content/api-reference/menubar.api.ts
+++ b/docs/src/lib/content/api-reference/menubar.api.ts
@@ -33,6 +33,7 @@ import {
 	defineComponentApiSchema,
 	defineFunctionProp,
 	defineStringProp,
+	defineSimpleDataAttr,
 } from "../utils.js";
 
 export const root = defineComponentApiSchema<MenubarRootPropsWithoutHTML>({
@@ -76,6 +77,13 @@ export const trigger = defineComponentApiSchema<MenubarTriggerPropsWithoutHTML>(
 	title: "Trigger",
 	description: "The button element which toggles the dropdown menu.",
 	...m.trigger,
+	dataAttributes: [
+		...m.trigger.dataAttributes,
+		defineSimpleDataAttr({
+			name: "menubar-trigger",
+			description: "Present on the trigger element.",
+		}),
+	],
 });
 
 const portal = defineComponentApiSchema<MenubarPortalPropsWithoutHTML>({
@@ -90,48 +98,102 @@ export const content = defineComponentApiSchema<MenubarContentPropsWithoutHTML>(
 	description: "The content displayed when the dropdown menu is open.",
 	...m.content,
 	cssVars: floatingContentCSSVars("menubar-menu"),
+	dataAttributes: [
+		...m.content.dataAttributes,
+		defineSimpleDataAttr({
+			name: "menubar-content",
+			description: "Present on the content element.",
+		}),
+	],
 });
 
 export const contentStatic = defineComponentApiSchema<MenubarContentStaticPropsWithoutHTML>({
 	title: "ContentStatic",
 	description: "The content displayed when the dropdown menu is open. (Static/No Floating UI)",
 	...m.contentStatic,
+	dataAttributes: [
+		...m.contentStatic.dataAttributes,
+		defineSimpleDataAttr({
+			name: "menubar-content",
+			description: "Present on the content element.",
+		}),
+	],
 });
 
 export const item = defineComponentApiSchema<MenubarItemPropsWithoutHTML>({
 	title: "Item",
 	description: "A menu item within the dropdown menu.",
 	...m.item,
+	dataAttributes: [
+		...m.item.dataAttributes,
+		defineSimpleDataAttr({
+			name: "menubar-item",
+			description: "Present on the item element.",
+		}),
+	],
 });
 
 export const separator = defineComponentApiSchema<MenubarSeparatorPropsWithoutHTML>({
 	title: "Separator",
 	description: "A horizontal line to visually separate menu items.",
 	...m.separator,
+	dataAttributes: [
+		...m.separator.dataAttributes,
+		defineSimpleDataAttr({
+			name: "menubar-separator",
+			description: "Present on the separator element.",
+		}),
+	],
 });
 
 export const arrow = defineComponentApiSchema<MenubarArrowPropsWithoutHTML>({
 	title: "Arrow",
 	description: "An optional arrow which points to the dropdown menu's anchor/trigger point.",
 	...m.arrow,
+	dataAttributes: [
+		...m.arrow.dataAttributes,
+		defineSimpleDataAttr({
+			name: "menubar-arrow",
+			description: "Present on the arrow element.",
+		}),
+	],
 });
 
 export const checkboxItem = defineComponentApiSchema<MenubarCheckboxItemPropsWithoutHTML>({
 	title: "CheckboxItem",
 	description: "A menu item that can be controlled and toggled like a checkbox.",
 	...m.checkboxItem,
+	dataAttributes: [
+		...m.checkboxItem.dataAttributes,
+		defineSimpleDataAttr({
+			name: "menubar-checkbox-item",
+			description: "Present on the checkbox item element.",
+		}),
+	],
 });
 
 export const checkboxGroup = defineComponentApiSchema<MenubarCheckboxGroupPropsWithoutHTML>({
 	title: "CheckboxGroup",
 	description: "A group of checkbox menu items, where multiple can be checked at a time.",
 	...m.checkboxGroup,
+	dataAttributes: [
+		defineSimpleDataAttr({
+			name: "menubar-checkbox-group",
+			description: "Present on the checkbox group element.",
+		}),
+	],
 });
 
 export const radioGroup = defineComponentApiSchema<MenubarRadioGroupPropsWithoutHTML>({
 	title: "RadioGroup",
 	description: "A group of radio menu items, where only one can be checked at a time.",
 	...m.radioGroup,
+	dataAttributes: [
+		defineSimpleDataAttr({
+			name: "menubar-radio-group",
+			description: "Present on the radio group element.",
+		}),
+	],
 });
 
 export const radioItem = defineComponentApiSchema<MenubarRadioItemPropsWithoutHTML>({
@@ -139,6 +201,13 @@ export const radioItem = defineComponentApiSchema<MenubarRadioItemPropsWithoutHT
 	description:
 		"A menu item that can be controlled and toggled like a radio button. It must be a child of a `RadioGroup`.",
 	...m.radioItem,
+	dataAttributes: [
+		...m.radioItem.dataAttributes,
+		defineSimpleDataAttr({
+			name: "menubar-radio-item",
+			description: "Present on the radio item element.",
+		}),
+	],
 });
 
 export const sub = defineComponentApiSchema<MenubarSubPropsWithoutHTML>({
@@ -152,12 +221,26 @@ export const subTrigger = defineComponentApiSchema<MenubarSubTriggerPropsWithout
 	title: "SubTrigger",
 	description: "A menu item which when pressed or hovered, opens the submenu it is a child of.",
 	...m.subTrigger,
+	dataAttributes: [
+		...m.subTrigger.dataAttributes,
+		defineSimpleDataAttr({
+			name: "menubar-sub-trigger",
+			description: "Present on the submenu trigger element.",
+		}),
+	],
 });
 
 export const subContent = defineComponentApiSchema<MenubarSubContentPropsWithoutHTML>({
 	title: "SubContent",
 	description: "The submenu content displayed when the parent submenu is open.",
 	...m.subContent,
+	dataAttributes: [
+		...m.subContent.dataAttributes,
+		defineSimpleDataAttr({
+			name: "menubar-sub-content",
+			description: "Present on the submenu content element.",
+		}),
+	],
 });
 
 export const subContentStatic = defineComponentApiSchema<MenubarSubContentStaticPropsWithoutHTML>({
@@ -165,6 +248,13 @@ export const subContentStatic = defineComponentApiSchema<MenubarSubContentStatic
 	description:
 		"The submenu content displayed when the parent submenu menu is open. (Static/No Floating UI)",
 	...m.subContentStatic,
+	dataAttributes: [
+		...m.subContentStatic.dataAttributes,
+		defineSimpleDataAttr({
+			name: "menubar-sub-content",
+			description: "Present on the submenu content element.",
+		}),
+	],
 });
 
 export const group = defineComponentApiSchema<MenubarGroupPropsWithoutHTML>({
@@ -172,6 +262,12 @@ export const group = defineComponentApiSchema<MenubarGroupPropsWithoutHTML>({
 	description:
 		"A group of menu items. It should be passed an `aria-label` or have a child `Menu.GroupHeading` component to provide a label for a group of menu items.",
 	...m.group,
+	dataAttributes: [
+		defineSimpleDataAttr({
+			name: "menubar-group",
+			description: "Present on the group element.",
+		}),
+	],
 });
 
 export const groupHeading = defineComponentApiSchema<MenubarGroupHeadingPropsWithoutHTML>({
@@ -179,6 +275,12 @@ export const groupHeading = defineComponentApiSchema<MenubarGroupHeadingPropsWit
 	description:
 		"A heading for a group which will be skipped when navigating with the keyboard. It is used to provide a heading for a group of menu items and must be a child of either a `Menubar.Group` or `Menubar.RadioGroup` component.",
 	...m.label,
+	dataAttributes: [
+		defineSimpleDataAttr({
+			name: "menubar-group-heading",
+			description: "Present on the group heading element.",
+		}),
+	],
 });
 
 export const menubar = [


### PR DESCRIPTION
fixes #1718 

The API Reference docs for the menubar, context menu, and dropdown menu components were inheriting incorrect data attributes from the parent menu. Removed the definitions from the menu and added the correct attributes to each components reference.