### PR TITLE
docs: Fix demo for `<Accordion type="multiple">`

### DIFF
--- a/docs/content/components/accordion.md
+++ b/docs/content/components/accordion.md
@@ -246,7 +246,7 @@ Set the `type` prop to `"multiple"` to allow multiple accordion items to be open
 />
 ```
 
-<AccordionDemoCustom type="single" />
+<AccordionDemoCustom type="multiple" />
 
 ### Default Open Items
 


### PR DESCRIPTION
This makes the interactive example match the expected behaviour as defined in the docs.

Fix #1732 

For more details, notice how the docs now has one demo with `single` and one with `multiple`: https://github.com/Greenheart/bits-ui/commit/ee5c7e9d0dc4d35deca67ea4c1f86b7012f9a569#diff-3cbdbe31cc723279b7d4860d9ad1009c3b3bfdc33024d251fb61b870d57c788dL225-R249