### PR TITLE
docs: fix reusable component example

### DIFF
--- a/docs/content/components/tooltip.md
+++ b/docs/content/components/tooltip.md
@@ -162,7 +162,7 @@ Below is an example of how you might create a reusable tooltip component that ca
   let {
     open = $bindable(false),
     children,
-    buttonText,
+    trigger,
     triggerProps = {},
     ...restProps
   }: Tooltip.RootProps = $props();
@@ -172,7 +172,7 @@ Below is an example of how you might create a reusable tooltip component that ca
  Ensure you have a `Tooltip.Provider` component wrapping
  your root layout content
 -->
-<Tooltip.Root bind:open {onOpenChange}>
+<Tooltip.Root bind:open {...restProps}>
   <Tooltip.Trigger {...triggerProps}>
     {@render trigger()}
   </Tooltip.Trigger>


### PR DESCRIPTION
This fixes the reusable tooltip example, so it can be copy pasted without error