### PR TITLE
feat(Accordion/Collapsible): `hiddenUntilFound` prop

### DIFF
--- a/.changeset/funny-boats-roll.md
+++ b/.changeset/funny-boats-roll.md
@@ -1,0 +1,5 @@
+---
+"bits-ui": minor
+---
+
+feat(Collapsible): add `hiddenUntilFound` prop to expand collapsible when the content matches a browser search

--- a/.changeset/yellow-eagles-itch.md
+++ b/.changeset/yellow-eagles-itch.md
@@ -1,0 +1,5 @@
+---
+"bits-ui": minor
+---
+
+feat(Accordion): `hiddenUntilFound` to expand on browser search match

--- a/docs/content/components/accordion.md
+++ b/docs/content/components/accordion.md
@@ -270,6 +270,25 @@ Disable specific items with the `disabled` prop:
 </Accordion.Root>
 ```
 
+### Hidden Until Found
+
+The `hiddenUntilFound` prop enables browser search functionality within collapsed accordion content. When enabled, collapsed content is marked with `hidden="until-found"`, allowing browsers to automatically expand accordion items when users search for text within them.
+
+```svelte {4}
+<Accordion.Root type="single">
+  <Accordion.Item value="item-1">
+    <Accordion.Header>
+      <Accordion.Trigger>Search Demo</Accordion.Trigger>
+    </Accordion.Header>
+    <Accordion.Content hiddenUntilFound>
+      This content can be found by browser search (Ctrl+F/CMD+F) even when the
+      accordion is closed. The accordion will automatically open when the
+      browser finds matching text.
+    </Accordion.Content>
+  </Accordion.Item>
+</Accordion.Root>
+```
+
 ### Svelte Transitions
 
 The Accordion component can be enhanced with Svelte's built-in transition effects or other animation libraries.

--- a/docs/content/components/collapsible.md
+++ b/docs/content/components/collapsible.md
@@ -4,7 +4,7 @@ description: Conceals or reveals content sections, enhancing space utilization a
 ---
 
 <script>
-	import { APISection, ComponentPreview, CollapsibleDemo, CollapsibleDemoTransitions, Callout } from '$lib/components/index.js'
+	import { APISection, ComponentPreview, CollapsibleDemo, CollapsibleDemoTransitions, CollapsibleHiddenUntilFoundDemo, Callout } from '$lib/components/index.js'
 	let { schemas } = $props()
 </script>
 
@@ -26,6 +26,7 @@ The Collapsible component enables you to create expandable and collapsible conte
 - **Transition Support**: CSS variables and data attributes for smooth transitions between states.
 - **Flexible State Management**: Supports controlled and uncontrolled state, take control if needed.
 - **Compound Component Structure**: Provides a set of sub-components that work together to create a fully-featured collapsible.
+- **Hidden Until Found**: Support for the `hidden="until-found"` attribute for browser search integration.
 
 ## Architecture
 
@@ -215,6 +216,39 @@ You can then use the `MyCollapsibleContent` component alongside the other `Colla
   <MyCollapsibleContent duration={300}>
     <!-- ... -->
   </MyCollapsibleContent>
+</Collapsible.Root>
+```
+
+## Hidden Until Found
+
+The `hiddenUntilFound` prop enables integration with the browser's find-in-page functionality. When enabled, the collapsible content is marked with `hidden="until-found"`, which allows browsers to automatically expand collapsed content when users search for text within it.
+
+<ComponentPreview variant="collapsed" name="collapsible-hidden-until-found-demo" componentName="Collapsible">
+
+{#snippet preview()}
+<CollapsibleHiddenUntilFoundDemo />
+{/snippet}
+
+</ComponentPreview>
+
+### Basic Usage
+
+```svelte
+<script lang="ts">
+  import { Collapsible } from "bits-ui";
+</script>
+
+<Collapsible.Root>
+  <Collapsible.Trigger>Show More Details</Collapsible.Trigger>
+  <Collapsible.Content hiddenUntilFound={true}>
+    <p>
+      This content will be automatically revealed when users search for text
+      within it using Ctrl+F (Cmd+F on Mac).
+    </p>
+    <p>
+      For example, try searching for "automatically revealed" on this page.
+    </p>
+  </Collapsible.Content>
 </Collapsible.Root>
 ```
 

--- a/docs/src/lib/components/demos/collapsible-demo.svelte
+++ b/docs/src/lib/components/demos/collapsible-demo.svelte
@@ -14,7 +14,10 @@
 		</Collapsible.Trigger>
 	</div>
 
-	<Collapsible.Content class="space-y-2 font-mono text-[15px] tracking-[0.01em]">
+	<Collapsible.Content
+		hiddenUntilFound
+		class="data-[state=open]:animate-collapsible-down data-[state=closed]:animate-collapsible-up space-y-2 overflow-hidden font-mono text-[15px] tracking-[0.01em]"
+	>
 		<div class="rounded-9px bg-muted inline-flex h-12 w-full items-center px-[18px] py-3">
 			@huntabyte/bits-ui
 		</div>

--- a/docs/src/lib/components/demos/collapsible-hidden-until-found-demo.svelte
+++ b/docs/src/lib/components/demos/collapsible-hidden-until-found-demo.svelte
@@ -1,0 +1,44 @@
+<script lang="ts">
+	import { Collapsible } from "bits-ui";
+	import CaretUpDown from "phosphor-svelte/lib/CaretUpDown";
+</script>
+
+<div class="flex w-full max-w-md flex-col gap-4">
+	<div
+		class="border-border bg-background-alt absolute left-4 top-4 flex flex-col gap-2 rounded-xl border p-4"
+	>
+		<div class="text-foreground-alt flex flex-col gap-2 text-sm">
+			<span>Try searching for "searchable content" on this page</span>
+			<code class="bg-muted w-fit rounded px-1 py-0.5 text-xs">(Ctrl+F / Cmd+F)</code>
+		</div>
+	</div>
+
+	<Collapsible.Root class="flex flex-col gap-3">
+		<div class="flex items-center justify-between gap-4">
+			<h4 class="text-[15px] font-medium">FAQ: How does search work?</h4>
+			<Collapsible.Trigger
+				class="rounded-9px border-border-input bg-background-alt text-foreground shadow-btn hover:bg-muted inline-flex h-10 w-10 items-center justify-center border transition-all active:scale-[0.98]"
+				aria-label="Toggle FAQ answer"
+			>
+				<CaretUpDown class="size-4" weight="bold" />
+			</Collapsible.Trigger>
+		</div>
+
+		<Collapsible.Content
+			hiddenUntilFound
+			class="data-[state=open]:animate-collapsible-down data-[state=closed]:animate-collapsible-up overflow-hidden"
+		>
+			<div
+				class="bg-background border-border rounded-lg border p-4 text-[14px] leading-relaxed"
+			>
+				<p class="mb-3">
+					This collapsible contains <strong>searchable content</strong> that demonstrates
+					the
+					<code class="bg-muted rounded px-1 py-0.5 text-xs">hiddenUntilFound</code> feature.
+					When you search for text within this collapsed section, the browser will automatically
+					expand it to show the matching results.
+				</p>
+			</div>
+		</Collapsible.Content>
+	</Collapsible.Root>
+</div>

--- a/docs/src/lib/components/demos/index.ts
+++ b/docs/src/lib/components/demos/index.ts
@@ -16,6 +16,7 @@ export { default as CheckboxDemoCustom } from "./checkbox-demo-custom.svelte";
 export { default as CheckboxDemoGroup } from "./checkbox-demo-group.svelte";
 export { default as CollapsibleDemo } from "./collapsible-demo.svelte";
 export { default as CollapsibleDemoTransitions } from "./collapsible-demo-transitions.svelte";
+export { default as CollapsibleHiddenUntilFoundDemo } from "./collapsible-hidden-until-found-demo.svelte";
 export { default as ComboboxDemo } from "./combobox-demo.svelte";
 export { default as ComboboxDemoAutoScrollDelay } from "./combobox-demo-auto-scroll-delay.svelte";
 export { default as ComboboxDemoTransition } from "./combobox-demo-transition.svelte";

--- a/docs/src/lib/content/api-reference/accordion.api.ts
+++ b/docs/src/lib/content/api-reference/accordion.api.ts
@@ -131,6 +131,11 @@ const content = defineComponentApiSchema<AccordionContentPropsWithoutHTML>({
 	description: "The accordion item content, which is displayed when the item is open.",
 	props: {
 		forceMount: forceMountProp,
+		hiddenUntilFound: defineBooleanProp({
+			description:
+				"Whether the content should use `hidden='until-found'` when closed. This allows browsers to search within collapsed content and automatically expand the accordion item when matches are found.",
+			default: false,
+		}),
 		...withChildProps({
 			elType: "HTMLDivElement",
 			child: {

--- a/docs/src/lib/content/api-reference/collapsible.api.ts
+++ b/docs/src/lib/content/api-reference/collapsible.api.ts
@@ -84,6 +84,11 @@ export const content = defineComponentApiSchema<CollapsibleContentPropsWithoutHT
 	description: "The content displayed when the collapsible is open.",
 	props: {
 		forceMount: forceMountProp,
+		hiddenUntilFound: defineBooleanProp({
+			default: false,
+			description:
+				'When true, the content will be marked with `hidden="until-found"` when collapsed, allowing browsers to find and automatically expand the content during page searches.',
+		}),
 		...withChildProps({
 			elType: "HTMLDivElement",
 			child: {

--- a/docs/src/lib/styles/app.css
+++ b/docs/src/lib/styles/app.css
@@ -132,6 +132,8 @@
 
 	--animate-accordion-down: accordion-down 0.2s ease-out;
 	--animate-accordion-up: accordion-up 0.2s ease-out;
+	--animate-collapsible-down: collapsible-down 0.2s ease-out;
+	--animate-collapsible-up: collapsible-up 0.2s ease-out;
 	--animate-caret-blink: caret-blink 1s ease-out infinite;
 	--animate-scale-in: scale-in 0.2s ease;
 	--animate-scale-out: scale-out 0.15s ease;
@@ -166,6 +168,27 @@
 			height: 0;
 		}
 	}
+
+	@keyframes collapsible-down {
+		from {
+			height: 0;
+		}
+
+		to {
+			height: var(--bits-collapsible-content-height);
+		}
+	}
+
+	@keyframes collapsible-up {
+		from {
+			height: var(--bits-collapsible-content-height);
+		}
+
+		to {
+			height: 0;
+		}
+	}
+
 
 	@keyframes caret-blink {
 

--- a/packages/bits-ui/package.json
+++ b/packages/bits-ui/package.json
@@ -51,7 +51,7 @@
 		"@floating-ui/dom": "^1.7.1",
 		"esm-env": "^1.1.2",
 		"runed": "catalog:",
-		"svelte-toolbelt": "^0.10.2",
+		"svelte-toolbelt": "^0.10.4",
 		"tabbable": "^6.2.0"
 	},
 	"peerDependencies": {

--- a/packages/bits-ui/src/lib/bits/accordion/components/accordion-content.svelte
+++ b/packages/bits-ui/src/lib/bits/accordion/components/accordion-content.svelte
@@ -13,6 +13,7 @@
 		id = createId(uid),
 		forceMount = false,
 		children,
+		hiddenUntilFound = false,
 		...restProps
 	}: AccordionContentProps = $props();
 
@@ -23,14 +24,21 @@
 			() => ref,
 			(v) => (ref = v)
 		),
+		hiddenUntilFound: boxWith(() => hiddenUntilFound),
 	});
 </script>
 
 <PresenceLayer forceMount={true} open={contentState.open} ref={contentState.opts.ref}>
 	{#snippet presence({ present })}
-		{@const mergedProps = mergeProps(restProps, contentState.props, {
-			hidden: forceMount ? undefined : !present,
-		})}
+		{@const mergedProps = mergeProps(
+			restProps,
+			contentState.props,
+			hiddenUntilFound && !present
+				? {}
+				: {
+						hidden: hiddenUntilFound ? !present : forceMount ? undefined : !present,
+					}
+		)}
 		{#if child}
 			{@render child({
 				props: mergedProps,

--- a/packages/bits-ui/src/lib/bits/accordion/types.ts
+++ b/packages/bits-ui/src/lib/bits/accordion/types.ts
@@ -14,7 +14,7 @@ export type BaseAccordionRootPropsWithoutHTML = {
 	/**
 	 * Whether the accordion is disabled or not.
 	 *
-	 * @defaultValue false
+	 * @default false
 	 */
 	disabled?: boolean;
 
@@ -22,14 +22,14 @@ export type BaseAccordionRootPropsWithoutHTML = {
 	 * Whether to loop through the accordion items when navigating
 	 * with the arrow keys.
 	 *
-	 * @defaultValue true
+	 * @default true
 	 */
 	loop?: boolean;
 
 	/**
 	 * The orientation of the accordion.
 	 *
-	 * @defaultValue "vertical"
+	 * @default "vertical"
 	 */
 	orientation?: Orientation;
 };
@@ -48,7 +48,7 @@ export type AccordionRootSinglePropsWithoutHTML = BaseAccordionRootPropsWithoutH
 	 * The value of the currently open accordion item.
 	 *
 	 * @bindable
-	 * @defaultValue ""
+	 * @default ""
 	 */
 	value?: string;
 
@@ -72,7 +72,7 @@ export type AccordionRootMultiplePropsWithoutHTML = BaseAccordionRootPropsWithou
 	 * The value of the currently open accordion item.
 	 *
 	 * @bindable
-	 * @defaultValue []
+	 * @default []
 	 */
 	value?: string[];
 
@@ -113,9 +113,19 @@ export type AccordionContentPropsWithoutHTML = WithChildNoChildrenSnippetProps<
 		 * Whether to forcefully mount the content, regardless of the open state.
 		 * This is useful if you want to use Svelte transitions for the content.
 		 *
-		 * @defaultValue `true`
+		 * @default true
 		 */
 		forceMount?: boolean;
+
+		/**
+		 * Whether to allow the browser to expand the content when searching for content
+		 * within the panel via the browser's built-in search functionality.
+		 *
+		 * When `true`, this prop will override the `forceMount` prop.
+		 *
+		 * @default false
+		 */
+		hiddenUntilFound?: boolean;
 	},
 	AccordionContentSnippetProps
 >;
@@ -133,7 +143,7 @@ export type AccordionItemPropsWithoutHTML = WithChild<{
 	/**
 	 * Whether the accordion item is disabled, which prevents users from interacting with it.
 	 *
-	 * @defaultValue `false`
+	 * @default false
 	 */
 	disabled?: boolean;
 }>;
@@ -145,7 +155,7 @@ export type AccordionHeaderPropsWithoutHTML = WithChild<{
 	 * The level of the accordion header, applied to the element's `aria-level` attribute.
 	 * This is used to indicate the hierarchical relationship between the accordion items.
 	 *
-	 * @defaultValue `3`
+	 * @default `3`
 	 */
 	level?: 1 | 2 | 3 | 4 | 5 | 6;
 }>;

--- a/packages/bits-ui/src/lib/bits/collapsible/components/collapsible-content.svelte
+++ b/packages/bits-ui/src/lib/bits/collapsible/components/collapsible-content.svelte
@@ -11,6 +11,7 @@
 		child,
 		ref = $bindable(null),
 		forceMount = false,
+		hiddenUntilFound = false,
 		children,
 		id = createId(uid),
 		...restProps
@@ -19,6 +20,7 @@
 	const contentState = CollapsibleContentState.create({
 		id: boxWith(() => id),
 		forceMount: boxWith(() => forceMount),
+		hiddenUntilFound: boxWith(() => hiddenUntilFound),
 		ref: boxWith(
 			() => ref,
 			(v) => (ref = v)
@@ -28,9 +30,15 @@
 
 <PresenceLayer forceMount={true} open={contentState.present} ref={contentState.opts.ref}>
 	{#snippet presence({ present })}
-		{@const mergedProps = mergeProps(restProps, contentState.props, {
-			hidden: forceMount ? undefined : !present,
-		})}
+		{@const mergedProps = mergeProps(
+			restProps,
+			contentState.props,
+			hiddenUntilFound && !present
+				? {}
+				: {
+						hidden: hiddenUntilFound ? !present : forceMount ? undefined : !present,
+					}
+		)}
 		{#if child}
 			{@render child({
 				...contentState.snippetProps,

--- a/packages/bits-ui/src/lib/bits/collapsible/types.ts
+++ b/packages/bits-ui/src/lib/bits/collapsible/types.ts
@@ -13,14 +13,14 @@ export type CollapsibleRootPropsWithoutHTML = WithChild<{
 	/**
 	 * Whether the collapsible is disabled.
 	 *
-	 * @defaultValue false
+	 * @default false
 	 */
 	disabled?: boolean;
 
 	/**
 	 * Whether the collapsible is open.
 	 *
-	 * @defaultValue false
+	 * @default false
 	 */
 	open?: boolean;
 
@@ -47,9 +47,19 @@ export type CollapsibleContentPropsWithoutHTML = WithChildNoChildrenSnippetProps
 		/**
 		 * Whether to force mount the content to the DOM.
 		 *
-		 * @defaultValue false
+		 * @default false
 		 */
 		forceMount?: boolean;
+
+		/**
+		 * Whether to allow the browser to expand the content when searching for content
+		 * within the panel via the browser's built-in search functionality.
+		 *
+		 * When `true`, this prop will override the `forceMount` prop.
+		 *
+		 * @default true
+		 */
+		hiddenUntilFound?: boolean;
 	},
 	CollapsibleContentSnippetProps
 >;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -279,8 +279,8 @@ importers:
         specifier: 'catalog:'
         version: 0.31.1(svelte@5.38.1)
       svelte-toolbelt:
-        specifier: ^0.10.2
-        version: 0.10.2(svelte@5.38.1)
+        specifier: ^0.10.4
+        version: 0.10.4(svelte@5.38.1)
       tabbable:
         specifier: ^6.2.0
         version: 6.2.0
@@ -3743,8 +3743,8 @@ packages:
     peerDependencies:
       svelte: ^5.0.0
 
-  svelte-toolbelt@0.10.2:
-    resolution: {integrity: sha512-Tn189QVzouT88hkguEELdsFNFI4s+8zFHa4AKsnYfPsvs7o/WIg9tC0m1AVGiHqa03KdT+Up8IuiyL5dmbphJw==}
+  svelte-toolbelt@0.10.4:
+    resolution: {integrity: sha512-ZAoHSMPY7/ADz5UgjAEgXq6l2jvUdeLQwSQaTtvGalO9qEkVEeWSzXNQ4EPJCRDt6S43FNsJMdJVYHVvupli8Q==}
     engines: {node: '>=18', pnpm: '>=8.7.0'}
     peerDependencies:
       svelte: ^5.30.2
@@ -7870,7 +7870,7 @@ snapshots:
       runed: 0.28.0(svelte@5.38.1)
       svelte: 5.38.1
 
-  svelte-toolbelt@0.10.2(svelte@5.38.1):
+  svelte-toolbelt@0.10.4(svelte@5.38.1):
     dependencies:
       clsx: 2.1.1
       runed: 0.29.1(svelte@5.38.1)

--- a/tests/src/tests/accordion/accordion-hidden-until-found-test.svelte
+++ b/tests/src/tests/accordion/accordion-hidden-until-found-test.svelte
@@ -1,0 +1,52 @@
+<script lang="ts">
+	import { Accordion } from "bits-ui";
+
+	type Item = {
+		value: string;
+		title: string;
+		disabled: boolean;
+		content: string;
+		level: 1 | 2 | 3 | 4 | 5 | 6;
+	};
+
+	let {
+		value = "",
+		hiddenUntilFound = true,
+		items = [],
+		...restProps
+	}: {
+		hiddenUntilFound?: boolean;
+		items: Item[];
+		value?: string;
+		onValueChange?: (v: string) => void;
+	} = $props();
+</script>
+
+<main>
+	<p data-testid="binding">{value}</p>
+	<Accordion.Root data-testid="root" type="single" bind:value {...restProps}>
+		{#each items as { value: itemValue, title, disabled, content, level } (itemValue)}
+			<Accordion.Item value={itemValue} {disabled} data-testid="{itemValue}-item">
+				<Accordion.Header {level} data-testid="{itemValue}-header">
+					<Accordion.Trigger {disabled} data-testid="{itemValue}-trigger">
+						{title}
+					</Accordion.Trigger>
+				</Accordion.Header>
+				<Accordion.Content data-testid="{itemValue}-content" {hiddenUntilFound}>
+					<div data-testid="{itemValue}-searchable-content">
+						{content} This is some searchable content that should be found by the browser's
+						search functionality. Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+						<p data-testid="{itemValue}-nested-content">
+							Nested paragraph with more searchable text.
+						</p>
+					</div>
+				</Accordion.Content>
+			</Accordion.Item>
+		{/each}
+	</Accordion.Root>
+	<button
+		data-testid="alt-trigger"
+		onclick={() => (value = value === items[0]?.value ? "" : (items[0]?.value ?? ""))}
+		>Toggle</button
+	>
+</main>

--- a/tests/src/tests/accordion/accordion-multi-hidden-until-found-test.svelte
+++ b/tests/src/tests/accordion/accordion-multi-hidden-until-found-test.svelte
@@ -1,0 +1,51 @@
+<script lang="ts">
+	import { Accordion } from "bits-ui";
+
+	type Item = {
+		value: string;
+		title: string;
+		disabled: boolean;
+		content: string;
+		level: 1 | 2 | 3 | 4 | 5 | 6;
+	};
+
+	let {
+		value = [],
+		hiddenUntilFound = true,
+		items = [],
+		...restProps
+	}: {
+		hiddenUntilFound?: boolean;
+		items: Item[];
+		value?: string[];
+		onValueChange?: (v: string[]) => void;
+	} = $props();
+</script>
+
+<main>
+	<p data-testid="binding">{JSON.stringify(value)}</p>
+	<Accordion.Root data-testid="root" type="multiple" bind:value {...restProps}>
+		{#each items as { value: itemValue, title, disabled, content, level } (itemValue)}
+			<Accordion.Item value={itemValue} {disabled} data-testid="{itemValue}-item">
+				<Accordion.Header {level} data-testid="{itemValue}-header">
+					<Accordion.Trigger {disabled} data-testid="{itemValue}-trigger">
+						{title}
+					</Accordion.Trigger>
+				</Accordion.Header>
+				<Accordion.Content data-testid="{itemValue}-content" {hiddenUntilFound}>
+					<div data-testid="{itemValue}-searchable-content">
+						{content} This is some searchable content that should be found by the browser's
+						search functionality. Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+						<p data-testid="{itemValue}-nested-content">
+							Nested paragraph with more searchable text.
+						</p>
+					</div>
+				</Accordion.Content>
+			</Accordion.Item>
+		{/each}
+	</Accordion.Root>
+	<button
+		data-testid="alt-trigger"
+		onclick={() => (value = value.length > 0 ? [] : [items[0]?.value ?? ""])}>Toggle</button
+	>
+</main>

--- a/tests/src/tests/collapsible/collapsible-hidden-until-found-test.svelte
+++ b/tests/src/tests/collapsible/collapsible-hidden-until-found-test.svelte
@@ -1,0 +1,26 @@
+<script lang="ts">
+	import { Collapsible } from "bits-ui";
+
+	let {
+		open = false,
+		hiddenUntilFound = true,
+		...restProps
+	}: Omit<Collapsible.RootProps, "asChild" | "child" | "children"> & {
+		hiddenUntilFound?: boolean;
+	} = $props();
+</script>
+
+<main>
+	<p data-testid="binding">{open}</p>
+	<Collapsible.Root data-testid="root" bind:open {...restProps}>
+		<Collapsible.Trigger data-testid="trigger">Trigger</Collapsible.Trigger>
+		<Collapsible.Content data-testid="content" {hiddenUntilFound}>
+			<div data-testid="searchable-content">
+				This is some searchable content that should be found by the browser's search
+				functionality. Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+				<p data-testid="nested-content">Nested paragraph with more searchable text.</p>
+			</div>
+		</Collapsible.Content>
+	</Collapsible.Root>
+	<button data-testid="alt-trigger" onclick={() => (open = !open)}>Toggle</button>
+</main>

--- a/tests/src/tests/collapsible/collapsible.browser.test.ts
+++ b/tests/src/tests/collapsible/collapsible.browser.test.ts
@@ -5,6 +5,7 @@ import type { Component } from "svelte";
 import type { Collapsible } from "bits-ui";
 import CollapsibleTest from "./collapsible-test.svelte";
 import CollapsibleForceMountTest from "./collapsible-force-mount-test.svelte";
+import CollapsibleHiddenUntilFoundTest from "./collapsible-hidden-until-found-test.svelte";
 
 function setup(
 	props: Collapsible.RootProps & { withOpenCheck?: boolean } = {},
@@ -81,6 +82,96 @@ describe("Collapsible ", () => {
 			await t.user.click(t.trigger);
 			const content = t.getByTestId("content");
 			expect(content).toBeVisible();
+		});
+	});
+
+	describe("Hidden Until Found Behavior", () => {
+		function setupHiddenUntilFound(
+			props: Collapsible.RootProps & { hiddenUntilFound?: boolean } = {}
+		) {
+			const user = userEvent;
+			const returned = render(CollapsibleHiddenUntilFoundTest, props);
+			const root = page.getByTestId("root");
+			const trigger = page.getByTestId("trigger");
+			const content = page.getByTestId("content");
+			const searchableContent = page.getByTestId("searchable-content");
+			const nestedContent = page.getByTestId("nested-content");
+			const binding = page.getByTestId("binding");
+			return {
+				...returned,
+				root,
+				trigger,
+				content,
+				searchableContent,
+				nestedContent,
+				binding,
+				user,
+			};
+		}
+
+		it("should render content with hidden='until-found' when closed and hiddenUntilFound is true", async () => {
+			const t = setupHiddenUntilFound({ open: false, hiddenUntilFound: true });
+			expect(t.content).toHaveAttribute("hidden", "until-found");
+			expect(t.binding).toHaveTextContent("false");
+		});
+
+		it("should not have hidden='until-found' when hiddenUntilFound is false", async () => {
+			const t = setupHiddenUntilFound({ open: false, hiddenUntilFound: false });
+			await expect.element(t.content).toHaveAttribute("hidden", "");
+			await expect.element(t.binding).toHaveTextContent("false");
+		});
+
+		it("should open collapsible when beforematch event is triggered", async () => {
+			const t = setupHiddenUntilFound({ open: false, hiddenUntilFound: true });
+			await expect.element(t.binding).toHaveTextContent("false");
+			await expect.element(t.content).toHaveAttribute("hidden", "until-found");
+
+			// simulate the beforematch event that browsers fire when content is found during search
+			const beforeMatchEvent = new Event("beforematch", { bubbles: true });
+			t.content.element().dispatchEvent(beforeMatchEvent);
+
+			await expect.element(t.binding).toHaveTextContent("true");
+		});
+
+		it("should call onOpenChange when beforematch event opens the collapsible", async () => {
+			const mock = vi.fn();
+			const t = setupHiddenUntilFound({
+				open: false,
+				hiddenUntilFound: true,
+				onOpenChange: mock,
+			});
+
+			const beforeMatchEvent = new Event("beforematch", { bubbles: true });
+			t.content.element().dispatchEvent(beforeMatchEvent);
+
+			// wait for state to update
+			await new Promise((resolve) => setTimeout(resolve, 10));
+
+			expect(mock).toHaveBeenCalledWith(true);
+		});
+
+		it("should not trigger open change when already open and beforematch is fired", async () => {
+			const mock = vi.fn();
+			const t = setupHiddenUntilFound({
+				open: true,
+				hiddenUntilFound: true,
+				onOpenChange: mock,
+			});
+
+			const beforeMatchEvent = new Event("beforematch", { bubbles: true });
+			t.content.element().dispatchEvent(beforeMatchEvent);
+
+			await new Promise((resolve) => setTimeout(resolve, 10));
+
+			expect(mock).not.toHaveBeenCalled();
+		});
+
+		it.only("should maintain hidden='until-found' after closing when hiddenUntilFound is true", async () => {
+			const t = setupHiddenUntilFound({ open: false, hiddenUntilFound: true });
+
+			await t.user.click(t.trigger);
+			await t.user.click(t.trigger);
+			await expect.element(t.content).toHaveAttribute("hidden", "until-found");
 		});
 	});
 });


### PR DESCRIPTION
This pull request introduces a new `hiddenUntilFound` prop to both the Accordion and Collapsible components , enabling browser-native search to automatically expand collapsed content when a search match is found. 
