### PR TITLE
Better llms txt

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -29,6 +29,7 @@
 		"@types/jsdom": "^21.1.7",
 		"@types/mdast": "^4.0.4",
 		"@types/node": "catalog:",
+		"@types/unist": "^3.0.3",
 		"bits-ui": "workspace:*",
 		"clsx": "^2.1.1",
 		"consola": "^3.4.2",
@@ -41,6 +42,7 @@
 		"rehype-parse": "^9.0.1",
 		"rehype-pretty-code": "^0.13.2",
 		"rehype-remark": "^10.0.1",
+		"rehype-remove-comments": "^6.1.1",
 		"rehype-slug": "^6.0.0",
 		"remark-gfm": "^4.0.1",
 		"remark-stringify": "^11.0.0",
@@ -59,11 +61,10 @@
 		"unified": "^11.0.5",
 		"unist-builder": "^4.0.0",
 		"unist-util-visit": "^5.0.0",
+		"unist-util-visit-parents": "^6.0.2",
 		"velite": "^0.2.4",
 		"vite": "catalog:",
-		"vite-plugin-devtools-json": "^1.0.0",
-		"rehype-remove-comments": "^6.1.1",
-		"unist-util-visit-parents": "^6.0.2"
+		"vite-plugin-devtools-json": "^1.0.0"
 	},
 	"type": "module"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -164,6 +164,9 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 20.19.11
+      '@types/unist':
+        specifier: ^3.0.3
+        version: 3.0.3
       bits-ui:
         specifier: workspace:*
         version: link:../packages/bits-ui


### PR DESCRIPTION
I've had a look at #1883 and fixed a bunch of formatting issues in the generated llms.txt

```ts
const REGEX_PATTERNS = {
	multipleNewlines: /\n{3,}/g,
	bulletSpacing: /- \n\s+/g,
	multiLineBullets: /(- [^\n]*)(?:\n\s+([^\n-][^\n]*))/g,
	startLineSpaces: /(\n|^)[ \t]+\n/g,
	endLineSpaces: /\n[ \t]+($|\n)/g,
	inlineCodeBefore: /(\S+)\s*\n\s*(`[^`]+?`)/g,
	inlineCodeAfter: /(`[^`]+?`)\s*\n\s*(\S+)/g,
	parenCodeStart: /\(\s*\n\s*(`[^`]+?`)/g,
	parenCodeEnd: /(`[^`]+?`)\s*\n\s*\)/g,
	escapedBackticks: /\\`([^`]+?)\\`/g,
	codeBlockIndent: /```([a-z]*)\n\t/g,
	htmlComments: /<!--.*?-->/gs,
} as const;
```
As expected, overlapping regex leads to multiple issues:

- code blocks collide with other elements:
```
- You can add scoped styles, transitions, actions, etc. directly to the element ## How It Works
```
```
1. 
   An **outer wrapper element** with `{...wrapperProps}` 2. 
   An **inner content element** with `{...props}` ```svelte
```
```
- `Combobox.Content` - `DatePicker.Content` - `DateRangePicker.Content` - `DropdownMenu.Content` - `LinkPreview.Content` - `Menubar.Content` - `Popover.Content` - `Select.Content` - `Tooltip.Content` ## Examples
```

-  Numbered lists get an extra newline:
```
1. 
   The component passes all internal props and your custom props passed to the component via the `props` snippet parameter
2. 
   You decide which element receives these props
```

- Tables get those humonguous -----:
```
| Property                                                                                    | Type                                                                                                                                                                                                                                                              | Description                                                                                                                                                                                                                                     | Details                                                                                                                                                                                        |
| ------------------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| `type` required | `enum`- 'single' \| 'multiple'                                                          | The type of accordion. If set to `'multiple'`, the accordion will allow multiple items to be open at the same time. If set to `single`, the accordion will only allow a single item to be open.`Default:  undefined`           |                                      |
```

This should be a mode reasonable
```
| Property          | Type                                                                  | Description                                                                                                                                                                                                                       | Details |
| ----------------- | --------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
| `type` required   | `enum` - 'single' \| 'multiple'                                       | The type of accordion. If set to `'multiple'`, the accordion will allow multiple items to be open at the same time. If set to `single`, the accordion will only allow a single item to be open.`Default:  —— undefined`           |         |
```

- htmlComments discards comments in the *examples*, not just the html code.


In addition, we are not handling the double html encoding in prop tables, which is an unrelated issue:
```
| `child`                                                   | `Snippet`- type SnippetProps = \&#123; props: Record\&lt;string, unknown\&gt;; \&#125;; | Use render delegation to render your own element. See [Child Snippet](/docs/child-snippet) docs for more information.`Default:  undefined`                                                                                     |  | | Data Attribute                           | 
```
This should be
```
| `child`           | `Snippet` - type SnippetProps = { props: Record\<string, unknown>; }; | Use render delegation to render your own element. See [Child Snippet](/docs/child-snippet) docs for more information.`Default:  —— undefined`                                                                                     |         |
```
(`\< ` is added by remark to avoid opening a tag)

Unrelated issue - the \`code\` was not rendered properly from the frontmatter descrition:
<img width="678" height="144" alt="image" src="https://github.com/user-attachments/assets/26a138e4-26b7-4015-9019-657018579696" />

Fixed, which also fixes it for llms.txt:
<img width="538" height="124" alt="image" src="https://github.com/user-attachments/assets/d83c938e-bf03-477b-9278-495832ba4fc7" />

This PR fixes all the issue. I had a good look at the generated llms.txt, and among a large amount of improvements I don't see any new issues.

Here's a commit I made in a separate branch to compare the before and after: https://github.com/xl0/bits-ui/commit/2f17d256174c76376087a42c64fef1a2001be7f0

Instead of relying on regex, I worked on the remark AST for the few instances that actually required work.

I also took the liberty to get rid of the unicode replacement stuff. LLMs have no problems with unicode tokenization, and we were missing a bunch of uncode characters mainly in examples:
<img width="445" height="226" alt="image" src="https://github.com/user-attachments/assets/c920f99f-281f-446f-b2ad-3de11bd76043" />





