### PR TITLE
fix(docs): use correct tooltip component props type definition

### DIFF
--- a/docs/content/components/tooltip.md
+++ b/docs/content/components/tooltip.md
@@ -165,7 +165,7 @@ Below is an example of how you might create a reusable tooltip component that ca
     trigger,
     triggerProps = {},
     ...restProps
-  }: Tooltip.RootProps = $props();
+  }: Props = $props();
 </script>
 
 <!--


### PR DESCRIPTION
The [current code snippet](https://bits-ui.com/docs/components/tooltip#reusable-components) for the reusable `MyTootlip.svelte` has TypeScript errors when pasted into a real project.

The component prop type is updated in the docs to use the locally defined `Props` type instead of the imported `Tooltip.RootProps`.