### PR TITLE
feat: add subpath exports

### DIFF
--- a/.changeset/fluffy-flowers-visit.md
+++ b/.changeset/fluffy-flowers-visit.md
@@ -1,0 +1,5 @@
+---
+"bits-ui": minor
+---
+
+feat: add subpath exports

--- a/packages/bits-ui/package.json
+++ b/packages/bits-ui/package.json
@@ -20,6 +20,11 @@
 			"types": "./dist/index.d.ts",
 			"svelte": "./dist/index.js",
 			"default": "./dist/index.js"
+		},
+		"./*":{
+  		"types": "./dist/bits/*/index.d.ts",
+  		"svelte": "./dist/bits/*/index.js",
+  		"default": "./dist/bits/*/index.js"
 		}
 	},
 	"files": [


### PR DESCRIPTION
I would really like bits-ui to support subpath exports and I saw that #1522 seems to be abandoned so here I am