### PR TITLE
fix(ContextMenu): Ensure props are applied correctly when force mounted

### DIFF
--- a/.changeset/stale-crabs-rhyme.md
+++ b/.changeset/stale-crabs-rhyme.md
@@ -1,0 +1,5 @@
+---
+"bits-ui": patch
+---
+
+fix(ContextMenu): Ensure props are applied correctly when force mounted

--- a/packages/bits-ui/src/lib/bits/context-menu/components/context-menu-content.svelte
+++ b/packages/bits-ui/src/lib/bits/context-menu/components/context-menu-content.svelte
@@ -39,7 +39,23 @@
 		onCloseAutoFocus: boxWith(() => onCloseAutoFocus),
 	});
 
-	const mergedProps = $derived(mergeProps(restProps, contentState.props));
+	const mergedProps = $derived(
+		mergeProps(restProps, contentState.props, {
+			side,
+			sideOffset,
+			align,
+			onOpenAutoFocus,
+			isValidEvent,
+			trapFocus,
+			loop,
+			id,
+			ref: contentState.opts.ref,
+			preventScroll,
+			onInteractOutside: handleInteractOutside,
+			onEscapeKeydown: handleEscapeKeydown,
+			shouldRender: contentState.shouldRender,
+		})
+	);
 
 	function handleInteractOutside(e: PointerEvent) {
 		onInteractOutside(e);
@@ -76,20 +92,7 @@
 	<PopperLayerForceMount
 		{...mergedProps}
 		{...contentState.popperProps}
-		ref={contentState.opts.ref}
-		{side}
-		{sideOffset}
-		{align}
 		enabled={contentState.parentMenu.opts.open.current}
-		{preventScroll}
-		onInteractOutside={handleInteractOutside}
-		onEscapeKeydown={handleEscapeKeydown}
-		{onOpenAutoFocus}
-		{isValidEvent}
-		{trapFocus}
-		{loop}
-		{id}
-		shouldRender={contentState.shouldRender}
 	>
 		{#snippet popper({ props, wrapperProps })}
 			{@const finalProps = mergeProps(props, {
@@ -110,20 +113,7 @@
 	<PopperLayer
 		{...mergedProps}
 		{...contentState.popperProps}
-		ref={contentState.opts.ref}
-		side="right"
-		sideOffset={2}
-		align="start"
 		open={contentState.parentMenu.opts.open.current}
-		{preventScroll}
-		onInteractOutside={handleInteractOutside}
-		onEscapeKeydown={handleEscapeKeydown}
-		{onOpenAutoFocus}
-		{isValidEvent}
-		{trapFocus}
-		{loop}
-		{id}
-		shouldRender={contentState.shouldRender}
 	>
 		{#snippet popper({ props, wrapperProps })}
 			{@const finalProps = mergeProps(props, {


### PR DESCRIPTION
In #1911 I added these props back but missed that they needed to be added to both the forceMount and non-forceMount versions of the component. This PR aims to both fix that issue and also prevent similar things from happening in the future. 

Now common props are included in the mergeProps call so that they are spread onto both without having to duplicate each prop.