### PR TITLE
fix(Command): prevent scroll blocking when groups are not used

### DIFF
--- a/packages/bits-ui/src/lib/bits/command/command.svelte.ts
+++ b/packages/bits-ui/src/lib/bits/command/command.svelte.ts
@@ -482,9 +482,11 @@ export class CommandRootState {
 					const closestGroupHeader = item
 						?.closest(COMMAND_GROUP_SELECTOR)
 						?.querySelector(COMMAND_GROUP_HEADING_SELECTOR);
-					closestGroupHeader?.scrollIntoView({ block: "nearest" });
 
-					return;
+					if (closestGroupHeader) {
+						closestGroupHeader.scrollIntoView({ block: "nearest" });
+						return;
+					}
 				}
 			}
 


### PR DESCRIPTION
When using Command.Item exclusively (without grouping, etc.), the view fails to scroll to the first element even though the focus successfully shifts to it.
```
<Command.List>
  <Command.Viewport>
    <Command.Item></Command.Item>
    <Command.Item></Command.Item>
    ...
  </Command.Viewport>
</Command.List>
```

https://github.com/user-attachments/assets/39c80f33-97a2-4d67-b8ce-66f7da48449c

