### PR TITLE
fix(ContextMenu): prevent left-click on nested context-menu triggers from dismissing parent layers

### DIFF
--- a/.changeset/calm-worms-change.md
+++ b/.changeset/calm-worms-change.md
@@ -1,0 +1,5 @@
+---
+"bits-ui": patch
+---
+
+fix(ContextMenu): prevent left-click on nested context-menu triggers from dismissing parent layers

--- a/packages/bits-ui/src/lib/bits/utilities/dismissible-layer/use-dismissable-layer.svelte.ts
+++ b/packages/bits-ui/src/lib/bits/utilities/dismissible-layer/use-dismissable-layer.svelte.ts
@@ -254,10 +254,10 @@ function isValidEvent(e: PointerEvent, node: HTMLElement): boolean {
 	if (!isElementOrSVGElement(target)) return false;
 
 	const targetIsContextMenuTrigger = Boolean(target.closest(`[${CONTEXT_MENU_TRIGGER_ATTR}]`));
-	if ("button" in e && e.button > 0 && !targetIsContextMenuTrigger) return false;
-	if ("button" in e && e.button === 0 && targetIsContextMenuTrigger) return true;
-
 	const nodeIsContextMenu = Boolean(node.closest(`[${CONTEXT_MENU_CONTENT_ATTR}]`));
+
+	if ("button" in e && e.button > 0 && !targetIsContextMenuTrigger) return false;
+	if ("button" in e && e.button === 0 && targetIsContextMenuTrigger) return nodeIsContextMenu;
 	if (targetIsContextMenuTrigger && nodeIsContextMenu) return false;
 
 	const ownerDocument = getOwnerDocument(target);

--- a/tests/src/tests/context-menu/context-menu-integration-test.svelte
+++ b/tests/src/tests/context-menu/context-menu-integration-test.svelte
@@ -1,5 +1,5 @@
 <script lang="ts" module>
-	import { ContextMenu, Dialog, DropdownMenu } from "bits-ui";
+	import { ContextMenu, Dialog, DropdownMenu, Popover } from "bits-ui";
 	export type ContextMenuTestProps = ContextMenu.RootProps & {
 		checked?: boolean;
 		subChecked?: boolean;
@@ -56,4 +56,13 @@
 			</Dialog.Content>
 		</Dialog.Portal>
 	</Dialog.Root>
+
+	<Popover.Root>
+		<Popover.Trigger data-testid="popover-trigger">open</Popover.Trigger>
+		<Popover.Portal>
+			<Popover.Content data-testid="popover-content">
+				{@render contextMenu({ id: "4" })}
+			</Popover.Content>
+		</Popover.Portal>
+	</Popover.Root>
 </main>

--- a/tests/src/tests/context-menu/context-menu.browser.test.ts
+++ b/tests/src/tests/context-menu/context-menu.browser.test.ts
@@ -535,6 +535,26 @@ it("should open inside of a dialog", async () => {
 	await expectNotExists(page.getByTestId("context-content-3"));
 });
 
+it("should not close the dialog when the context menu trigger is left clicked", async () => {
+	render(ContextMenuIntegrationTest);
+	await page.getByTestId("dialog-trigger").click();
+	await expectExists(page.getByTestId("dialog-content"));
+	await page.getByTestId("context-trigger-3").click();
+	await new Promise((resolve) => setTimeout(resolve, 50));
+	await expect.element(page.getByTestId("dialog-content")).toHaveAttribute("data-state", "open");
+	await expectNotExists(page.getByTestId("context-content-3"));
+});
+
+it("should not close the popover when the context menu trigger is left clicked", async () => {
+	render(ContextMenuIntegrationTest);
+	await page.getByTestId("popover-trigger").click();
+	await expectExists(page.getByTestId("popover-content"));
+	await page.getByTestId("context-trigger-4").click();
+	await new Promise((resolve) => setTimeout(resolve, 50));
+	await expect.element(page.getByTestId("popover-content")).toHaveAttribute("data-state", "open");
+	await expectNotExists(page.getByTestId("context-content-4"));
+});
+
 it("should open nested context menus", async () => {
 	render(ContextMenuNestedTest);
 	await page.getByTestId("trigger").click({ button: "right" });


### PR DESCRIPTION
Fixes: #1948
