### PR TITLE
feat(Select): Add `<Select.Value/>` component

### DIFF
--- a/.changeset/new-bats-call.md
+++ b/.changeset/new-bats-call.md
@@ -1,0 +1,5 @@
+---
+"bits-ui": minor
+---
+
+feat(Select): Add `<Select.Value/>` component

--- a/docs/content/components/select.md
+++ b/docs/content/components/select.md
@@ -422,7 +422,7 @@ You can use the `child` snippet to customize the rendering of the value in the `
 </Select.Value>
 ```
 
-This allows you to create custom value components that can modify the value as well.
+This allows you to display and modify the value however you want.
 
 <ComponentPreview name="select-demo-custom-value" componentName="Select" variant="preview">
 

--- a/docs/content/components/select.md
+++ b/docs/content/components/select.md
@@ -412,11 +412,19 @@ Of course, this isn't the prettiest syntax, so it's recommended to create your o
 
 ## Customizing Select.Value
 
-You can use the `child` snippet to customize the rendering of the value in the `Select.Value` component.
+You can use the `child` or `children` snippets to customize the rendering of the value in the `Select.Value` component.
 
-```svelte /child/
+```svelte /child/ /children/
 <Select.Value>
-  {#snippet child({ selected, setValue, placeholder })}
+  {#snippet child({ props, selection, placeholder, disabled })}
+    <div {...props}>
+      <!-- ... -->
+    </div>
+    <!-- ... -->
+  {/snippet}
+</Select.Value>
+<Select.Value>
+  {#snippet children({ selection, placeholder, disabled })}
     <!-- ... -->
   {/snippet}
 </Select.Value>

--- a/docs/content/components/select.md
+++ b/docs/content/components/select.md
@@ -414,7 +414,7 @@ Of course, this isn't the prettiest syntax, so it's recommended to create your o
 
 You can use the `child` or `children` snippets to customize the rendering of the value in the `Select.Value` component.
 
-```svelte /child/ /children/
+```svelte
 <Select.Value>
   {#snippet child({ props, selection, placeholder, disabled })}
     <div {...props}>

--- a/docs/content/components/select.md
+++ b/docs/content/components/select.md
@@ -4,7 +4,7 @@ description: Enables users to pick from a list of options displayed in a dropdow
 ---
 
 <script>
-	import { APISection, ComponentPreview, SelectDemo, SelectDemoCustomAnchor, SelectDemoMultiple, SelectDemoTransition, SelectDemoAutoScrollDelay, Callout } from '$lib/components'
+	import { APISection, ComponentPreview, SelectDemo, SelectDemoCustomAnchor, SelectDemoMultiple, SelectDemoTransition, SelectDemoAutoScrollDelay, Callout, SelectDemoCustomValue } from '$lib/components'
 	let { schemas } = $props()
 </script>
 
@@ -57,7 +57,7 @@ Here's an overview of how the Select component is structured in code:
 
 <Select.Root>
   <Select.Trigger>
-    <Select.Value/>
+    <Select.Value />
   </Select.Trigger>
   <Select.Portal>
     <Select.Content>
@@ -406,6 +406,16 @@ Of course, this isn't the prettiest syntax, so it's recommended to create your o
 
 {#snippet preview()}
 <SelectDemoTransition />
+{/snippet}
+
+</ComponentPreview>
+
+## Customizing Select.Value
+
+<ComponentPreview name="select-demo-custom-value" componentName="Select" variant="preview">
+
+{#snippet preview()}
+<SelectDemoCustomValue />
 {/snippet}
 
 </ComponentPreview>

--- a/docs/content/components/select.md
+++ b/docs/content/components/select.md
@@ -56,7 +56,9 @@ Here's an overview of how the Select component is structured in code:
 </script>
 
 <Select.Root>
-  <Select.Trigger />
+  <Select.Trigger>
+    <Select.Value/>
+  </Select.Trigger>
   <Select.Portal>
     <Select.Content>
       <Select.ScrollUpButton />
@@ -99,10 +101,6 @@ Here's an example of how you might create a reusable `MySelect` component that r
     placeholder,
     ...restProps
   }: Props = $props();
-
-  const selectedLabel = $derived(
-    items.find((item) => item.value === value)?.label
-  );
 </script>
 
 <!--
@@ -112,7 +110,7 @@ from the perspective of the consumer of this component, it will be typed appropr
 -->
 <Select.Root bind:value={value as never} {...restProps}>
   <Select.Trigger>
-    {selectedLabel ? selectedLabel : placeholder}
+    <Select.Value {placeholder} />
   </Select.Trigger>
   <Select.Portal>
     <Select.Content {...contentProps}>
@@ -271,7 +269,9 @@ You can opt-out of this behavior by instead using the `Select.ContentStatic` com
 
 ```svelte /Select.ContentStatic/
 <Select.Root>
-  <Select.Trigger />
+  <Select.Trigger>
+    <Select.Value />
+  </Select.Trigger>
   <Select.Portal>
     <Select.ContentStatic>
       <Select.ScrollUpButton />
@@ -306,7 +306,9 @@ If you wish to instead anchor the content to a different element, you can pass e
 <div bind:this={customAnchor}></div>
 
 <Select.Root>
-  <Select.Trigger />
+  <Select.Trigger>
+    <Select.Value />
+  </Select.Trigger>
   <Select.Content {customAnchor}>
     <!-- ... -->
   </Select.Content>

--- a/docs/content/components/select.md
+++ b/docs/content/components/select.md
@@ -412,6 +412,18 @@ Of course, this isn't the prettiest syntax, so it's recommended to create your o
 
 ## Customizing Select.Value
 
+You can use the `child` snippet to customize the rendering of the value in the `Select.Value` component.
+
+```svelte /child/
+<Select.Value>
+  {#snippet child({ selected, setValue, placeholder })}
+    <!-- ... -->
+  {/snippet}
+</Select.Value>
+```
+
+This allows you to create custom value components that can modify the value as well.
+
 <ComponentPreview name="select-demo-custom-value" componentName="Select" variant="preview">
 
 {#snippet preview()}

--- a/docs/content/components/tooltip.md
+++ b/docs/content/components/tooltip.md
@@ -428,23 +428,23 @@ You can use the `forceMount` prop along with the `child` snippet to forcefully m
 
 ```svelte /forceMount/ /transition:fade/ /transition:fly/
 <script lang="ts">
-	import { Tooltip } from "bits-ui";
-	import { fly, fade } from "svelte/transition";
+  import { Tooltip } from "bits-ui";
+  import { fly, fade } from "svelte/transition";
 </script>
 
 <Tooltip.Root>
-	<!-- ... other tooltip components -->
-	<Tooltip.Content forceMount>
-		{#snippet child({ wrapperProps, props, open })}
-			{#if open}
-				<div {...wrapperProps}>
-					<div {...props} transition:fly>
-						<!-- ... -->
-					</div>
-				</div>
-			{/if}
-		{/snippet}
-	</Tooltip.Content>
+  <!-- ... other tooltip components -->
+  <Tooltip.Content forceMount>
+    {#snippet child({ wrapperProps, props, open })}
+      {#if open}
+        <div {...wrapperProps}>
+          <div {...props} transition:fly>
+            <!-- ... -->
+          </div>
+        </div>
+      {/if}
+    {/snippet}
+  </Tooltip.Content>
 </Tooltip.Root>
 ```
 

--- a/docs/src/app.d.ts
+++ b/docs/src/app.d.ts
@@ -13,6 +13,11 @@ declare global {
 		const component: Component;
 		export default component;
 	}
+
+	declare module "*.md?raw" {
+		const content: string;
+		export default content;
+	}
 }
 
 export {};

--- a/docs/src/lib/components/demos/index.ts
+++ b/docs/src/lib/components/demos/index.ts
@@ -43,6 +43,7 @@ export { default as SelectDemo } from "./select-demo.svelte";
 export { default as SelectDemoAutoScrollDelay } from "./select-demo-auto-scroll-delay.svelte";
 export { default as SelectDemoCustom } from "./select-demo-custom.svelte";
 export { default as SelectDemoCustomAnchor } from "./select-demo-custom-anchor.svelte";
+export { default as SelectDemoCustomValue } from "./select-demo-custom-value.svelte";
 export { default as SelectDemoMultiple } from "./select-demo-multiple.svelte";
 export { default as SelectDemoTransition } from "./select-demo-transition.svelte";
 export { default as MenubarDemo } from "./menubar-demo.svelte";

--- a/docs/src/lib/components/demos/select-demo-auto-scroll-delay.svelte
+++ b/docs/src/lib/components/demos/select-demo-auto-scroll-delay.svelte
@@ -39,11 +39,6 @@
 		}
 	}
 
-	let value = $state<string>("");
-	const selectedLabel = $derived(
-		value ? themes.find((theme) => theme.value === value)?.label : "Select a theme"
-	);
-
 	function autoScrollDelay(tick: number) {
 		const maxDelay = 200;
 		const minDelay = 25;
@@ -55,13 +50,13 @@
 	}
 </script>
 
-<Select.Root type="single" onValueChange={(v) => (value = v)} items={themes}>
+<Select.Root type="single" items={themes}>
 	<Select.Trigger
 		class="h-input rounded-9px border-border-input bg-background data-placeholder:text-foreground-alt/50 inline-flex w-[296px] touch-none select-none items-center border px-[11px] text-sm transition-colors"
 		aria-label="Select a theme"
 	>
 		<Palette class="text-muted-foreground mr-[9px] size-6" />
-		{selectedLabel}
+		<Select.Value placeholder="Select a theme" />
 		<CaretUpDown class="text-muted-foreground ml-auto size-6" />
 	</Select.Trigger>
 	<Select.Portal>

--- a/docs/src/lib/components/demos/select-demo-custom-value.svelte
+++ b/docs/src/lib/components/demos/select-demo-custom-value.svelte
@@ -1,0 +1,110 @@
+<script lang="ts">
+	import { Select } from "bits-ui";
+	import Check from "phosphor-svelte/lib/Check";
+	import Palette from "phosphor-svelte/lib/Palette";
+	import CaretUpDown from "phosphor-svelte/lib/CaretUpDown";
+	import CaretDoubleUp from "phosphor-svelte/lib/CaretDoubleUp";
+	import CaretDoubleDown from "phosphor-svelte/lib/CaretDoubleDown";
+	import X from "phosphor-svelte/lib/X";
+
+	const themes = [
+		{ value: "light-monochrome", label: "Light Monochrome" },
+		{ value: "dark-green", label: "Dark Green" },
+		{ value: "svelte-orange", label: "Svelte Orange" },
+		{ value: "punk-pink", label: "Punk Pink" },
+		{ value: "ocean-blue", label: "Ocean Blue", disabled: true },
+		{ value: "sunset-orange", label: "Sunset Orange" },
+		{ value: "sunset-red", label: "Sunset Red" },
+		{ value: "forest-green", label: "Forest Green" },
+		{ value: "lavender-purple", label: "Lavender Purple", disabled: true },
+		{ value: "mustard-yellow", label: "Mustard Yellow" },
+		{ value: "slate-gray", label: "Slate Gray" },
+		{ value: "neon-green", label: "Neon Green" },
+		{ value: "coral-reef", label: "Coral Reef" },
+		{ value: "midnight-blue", label: "Midnight Blue" },
+		{ value: "crimson-red", label: "Crimson Red" },
+		{ value: "mint-green", label: "Mint Green" },
+		{ value: "pastel-pink", label: "Pastel Pink" },
+		{ value: "golden-yellow", label: "Golden Yellow" },
+		{ value: "deep-purple", label: "Deep Purple" },
+		{ value: "turquoise-blue", label: "Turquoise Blue" },
+		{ value: "burnt-orange", label: "Burnt Orange" },
+	];
+</script>
+
+<Select.Root type="multiple" items={themes} allowDeselect={true}>
+	<Select.Trigger
+		class="h-input rounded-9px border-border-input bg-background data-placeholder:text-foreground-alt/50 inline-flex w-[296px] touch-none select-none items-center border px-[11px] text-sm transition-colors"
+		aria-label="Select a theme"
+	>
+		<Palette class="text-muted-foreground mr-[9px] size-6 shrink-0" />
+		<Select.Value placeholder="Select your favorite themes">
+			{#snippet child({ selected, setValue, placeholder })}
+				{@const selectedThemes = selected as { value: string; label: string }[] | undefined}
+				<div class="flex gap-2 overflow-x-auto">
+					{#if selectedThemes}
+						{#each selectedThemes as selectedTheme (selectedTheme.value)}
+							<div
+								class="rounded-button bg-muted flex items-center gap-1 px-2 py-1 text-sm"
+							>
+								<span class="text-nowrap">{selectedTheme.label}</span>
+								<button
+									type="button"
+									onclick={(e) => {
+										e.stopPropagation();
+										e.preventDefault();
+										setValue([
+											...selectedThemes
+												.filter(
+													(theme) => theme.value !== selectedTheme.value
+												)
+												.map((theme) => theme.value),
+										]);
+									}}
+									class="ml-auto"
+								>
+									<X />
+								</button>
+							</div>
+						{/each}
+					{:else}
+						{placeholder}
+					{/if}
+				</div>
+			{/snippet}
+		</Select.Value>
+		<CaretUpDown class="text-muted-foreground ml-auto size-6 shrink-0" />
+	</Select.Trigger>
+	<Select.Portal>
+		<Select.Content
+			class="focus-override border-muted bg-background shadow-popover data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 outline-hidden z-50 h-96 max-h-[var(--bits-select-content-available-height)] w-[var(--bits-select-anchor-width)] min-w-[var(--bits-select-anchor-width)] select-none rounded-xl border px-1 py-3 data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1"
+			sideOffset={10}
+		>
+			<Select.ScrollUpButton class="flex w-full items-center justify-center">
+				<CaretDoubleUp class="size-3" />
+			</Select.ScrollUpButton>
+			<Select.Viewport class="p-1">
+				{#each themes as theme, i (i + theme.value)}
+					<Select.Item
+						class="rounded-button data-highlighted:bg-muted outline-hidden data-disabled:opacity-50 flex h-10 w-full select-none items-center py-3 pl-5 pr-1.5 text-sm capitalize"
+						value={theme.value}
+						label={theme.label}
+						disabled={theme.disabled}
+					>
+						{#snippet children({ selected })}
+							{theme.label}
+							{#if selected}
+								<div class="ml-auto">
+									<Check aria-label="check" />
+								</div>
+							{/if}
+						{/snippet}
+					</Select.Item>
+				{/each}
+			</Select.Viewport>
+			<Select.ScrollDownButton class="flex w-full items-center justify-center">
+				<CaretDoubleDown class="size-3" />
+			</Select.ScrollDownButton>
+		</Select.Content>
+	</Select.Portal>
+</Select.Root>

--- a/docs/src/lib/components/demos/select-demo-custom-value.svelte
+++ b/docs/src/lib/components/demos/select-demo-custom-value.svelte
@@ -39,45 +39,54 @@
 	>
 		<Palette class="text-muted-foreground mr-[9px] size-6 shrink-0" />
 		<Select.Value placeholder="Select your favorite themes">
-			{#snippet child({ selected, setValue, placeholder, disabled })}
-				{@const selectedThemes = selected as { value: string; label: string }[] | undefined}
-				<div class="flex gap-2 overflow-x-auto">
-					{#if selectedThemes}
-						{#each selectedThemes as selectedTheme (selectedTheme.value)}
+			{#snippet child({ props, selection, placeholder, disabled })}
+				<div
+					{...props}
+					class="flex min-w-0 flex-1 items-center gap-1.5 overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+				>
+					{#if selection.type === "multiple" && selection.selected.length > 0}
+						{#each selection.selected as selectedTheme (selectedTheme.value)}
 							<div
-								class="rounded-button bg-muted flex items-center gap-1 px-2 py-1 text-sm"
+								class="rounded-button bg-muted flex shrink-0 items-center gap-0.5 py-0.5 pl-2 pr-1 text-sm"
 							>
 								<span class="text-nowrap">{selectedTheme.label}</span>
-								<button
-									type="button"
-									{disabled}
+								<div
+									role="button"
+									tabindex={0}
+									aria-disabled={disabled}
+									aria-label="Remove {selectedTheme.label}"
 									onpointerdown={(e) => e.stopPropagation()}
 									onpointerup={(e) => e.stopPropagation()}
+									onkeydown={(e) => {
+										if (e.key === "Enter" || e.key === " ") {
+											e.currentTarget.click();
+										}
+									}}
 									onclick={(e) => {
 										if (disabled) return;
 										e.stopPropagation();
 										e.preventDefault();
-										setValue([
-											...selectedThemes
+										selection.setValue(
+											selection.selected
 												.filter(
 													(theme) => theme.value !== selectedTheme.value
 												)
-												.map((theme) => theme.value),
-										]);
+												.map((theme) => theme.value)
+										);
 									}}
-									class="ml-auto disabled:cursor-not-allowed"
+									class="text-muted-foreground hover:bg-background/60 hover:text-foreground rounded-sm p-0.5 transition-colors disabled:cursor-not-allowed"
 								>
-									<X />
-								</button>
+									<X class="size-3" />
+								</div>
 							</div>
 						{/each}
 					{:else}
-						{placeholder}
+						<span class="text-foreground-alt/50 truncate">{placeholder}</span>
 					{/if}
 				</div>
 			{/snippet}
 		</Select.Value>
-		<CaretUpDown class="text-muted-foreground ml-auto size-6 shrink-0" />
+		<CaretUpDown class="text-muted-foreground ml-2 size-6 shrink-0" />
 	</Select.Trigger>
 	<Select.Portal>
 		<Select.Content

--- a/docs/src/lib/components/demos/select-demo-custom-value.svelte
+++ b/docs/src/lib/components/demos/select-demo-custom-value.svelte
@@ -39,7 +39,7 @@
 	>
 		<Palette class="text-muted-foreground mr-[9px] size-6 shrink-0" />
 		<Select.Value placeholder="Select your favorite themes">
-			{#snippet child({ selected, setValue, placeholder })}
+			{#snippet child({ selected, setValue, placeholder, disabled })}
 				{@const selectedThemes = selected as { value: string; label: string }[] | undefined}
 				<div class="flex gap-2 overflow-x-auto">
 					{#if selectedThemes}
@@ -50,9 +50,11 @@
 								<span class="text-nowrap">{selectedTheme.label}</span>
 								<button
 									type="button"
+									{disabled}
 									onpointerdown={(e) => e.stopPropagation()}
 									onpointerup={(e) => e.stopPropagation()}
 									onclick={(e) => {
+										if (disabled) return;
 										e.stopPropagation();
 										e.preventDefault();
 										setValue([
@@ -63,7 +65,7 @@
 												.map((theme) => theme.value),
 										]);
 									}}
-									class="ml-auto"
+									class="ml-auto disabled:cursor-not-allowed"
 								>
 									<X />
 								</button>

--- a/docs/src/lib/components/demos/select-demo-custom-value.svelte
+++ b/docs/src/lib/components/demos/select-demo-custom-value.svelte
@@ -50,6 +50,8 @@
 								<span class="text-nowrap">{selectedTheme.label}</span>
 								<button
 									type="button"
+									onpointerdown={(e) => e.stopPropagation()}
+									onpointerup={(e) => e.stopPropagation()}
 									onclick={(e) => {
 										e.stopPropagation();
 										e.preventDefault();

--- a/docs/src/lib/components/demos/select-demo-custom.svelte
+++ b/docs/src/lib/components/demos/select-demo-custom.svelte
@@ -34,10 +34,6 @@
 		{ value: "turquoise-blue", label: "Turquoise Blue" },
 		{ value: "burnt-orange", label: "Burnt Orange" },
 	];
-
-	const selectedLabel = $derived(
-		value ? themes.find((theme) => theme.value === value)?.label : "Select a theme"
-	);
 </script>
 
 <Select.Root {...restProps} type="single" bind:value items={themes}>
@@ -46,7 +42,7 @@
 		aria-label="Select a theme"
 	>
 		<Palette class="text-muted-foreground mr-[9px] size-6" />
-		{selectedLabel}
+		<Select.Value placeholder="Select a theme" />
 		<CaretUpDown class="text-muted-foreground ml-auto size-6" />
 	</Select.Trigger>
 	<Select.Portal>

--- a/docs/src/lib/components/demos/select-demo-multiple.svelte
+++ b/docs/src/lib/components/demos/select-demo-multiple.svelte
@@ -28,27 +28,18 @@
 		{ value: "turquoise-blue", label: "Turquoise Blue" },
 		{ value: "burnt-orange", label: "Burnt Orange" },
 	];
-
-	let value = $state<string[]>([]);
-	const selectedLabel = $derived(
-		value.length
-			? themes
-					.filter((theme) => value.includes(theme.value))
-					.map((theme) => theme.label)
-					.join(", ")
-			: "Select your favorite themes"
-	);
 </script>
 
-<Select.Root type="multiple" bind:value>
+<Select.Root type="multiple">
 	<Select.Trigger
 		class="h-input rounded-9px border-border-input bg-background data-placeholder:text-foreground-alt/50 inline-flex w-[296px] touch-none select-none items-center border px-[11px] text-sm transition-colors"
 		aria-label="Select a theme"
 	>
 		<Palette class="text-muted-foreground mr-[9px] size-6" />
-		<span class="w-[calc(296px-11px-11px-9px)] truncate text-start">
-			{selectedLabel}
-		</span>
+		<Select.Value
+			class="w-[calc(296px-11px-11px-9px)] truncate text-start"
+			placeholder="Select your favorite themes"
+		/>
 		<CaretUpDown class="text-muted-foreground ml-auto size-6" />
 	</Select.Trigger>
 	<Select.Portal>

--- a/docs/src/lib/components/demos/select-demo-transition.svelte
+++ b/docs/src/lib/components/demos/select-demo-transition.svelte
@@ -29,20 +29,15 @@
 		{ value: "turquoise-blue", label: "Turquoise Blue" },
 		{ value: "burnt-orange", label: "Burnt Orange" },
 	];
-
-	let value = $state<string>("");
-	const selectedLabel = $derived(
-		value ? themes.find((theme) => theme.value === value)?.label : "Select a theme"
-	);
 </script>
 
-<Select.Root type="single" bind:value items={themes}>
+<Select.Root type="single" items={themes}>
 	<Select.Trigger
 		class="h-input rounded-9px border-border-input bg-background placeholder:text-foreground-alt/50 inline-flex w-[296px] touch-none select-none items-center border px-[11px] text-sm transition-colors"
 		aria-label="Select a theme"
 	>
 		<Palette class="text-muted-foreground mr-[9px] size-6" />
-		{selectedLabel}
+		<Select.Value placeholder="Select a theme" />
 		<CaretUpDown class="text-muted-foreground ml-auto size-6" />
 	</Select.Trigger>
 	<Select.Portal>

--- a/docs/src/lib/components/demos/select-demo.svelte
+++ b/docs/src/lib/components/demos/select-demo.svelte
@@ -42,7 +42,7 @@
 		aria-label="Select a theme"
 	>
 		<Palette class="text-muted-foreground mr-[9px] size-6" />
-		{selectedLabel}
+		<Select.Value/>
 		<CaretUpDown class="text-muted-foreground ml-auto size-6" />
 	</Select.Trigger>
 	<Select.Portal>

--- a/docs/src/lib/components/demos/select-demo.svelte
+++ b/docs/src/lib/components/demos/select-demo.svelte
@@ -29,20 +29,15 @@
 		{ value: "turquoise-blue", label: "Turquoise Blue" },
 		{ value: "burnt-orange", label: "Burnt Orange" },
 	];
-
-	let value = $state<string>("");
-	const selectedLabel = $derived(
-		value ? themes.find((theme) => theme.value === value)?.label : "Select a theme"
-	);
 </script>
 
-<Select.Root type="single" onValueChange={(v) => (value = v)} items={themes} allowDeselect={true}>
+<Select.Root type="single" items={themes} allowDeselect={true}>
 	<Select.Trigger
 		class="h-input rounded-9px border-border-input bg-background data-placeholder:text-foreground-alt/50 inline-flex w-[296px] touch-none select-none items-center border px-[11px] text-sm transition-colors"
 		aria-label="Select a theme"
 	>
 		<Palette class="text-muted-foreground mr-[9px] size-6" />
-		<Select.Value/>
+		<Select.Value placeholder="Select a theme" />
 		<CaretUpDown class="text-muted-foreground ml-auto size-6" />
 	</Select.Trigger>
 	<Select.Portal>

--- a/docs/src/lib/components/demos/tooltip-demo-singleton-force-mount.svelte
+++ b/docs/src/lib/components/demos/tooltip-demo-singleton-force-mount.svelte
@@ -40,7 +40,9 @@
 <Tooltip.Provider delayDuration={200}>
 	<Tooltip.Root tether={planTether}>
 		{#snippet children({ payload })}
-			<div class="rounded-10px border-border bg-background-alt shadow-mini flex flex-wrap items-center gap-1 border p-1">
+			<div
+				class="rounded-10px border-border bg-background-alt shadow-mini flex flex-wrap items-center gap-1 border p-1"
+			>
 				{#each plans as plan (plan.id)}
 					<Tooltip.Trigger
 						tether={planTether}
@@ -61,7 +63,9 @@
 									<div
 										class="rounded-input border-dark-10 bg-background shadow-popover outline-hidden z-0 w-[300px] border p-3"
 									>
-										<p class="text-sm font-semibold">{payload?.name ?? "Plan details"}</p>
+										<p class="text-sm font-semibold">
+											{payload?.name ?? "Plan details"}
+										</p>
 										<p class="text-foreground/70 mt-1 text-xs leading-relaxed">
 											{payload?.description ??
 												"forceMount keeps one tooltip node mounted so transitions stay smooth while content changes."}

--- a/docs/src/lib/components/demos/tooltip-demo-skip-delay.svelte
+++ b/docs/src/lib/components/demos/tooltip-demo-skip-delay.svelte
@@ -45,7 +45,7 @@
 						>
 							<span class="text-sm font-medium">{tool.label}</span>
 							<kbd
-								class="rounded-[4px] border-dark-10 text-foreground/50 bg-background-alt border px-1.5 py-0.5 font-mono text-[11px] leading-none"
+								class="border-dark-10 text-foreground/50 bg-background-alt rounded-[4px] border px-1.5 py-0.5 font-mono text-[11px] leading-none"
 							>
 								{tool.shortcut}
 							</kbd>

--- a/docs/src/lib/components/demos/tooltip-demo-tether.svelte
+++ b/docs/src/lib/components/demos/tooltip-demo-tether.svelte
@@ -12,10 +12,14 @@
 
 <Tooltip.Provider delayDuration={200}>
 	<div class="mx-auto grid w-full max-w-[760px] gap-2 sm:grid-cols-2">
-		<div class="rounded-10px border-border bg-background-alt shadow-mini flex items-center justify-between border p-3">
+		<div
+			class="rounded-10px border-border bg-background-alt shadow-mini flex items-center justify-between border p-3"
+		>
 			<div>
 				<p class="text-sm font-semibold">Data sources</p>
-				<p class="text-foreground/60 mt-0.5 text-xs">Pull live data from connected integrations</p>
+				<p class="text-foreground/60 mt-0.5 text-xs">
+					Pull live data from connected integrations
+				</p>
 			</div>
 			<Tooltip.Trigger
 				tether={actionsTether}
@@ -24,13 +28,15 @@
 					description: "Refreshes every connected source and recalculates all metrics.",
 					shortcut: "S",
 				}}
-				class="rounded-9px bg-background text-foreground/80 ring-dark ring-offset-background shadow-mini hover:bg-muted focus-visible:ring-dark focus-visible:ring-offset-background focus-visible:outline-hidden active:bg-dark-10 inline-flex h-8 shrink-0 items-center justify-center px-3 text-xs font-medium transition-all active:scale-[0.98] focus-visible:ring-2 focus-visible:ring-offset-2"
+				class="rounded-9px bg-background text-foreground/80 ring-dark ring-offset-background shadow-mini hover:bg-muted focus-visible:ring-dark focus-visible:ring-offset-background focus-visible:outline-hidden active:bg-dark-10 inline-flex h-8 shrink-0 items-center justify-center px-3 text-xs font-medium transition-all focus-visible:ring-2 focus-visible:ring-offset-2 active:scale-[0.98]"
 			>
 				Sync now
 			</Tooltip.Trigger>
 		</div>
 
-		<div class="rounded-10px border-border bg-background-alt shadow-mini flex items-center justify-between border p-3">
+		<div
+			class="rounded-10px border-border bg-background-alt shadow-mini flex items-center justify-between border p-3"
+		>
 			<div>
 				<p class="text-sm font-semibold">Sharing</p>
 				<p class="text-foreground/60 mt-0.5 text-xs">Share a live view with your team</p>
@@ -42,26 +48,31 @@
 					description: "Creates a read-only link with the current filter and date range.",
 					shortcut: "L",
 				}}
-				class="rounded-9px bg-background text-foreground/80 ring-dark ring-offset-background shadow-mini hover:bg-muted focus-visible:ring-dark focus-visible:ring-offset-background focus-visible:outline-hidden active:bg-dark-10 inline-flex h-8 shrink-0 items-center justify-center px-3 text-xs font-medium transition-all active:scale-[0.98] focus-visible:ring-2 focus-visible:ring-offset-2"
+				class="rounded-9px bg-background text-foreground/80 ring-dark ring-offset-background shadow-mini hover:bg-muted focus-visible:ring-dark focus-visible:ring-offset-background focus-visible:outline-hidden active:bg-dark-10 inline-flex h-8 shrink-0 items-center justify-center px-3 text-xs font-medium transition-all focus-visible:ring-2 focus-visible:ring-offset-2 active:scale-[0.98]"
 			>
 				Copy link
 			</Tooltip.Trigger>
 		</div>
 
-		<div class="rounded-10px border-border bg-background-alt shadow-mini flex items-center justify-between border p-3 sm:col-span-2">
+		<div
+			class="rounded-10px border-border bg-background-alt shadow-mini flex items-center justify-between border p-3 sm:col-span-2"
+		>
 			<div>
 				<p class="text-sm font-semibold">Automation</p>
-				<p class="text-foreground/60 mt-0.5 text-xs">Send recurring summaries to your team</p>
+				<p class="text-foreground/60 mt-0.5 text-xs">
+					Send recurring summaries to your team
+				</p>
 			</div>
 			<div class="flex items-center gap-2">
 				<Tooltip.Trigger
 					tether={actionsTether}
 					payload={{
 						label: "Schedule digest",
-						description: "Sends this dashboard summary to your team every Monday at 9:00 AM.",
+						description:
+							"Sends this dashboard summary to your team every Monday at 9:00 AM.",
 						shortcut: "D",
 					}}
-					class="rounded-9px bg-background text-foreground/80 ring-dark ring-offset-background shadow-mini hover:bg-muted focus-visible:ring-dark focus-visible:ring-offset-background focus-visible:outline-hidden active:bg-dark-10 inline-flex h-8 shrink-0 items-center justify-center px-3 text-xs font-medium transition-all active:scale-[0.98] focus-visible:ring-2 focus-visible:ring-offset-2"
+					class="rounded-9px bg-background text-foreground/80 ring-dark ring-offset-background shadow-mini hover:bg-muted focus-visible:ring-dark focus-visible:ring-offset-background focus-visible:outline-hidden active:bg-dark-10 inline-flex h-8 shrink-0 items-center justify-center px-3 text-xs font-medium transition-all focus-visible:ring-2 focus-visible:ring-offset-2 active:scale-[0.98]"
 				>
 					Schedule digest
 				</Tooltip.Trigger>
@@ -69,10 +80,11 @@
 					tether={actionsTether}
 					payload={{
 						label: "Pause digest",
-						description: "Stops all scheduled sends while keeping existing recipients intact.",
+						description:
+							"Stops all scheduled sends while keeping existing recipients intact.",
 						shortcut: "P",
 					}}
-					class="rounded-9px bg-background text-foreground/80 ring-dark ring-offset-background shadow-mini hover:bg-muted focus-visible:ring-dark focus-visible:ring-offset-background focus-visible:outline-hidden active:bg-dark-10 inline-flex h-8 shrink-0 items-center justify-center px-3 text-xs font-medium transition-all active:scale-[0.98] focus-visible:ring-2 focus-visible:ring-offset-2"
+					class="rounded-9px bg-background text-foreground/80 ring-dark ring-offset-background shadow-mini hover:bg-muted focus-visible:ring-dark focus-visible:ring-offset-background focus-visible:outline-hidden active:bg-dark-10 inline-flex h-8 shrink-0 items-center justify-center px-3 text-xs font-medium transition-all focus-visible:ring-2 focus-visible:ring-offset-2 active:scale-[0.98]"
 				>
 					Pause digest
 				</Tooltip.Trigger>
@@ -93,13 +105,14 @@
 						<div class="flex items-center justify-between gap-2">
 							<p class="text-sm font-semibold">{payload?.label ?? "Action"}</p>
 							<kbd
-								class="rounded-[4px] border-dark-10 text-foreground/65 bg-background-alt border px-1.5 py-0.5 font-mono text-[11px]"
+								class="border-dark-10 text-foreground/65 bg-background-alt rounded-[4px] border px-1.5 py-0.5 font-mono text-[11px]"
 							>
 								{payload?.shortcut ?? "?"}
 							</kbd>
 						</div>
 						<p class="text-foreground/70 mt-1 text-xs leading-relaxed">
-							{payload?.description ?? "Hover a detached action button to see what it does."}
+							{payload?.description ??
+								"Hover a detached action button to see what it does."}
 						</p>
 					</div>
 				</Tooltip.Content>

--- a/docs/src/lib/components/navigation/mobile-nav.svelte
+++ b/docs/src/lib/components/navigation/mobile-nav.svelte
@@ -25,7 +25,7 @@
 	</Popover.Trigger>
 	<Popover.Portal>
 		<Popover.Content
-			class="bg-background/90 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 h-(--bits-popover-content-available-height) w-(--bits-popover-content-available-width) origin-(--bits-popover-content-transform-origin) pr-0 backdrop-blur"
+			class="bg-background/90 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 h-(--bits-popover-content-available-height) w-(--bits-popover-content-available-width) origin-(--bits-popover-content-transform-origin) z-50 pr-0 backdrop-blur"
 			align="start"
 			side="bottom"
 			alignOffset={-16}

--- a/docs/src/lib/content/api-reference/accordion.api.ts
+++ b/docs/src/lib/content/api-reference/accordion.api.ts
@@ -21,6 +21,7 @@ import {
 	StringOrArrayStringProp,
 } from "./extended-types/shared/index.js";
 import { ContentChildSnippetProps } from "./extended-types/accordion/index.js";
+import contentChildSnippetPropsRaw from "./extended-types/accordion/content-child-snippet-props.md?raw";
 import {
 	defineBooleanProp,
 	defineComponentApiSchema,
@@ -31,6 +32,7 @@ import {
 	defineSimpleDataAttr,
 	defineStringProp,
 	defineUnionProp,
+	stringDefinitionFromMarkdown,
 } from "../utils.js";
 
 const stateDataAttr = defineEnumDataAttr({
@@ -39,6 +41,7 @@ const stateDataAttr = defineEnumDataAttr({
 	options: ["open", "closed"],
 	value: OpenClosedProp,
 });
+
 
 const root = defineComponentApiSchema<AccordionRootPropsWithoutHTML>({
 	title: "Root",
@@ -146,10 +149,7 @@ const content = defineComponentApiSchema<AccordionContentPropsWithoutHTML>({
 			elType: "HTMLDivElement",
 			child: {
 				definition: ContentChildSnippetProps,
-				stringDefinition: `type SnippetProps = {
-	open: boolean;
-	props: Record<string, unknown>;
-};`,
+				stringDefinition: stringDefinitionFromMarkdown(contentChildSnippetPropsRaw),
 			},
 		}),
 	},

--- a/docs/src/lib/content/api-reference/alert-dialog.api.ts
+++ b/docs/src/lib/content/api-reference/alert-dialog.api.ts
@@ -14,6 +14,8 @@ import {
 	DialogContentChildSnippetProps,
 	DialogOverlayChildSnippetProps,
 } from "./extended-types/dialog/index.js";
+import dialogContentChildSnippetPropsRaw from "./extended-types/dialog/dialog-content-child-snippet-props.md?raw";
+import dialogOverlayChildSnippetPropsRaw from "./extended-types/dialog/dialog-overlay-child-snippet-props.md?raw";
 import {
 	childrenSnippet,
 	dismissibleLayerProps,
@@ -35,6 +37,7 @@ import {
 	defineEnumDataAttr,
 	defineSimpleDataAttr,
 	defineUnionProp,
+	stringDefinitionFromMarkdown,
 } from "../utils.js";
 import { nestedCSSVars, nestedDataAttrs } from "./dialog.api.js";
 
@@ -96,10 +99,7 @@ const content = defineComponentApiSchema<AlertDialogContentPropsWithoutHTML>({
 			elType: "HTMLDivElement",
 			child: {
 				definition: DialogContentChildSnippetProps,
-				stringDefinition: `type SnippetProps = {
-	props: Record<string, unknown>;
-	open: boolean;
-};`,
+				stringDefinition: stringDefinitionFromMarkdown(dialogContentChildSnippetPropsRaw),
 			},
 		}),
 	},
@@ -170,10 +170,7 @@ const overlay = defineComponentApiSchema<AlertDialogOverlayPropsWithoutHTML>({
 			elType: "HTMLDivElement",
 			child: {
 				definition: DialogOverlayChildSnippetProps,
-				stringDefinition: `type SnippetProps = {
-	props: Record<string, unknown>;
-	open: boolean;
-};`,
+				stringDefinition: stringDefinitionFromMarkdown(dialogOverlayChildSnippetPropsRaw),
 			},
 		}),
 	},

--- a/docs/src/lib/content/api-reference/calendar.api.ts
+++ b/docs/src/lib/content/api-reference/calendar.api.ts
@@ -46,7 +46,14 @@ import {
 	defineStringProp,
 	defineSimplePropSchema,
 	defineUnionProp,
+	stringDefinitionFromMarkdown,
 } from "../utils.js";
+import calendarMonthSelectChildSnippetPropsRaw from "./extended-types/shared/calendar-month-select-child-snippet-prop.md?raw";
+import calendarMonthSelectChildrenSnippetPropsRaw from "./extended-types/shared/calendar-month-select-children-snippet-prop.md?raw";
+import calendarRootChildSnippetPropsRaw from "./extended-types/shared/calendar-root-child-snippet-props.md?raw";
+import calendarRootChildrenSnippetPropsRaw from "./extended-types/shared/calendar-root-children-snippet-props.md?raw";
+import calendarYearSelectChildSnippetPropsRaw from "./extended-types/shared/calendar-year-select-child-snippet-prop.md?raw";
+import calendarYearSelectChildrenSnippetPropsRaw from "./extended-types/shared/calendar-year-select-children-snippet-prop.md?raw";
 
 const sharedCellDayAttrs = [
 	defineSimpleDataAttr({
@@ -199,74 +206,11 @@ export const root = defineComponentApiSchema<CalendarRootPropsWithoutHTML>({
 			elType: "HTMLDivElement",
 			child: {
 				definition: CalendarRootChildSnippetProps,
-				stringDefinition: `type Month<T> = {
-	/**
-	 * A DateValue used to represent the month. Since days
-	 * from the previous and next months may be included in the
-	 * calendar grid, we need a source of truth for the value
-	 * the grid is representing.
-	 */
-	value: DateValue;
-
-	/**
-	 * An array of arrays representing the weeks in the calendar.
-	 * Each sub-array represents a week, and contains the dates for each
-	 * day in that week. This structure is useful for rendering the calendar
-	 * grid using a table, where each row represents a week and each cell
-	 * represents a day.
-	 */
-	weeks: T[][];
-
-	/**
-	 * An array of all the dates in the current month, including dates from
-	 * the previous and next months that are used to fill out the calendar grid.
-	 * This array is useful for rendering the calendar grid in a customizable way,
-	 * as it provides all the dates that should be displayed in the grid in a flat
-	 * array.
-	 */
-	dates: T[];
-};
-
-type ChildSnippetProps = {
-	props: Record<string, unknown>;
-	months: Month<DateValue>[];
-	weekdays: string[];
-};`,
+				stringDefinition: stringDefinitionFromMarkdown(calendarRootChildSnippetPropsRaw),
 			},
 			children: {
 				definition: CalendarRootChildrenSnippetProps,
-				stringDefinition: `type Month<T> = {
-	/**
-	 * A DateValue used to represent the month. Since days
-	 * from the previous and next months may be included in the
-	 * calendar grid, we need a source of truth for the value
-	 * the grid is representing.
-	 */
-	value: DateValue;
-
-	/**
-	 * An array of arrays representing the weeks in the calendar.
-	 * Each sub-array represents a week, and contains the dates for each
-	 * day in that week. This structure is useful for rendering the calendar
-	 * grid using a table, where each row represents a week and each cell
-	 * represents a day.
-	 */
-	weeks: T[][];
-
-	/**
-	 * An array of all the dates in the current month, including dates from
-	 * the previous and next months that are used to fill out the calendar grid.
-	 * This array is useful for rendering the calendar grid in a customizable way,
-	 * as it provides all the dates that should be displayed in the grid in a flat
-	 * array.
-	 */
-	dates: T[];
-};
-
-type ChildrenSnippetProps = {
-	months: Month<DateValue>[];
-	weekdays: string[];
-};`,
+				stringDefinition: stringDefinitionFromMarkdown(calendarRootChildrenSnippetPropsRaw),
 			},
 		}),
 	},
@@ -572,18 +516,11 @@ export function createCalendarMonthSelectSchema(isRange: boolean) {
 				elType: "HTMLSelectElement",
 				child: {
 					definition: CalendarMonthSelectChildSnippetProps,
-					stringDefinition: `type ChildSnippetProps = {
-	props: Record<string, unknown>;
-	monthItems: Array<{ value: number; label: string }>;
-	selectedMonthItem: { value: number; label: string };
-};`,
+					stringDefinition: stringDefinitionFromMarkdown(calendarMonthSelectChildSnippetPropsRaw),
 				},
 				children: {
 					definition: CalendarMonthSelectChildrenSnippetProps,
-					stringDefinition: `type ChildrenSnippetProps = {
-	monthItems: Array<{ value: number; label: string }>;
-	selectedMonthItem: { value: number; label: string };
-};`,
+					stringDefinition: stringDefinitionFromMarkdown(calendarMonthSelectChildrenSnippetPropsRaw),
 				},
 			}),
 		},
@@ -624,18 +561,11 @@ export function createCalendarYearSelectSchema(isRange: boolean) {
 				elType: "HTMLSelectElement",
 				child: {
 					definition: CalendarYearSelectChildSnippetProps,
-					stringDefinition: `type ChildSnippetProps = {
-	props: Record<string, unknown>;
-	yearItems: Array<{ value: number; label: string }>;
-	selectedYearItem: { value: number; label: string };
-};`,
+					stringDefinition: stringDefinitionFromMarkdown(calendarYearSelectChildSnippetPropsRaw),
 				},
 				children: {
 					definition: CalendarYearSelectChildrenSnippetProps,
-					stringDefinition: `type ChildrenSnippetProps = {
-	yearItems: Array<{ value: number; label: string }>;
-	selectedYearItem: { value: number; label: string };
-};`,
+					stringDefinition: stringDefinitionFromMarkdown(calendarYearSelectChildrenSnippetPropsRaw),
 				},
 			}),
 		},

--- a/docs/src/lib/content/api-reference/collapsible.api.ts
+++ b/docs/src/lib/content/api-reference/collapsible.api.ts
@@ -11,6 +11,7 @@ import {
 	withChildProps,
 } from "./shared.js";
 import { CollapsibleContentChildSnippetProps } from "./extended-types/collapsible/index.js";
+import collapsibleContentChildSnippetPropsRaw from "./extended-types/collapsible/content-child-snippet-props.md?raw";
 import { OpenClosedProp } from "./extended-types/shared/index.js";
 import {
 	defineBooleanProp,
@@ -18,6 +19,7 @@ import {
 	defineCSSVarSchema,
 	defineEnumDataAttr,
 	defineSimpleDataAttr,
+	stringDefinitionFromMarkdown,
 } from "../utils.js";
 
 export const root = defineComponentApiSchema<CollapsibleRootPropsWithoutHTML>({
@@ -94,10 +96,7 @@ export const content = defineComponentApiSchema<CollapsibleContentPropsWithoutHT
 			elType: "HTMLDivElement",
 			child: {
 				definition: CollapsibleContentChildSnippetProps,
-				stringDefinition: `type SnippetProps = {
-	open: boolean;
-	props: Record<string, unknown>;
-};`,
+				stringDefinition: stringDefinitionFromMarkdown(collapsibleContentChildSnippetPropsRaw),
 			},
 		}),
 	},

--- a/docs/src/lib/content/api-reference/command.api.ts
+++ b/docs/src/lib/content/api-reference/command.api.ts
@@ -14,6 +14,7 @@ import type {
 } from "bits-ui";
 import { NoopProp, OnStringValueChangeProp } from "./extended-types/shared/index.js";
 import { CommandFilterProp, CommandOnStateChangeProp } from "./extended-types/command/index.js";
+import commandOnStateChangePropRaw from "./extended-types/command/command-on-state-change-prop.md?raw";
 import { withChildProps } from "$lib/content/api-reference/shared.js";
 import {
 	defineBooleanProp,
@@ -24,7 +25,9 @@ import {
 	defineSimpleDataAttr,
 	defineStringProp,
 	defineSimplePropSchema,
+	stringDefinitionFromMarkdown,
 } from "../utils.js";
+
 
 const root = defineComponentApiSchema<CommandRootPropsWithoutHTML>({
 	title: "Root",
@@ -62,23 +65,7 @@ const root = defineComponentApiSchema<CommandRootPropsWithoutHTML>({
 			definition: CommandOnStateChangeProp,
 			description: `A callback that fires when the command's internal state changes. This callback receives a readonly snapshot of the current state.
 			The callback is debounced and only fires once per batch of related updates (e.g., when typing triggers filtering and selection changes).`,
-			stringDefinition: `type CommandState = {
-	/** The value of the search query */
-	search: string;
-	/** The value of the selected command menu item */
-	value: string;
-	/** The filtered items */
-	filtered: {
-		/** The count of all visible items. */
-		count: number;
-		/** Map from visible item id to its search store. */
-		items: Map<string, number>;
-		/** Set of groups with at least one visible item. */
-		groups: Set<string>;
-	};
-};
-
-type onStateChange = (state: Readonly<CommandState>) => void;`,
+			stringDefinition: stringDefinitionFromMarkdown(commandOnStateChangePropRaw),
 		}),
 		loop: defineBooleanProp({
 			default: false,

--- a/docs/src/lib/content/api-reference/date-field.api.ts
+++ b/docs/src/lib/content/api-reference/date-field.api.ts
@@ -22,6 +22,8 @@ import {
 } from "./extended-types/shared/index.js";
 
 import { DateFieldEditableSegmentPartProp } from "./extended-types/date-field/index.js";
+import dateFieldInputChildSnippetPropsRaw from "./extended-types/shared/date-field-input-child-snippet-props.md?raw";
+import dateFieldInputChildrenSnippetPropsRaw from "./extended-types/shared/date-field-input-children-snippet-props.md?raw";
 import {
 	defineBooleanProp,
 	defineComponentApiSchema,
@@ -31,8 +33,10 @@ import {
 	definePropSchema,
 	defineSimpleDataAttr,
 	defineStringProp,
+	stringDefinitionFromMarkdown,
 } from "../utils.js";
 import { dateValueProp } from "./shared.js";
+
 
 export const root = defineComponentApiSchema<DateFieldRootPropsWithoutHTML>({
 	title: "Root",
@@ -119,18 +123,11 @@ export const input = defineComponentApiSchema<DateFieldInputPropsWithoutHTML>({
 			elType: "HTMLDivElement",
 			children: {
 				definition: DateFieldInputChildrenSnippetProps,
-				stringDefinition: `import type { SegmentPart } from "bits-ui";
-type ChildrenSnippetProps = {
-	segments: Array<{ part: SegmentPart; value: string }>;
-};`,
+				stringDefinition: stringDefinitionFromMarkdown(dateFieldInputChildrenSnippetPropsRaw),
 			},
 			child: {
 				definition: DateFieldInputChildSnippetProps,
-				stringDefinition: `import type { SegmentPart } from "bits-ui";
-type ChildSnippetProps = {
-	props: Record<string, unknown>;
-	segments: Array<{ part: SegmentPart; value: string }>;
-};`,
+				stringDefinition: stringDefinitionFromMarkdown(dateFieldInputChildSnippetPropsRaw),
 			},
 		}),
 	},

--- a/docs/src/lib/content/api-reference/extended-types/select/index.ts
+++ b/docs/src/lib/content/api-reference/extended-types/select/index.ts
@@ -1,3 +1,4 @@
 export { default as ItemsProp } from "./items-prop.md"
 export { default as DelayProp } from "./delay-prop.md"
 export { default as SelectValueChildSnippetProps } from "./select-value-child-snippet-props.md"
+export { default as SelectValueChildrenSnippetProps } from "./select-value-children-snippet-props.md"

--- a/docs/src/lib/content/api-reference/extended-types/select/index.ts
+++ b/docs/src/lib/content/api-reference/extended-types/select/index.ts
@@ -1,2 +1,3 @@
 export { default as ItemsProp } from "./items-prop.md"
 export { default as DelayProp } from "./delay-prop.md"
+export { default as SelectValueChildSnippetProps } from "./select-value-child-snippet-props.md"

--- a/docs/src/lib/content/api-reference/extended-types/select/select-value-child-snippet-props.md
+++ b/docs/src/lib/content/api-reference/extended-types/select/select-value-child-snippet-props.md
@@ -1,0 +1,15 @@
+```ts
+type SelectValueSnippetProps =
+	| {
+			type: "single";
+			placeholder?: string | null;
+			selected?: { value: string; label: string };
+			setValue: (value: string) => void;
+	  }
+	| {
+			type: "multiple";
+			placeholder?: string | null;
+			selected?: { value: string; label: string }[];
+			setValue: (value: string[]) => void;
+	  };
+```

--- a/docs/src/lib/content/api-reference/extended-types/select/select-value-child-snippet-props.md
+++ b/docs/src/lib/content/api-reference/extended-types/select/select-value-child-snippet-props.md
@@ -1,15 +1,15 @@
 ```ts
 type SelectValueSnippetProps =
 	| {
-			type: "single";
-			placeholder?: string | null;
-			selected?: { value: string; label: string };
-			setValue: (value: string) => void;
+			type: "single"
+			placeholder?: string | null
+			selected?: { value: string; label: string }
+			setValue: (value: string) => void
 	  }
 	| {
-			type: "multiple";
-			placeholder?: string | null;
-			selected?: { value: string; label: string }[];
-			setValue: (value: string[]) => void;
-	  };
+			type: "multiple"
+			placeholder?: string | null
+			selected?: { value: string; label: string }[]
+			setValue: (value: string[]) => void
+	  }
 ```

--- a/docs/src/lib/content/api-reference/extended-types/select/select-value-children-snippet-props.md
+++ b/docs/src/lib/content/api-reference/extended-types/select/select-value-children-snippet-props.md
@@ -1,6 +1,5 @@
 ```ts
-type ChildSnippetProps = {
-	props: Record<string, unknown>
+type ChildrenSnippetProps = {
 	selection:
 		| {
 				type: "single"

--- a/docs/src/lib/content/api-reference/pagination.api.ts
+++ b/docs/src/lib/content/api-reference/pagination.api.ts
@@ -10,6 +10,8 @@ import {
 	PaginationChildrenSnippetProps,
 	PaginationOnPageChangeProp,
 } from "./extended-types/pagination/index.js";
+import paginationChildSnippetPropsRaw from "./extended-types/pagination/pagination-child-snippet-props.md?raw";
+import paginationChildrenSnippetPropsRaw from "./extended-types/pagination/pagination-children-snippet-props.md?raw";
 import { OrientationProp } from "./extended-types/shared/index.js";
 import {
 	defineBooleanProp,
@@ -18,7 +20,9 @@ import {
 	defineFunctionProp,
 	defineNumberProp,
 	defineSimpleDataAttr,
+	stringDefinitionFromMarkdown,
 } from "../utils.js";
+
 
 export const root = defineComponentApiSchema<PaginationRootPropsWithoutHTML>({
 	title: "Root",
@@ -62,54 +66,11 @@ export const root = defineComponentApiSchema<PaginationRootPropsWithoutHTML>({
 			elType: "HTMLDivElement",
 			child: {
 				definition: PaginationChildSnippetProps,
-				stringDefinition: `type Page = {
-	type: "page";
-	value: number;
-};
-
-type Ellipsis = {
-	type: "ellipsis";
-};
-
-type PageItem = (Page | Ellipsis) & {
-	/**  A unique key to be used as the key in a svelte #each block. */
-	key: string;
-};
-
-type ChildSnippetProps = {
-	/** The items to iterate over and render for the pagination component */
-	pages: PageItem[];
-	/** The range of pages to render */
-	range: { start: number; end: number };
-	/** The currently active page */
-	currentPage: number;
-	props: Record<string, unknown>;
-};`,
+				stringDefinition: stringDefinitionFromMarkdown(paginationChildSnippetPropsRaw),
 			},
 			children: {
 				definition: PaginationChildrenSnippetProps,
-				stringDefinition: `type Page = {
-	type: "page";
-	value: number;
-};
-
-type Ellipsis = {
-	type: "ellipsis";
-};
-
-type PageItem = (Page | Ellipsis) & {
-	/**  A unique key to be used as the key in a svelte #each block. */
-	key: string;
-};
-
-type ChildrenSnippetProps = {
-	/** The items to iterate over and render for the pagination component */
-	pages: PageItem[];
-	/** The range of pages to render */
-	range: { start: number; end: number };
-	/** The currently active page */
-	currentPage: number;
-};`,
+				stringDefinition: stringDefinitionFromMarkdown(paginationChildrenSnippetPropsRaw),
 			},
 		}),
 	},

--- a/docs/src/lib/content/api-reference/pin-input.api.ts
+++ b/docs/src/lib/content/api-reference/pin-input.api.ts
@@ -8,6 +8,9 @@ import {
 	PinInputRootPushPasswordManagerStrategyProp,
 	PinInputRootTextAlignProp,
 } from "./extended-types/pin-input/index.js";
+import pinInputCellCellPropRaw from "./extended-types/pin-input/pin-input-cell-cell-prop.md?raw";
+import pinInputRootChildSnippetPropsRaw from "./extended-types/pin-input/pin-input-root-child-snippet-props.md?raw";
+import pinInputRootChildrenSnippetPropsRaw from "./extended-types/pin-input/pin-input-root-children-snippet-props.md?raw";
 import { OnStringValueChangeProp } from "./extended-types/shared/index.js";
 import { withChildProps } from "$lib/content/api-reference/shared.js";
 import {
@@ -19,6 +22,7 @@ import {
 	defineObjectProp,
 	defineSimpleDataAttr,
 	defineStringProp,
+	stringDefinitionFromMarkdown,
 } from "../utils.js";
 
 const root = defineComponentApiSchema<PinInputRootPropsWithoutHTML>({
@@ -73,34 +77,11 @@ const root = defineComponentApiSchema<PinInputRootPropsWithoutHTML>({
 			elType: "HTMLDivElement",
 			child: {
 				definition: PinInputRootChildSnippetProps,
-				stringDefinition: `type PinInputCell = {
-	/** The character displayed in the cell. */
-	char: string | null | undefined;
-	/** Whether the cell is active. */
-	isActive: boolean;
-	/** Whether the cell has a fake caret. */
-	hasFakeCaret: boolean;
-};
-
-type SnippetProps = {
-	cells: PinInputCell[];
-	props: Record<string, unknown>;
-};`,
+				stringDefinition: stringDefinitionFromMarkdown(pinInputRootChildSnippetPropsRaw),
 			},
 			children: {
 				definition: PinInputRootChildrenSnippetProps,
-				stringDefinition: `type PinInputCell = {
-	/** The character displayed in the cell. */
-	char: string | null | undefined;
-	/** Whether the cell is active. */
-	isActive: boolean;
-	/** Whether the cell has a fake caret. */
-	hasFakeCaret: boolean;
-};
-
-type SnippetProps = {
-	cells: PinInputCell[];
-};`,
+				stringDefinition: stringDefinitionFromMarkdown(pinInputRootChildrenSnippetPropsRaw),
 			},
 		}),
 	},
@@ -120,14 +101,7 @@ const cell = defineComponentApiSchema<PinInputCellPropsWithoutHTML>({
 			definition: PinInputCellCellProp,
 			description:
 				"The cell object provided by the `cells` snippet prop from the `PinInput.Root` component.",
-			stringDefinition: `type Cell = {
-	/** The character displayed in the cell. */
-	char: string | null | undefined;
-	/** Whether the cell is active. */
-	isActive: boolean;
-	/** Whether the cell has a fake caret. */
-	hasFakeCaret: boolean;
-}`,
+			stringDefinition: stringDefinitionFromMarkdown(pinInputCellCellPropRaw),
 		}),
 		...withChildProps({ elType: "HTMLDivElement" }),
 	},

--- a/docs/src/lib/content/api-reference/rating-group.api.ts
+++ b/docs/src/lib/content/api-reference/rating-group.api.ts
@@ -9,6 +9,10 @@ import {
 	RatingGroupRootChildrenSnippetProps,
 	RatingGroupRootChildSnippetProps,
 } from "./extended-types/rating-group/index.js";
+import ratingGroupItemChildSnippetPropsRaw from "./extended-types/rating-group/rating-group-item-child-snippet-props.md?raw";
+import ratingGroupItemChildrenSnippetPropsRaw from "./extended-types/rating-group/rating-group-item-children-snippet-props.md?raw";
+import ratingGroupRootChildSnippetPropsRaw from "./extended-types/rating-group/rating-group-root-child-snippet-props.md?raw";
+import ratingGroupRootChildrenSnippetPropsRaw from "./extended-types/rating-group/rating-group-root-children-snippet-props.md?raw";
 import {
 	defineBooleanProp,
 	defineComponentApiSchema,
@@ -19,6 +23,7 @@ import {
 	defineSimpleDataAttr,
 	defineStringProp,
 	defineUnionProp,
+	stringDefinitionFromMarkdown,
 } from "../utils.js";
 
 export const root = defineComponentApiSchema<RatingGroupRootPropsWithoutHTML>({
@@ -88,34 +93,11 @@ export const root = defineComponentApiSchema<RatingGroupRootPropsWithoutHTML>({
 			elType: "HTMLDivElement",
 			child: {
 				definition: RatingGroupRootChildSnippetProps,
-				stringDefinition: `type RatingGroupItemState = "active" | "partial" | "inactive";
-
-type RatingGroupItemData = {
-	index: number;
-	state: RatingGroupItemState;
-};
-
-type ChildSnippetProps = {
-	items: RatingGroupItemData[];
-	value: number;
-	max: number;
-	props: Record<string, unknown>;
-};`,
+				stringDefinition: stringDefinitionFromMarkdown(ratingGroupRootChildSnippetPropsRaw),
 			},
 			children: {
 				definition: RatingGroupRootChildrenSnippetProps,
-				stringDefinition: `type RatingGroupItemState = "active" | "partial" | "inactive";
-
-type RatingGroupItemData = {
-	index: number;
-	state: RatingGroupItemState;
-};
-
-type ChildrenSnippetProps = {
-	items: RatingGroupItemData[];
-	value: number;
-	max: number;
-};`,
+				stringDefinition: stringDefinitionFromMarkdown(ratingGroupRootChildrenSnippetPropsRaw),
 			},
 		}),
 	},
@@ -157,20 +139,11 @@ export const item = defineComponentApiSchema<RatingGroupItemPropsWithoutHTML>({
 			elType: "HTMLDivElement",
 			child: {
 				definition: RatingGroupItemChildSnippetProps,
-				stringDefinition: `type RatingGroupItemState = "active" | "partial" | "inactive";
-
-type ChildSnippetProps = {
-	state: RatingGroupItemState;
-	props: Record<string, unknown>;
-};`,
+				stringDefinition: stringDefinitionFromMarkdown(ratingGroupItemChildSnippetPropsRaw),
 			},
 			children: {
 				definition: RatingGroupItemChildrenSnippetProps,
-				stringDefinition: `type RatingGroupItemState = "active" | "partial" | "inactive";
-
-type ChildrenSnippetProps = {
-	state: RatingGroupItemState;
-};`,
+				stringDefinition: stringDefinitionFromMarkdown(ratingGroupItemChildrenSnippetPropsRaw),
 			},
 		}),
 	},

--- a/docs/src/lib/content/api-reference/select.api.ts
+++ b/docs/src/lib/content/api-reference/select.api.ts
@@ -292,8 +292,7 @@ export const value = defineComponentApiSchema<SelectValueApiProps>({
 		"A text label of the currently selected item(s). Renders a `<span>` by default, or use the `child` snippet for full control.",
 	props: {
 		placeholder: defineStringProp({
-			description:
-				"Text shown when no value is selected.",
+			description: "Text shown when no value is selected.",
 		}),
 		child: childSnippet({
 			variant: "complex",

--- a/docs/src/lib/content/api-reference/select.api.ts
+++ b/docs/src/lib/content/api-reference/select.api.ts
@@ -42,7 +42,10 @@ import {
 	DelayProp,
 	ItemsProp,
 	SelectValueChildSnippetProps,
+	SelectValueChildrenSnippetProps,
 } from "./extended-types/select/index.js";
+import selectValueChildSnippetPropsRaw from "./extended-types/select/select-value-child-snippet-props.md?raw";
+import selectValueChildrenSnippetPropsRaw from "./extended-types/select/select-value-children-snippet-props.md?raw";
 import {
 	NoopProp,
 	OnChangeStringOrArrayProp,
@@ -68,6 +71,18 @@ const stateDataAttr = defineEnumDataAttr({
 	description: "The select's open state.",
 	value: OpenClosedProp,
 });
+
+function stripCodeFence(raw: string): string {
+	return raw
+		.replace(/^```[a-zA-Z0-9_-]*\r?\n/, "")
+		.replace(/\r?\n```[\r\n]*$/, "")
+		.trim();
+}
+
+const selectValueChildSnippetStringDefinition = stripCodeFence(selectValueChildSnippetPropsRaw);
+const selectValueChildrenSnippetStringDefinition = stripCodeFence(
+	selectValueChildrenSnippetPropsRaw
+);
 
 export const root = defineComponentApiSchema<SelectRootPropsWithoutHTML>({
 	title: "Root",
@@ -284,6 +299,7 @@ export const trigger = defineComponentApiSchema<SelectTriggerPropsWithoutHTML>({
 
 type SelectValueApiProps = SelectValuePropsWithoutHTML & {
 	ref?: HTMLSpanElement | null;
+	placeholder?: string;
 };
 
 export const value = defineComponentApiSchema<SelectValueApiProps>({
@@ -294,23 +310,17 @@ export const value = defineComponentApiSchema<SelectValueApiProps>({
 		placeholder: defineStringProp({
 			description: "Text shown when no value is selected.",
 		}),
+		children: childrenSnippet({
+			variant: "complex",
+			type: "Snippet",
+			definition: SelectValueChildrenSnippetProps,
+			stringDefinition: selectValueChildrenSnippetStringDefinition,
+		}),
 		child: childSnippet({
 			variant: "complex",
 			type: "Snippet",
 			definition: SelectValueChildSnippetProps,
-			stringDefinition: `type SelectValueSnippetProps =
-	| {
-			type: "single";
-			placeholder?: string | null;
-			selected?: { value: string; label: string };
-			setValue: (value: string) => void;
-	  }
-	| {
-			type: "multiple";
-			placeholder?: string | null;
-			selected?: { value: string; label: string }[];
-			setValue: (value: string[]) => void;
-	  };`,
+			stringDefinition: selectValueChildSnippetStringDefinition,
 		}),
 		ref: refProp({ elType: "HTMLSpanElement" }),
 	},

--- a/docs/src/lib/content/api-reference/select.api.ts
+++ b/docs/src/lib/content/api-reference/select.api.ts
@@ -63,6 +63,7 @@ import {
 	defineSimpleDataAttr,
 	defineStringProp,
 	defineUnionProp,
+	stringDefinitionFromMarkdown,
 } from "../utils.js";
 
 const stateDataAttr = defineEnumDataAttr({
@@ -72,17 +73,6 @@ const stateDataAttr = defineEnumDataAttr({
 	value: OpenClosedProp,
 });
 
-function stripCodeFence(raw: string): string {
-	return raw
-		.replace(/^```[a-zA-Z0-9_-]*\r?\n/, "")
-		.replace(/\r?\n```[\r\n]*$/, "")
-		.trim();
-}
-
-const selectValueChildSnippetStringDefinition = stripCodeFence(selectValueChildSnippetPropsRaw);
-const selectValueChildrenSnippetStringDefinition = stripCodeFence(
-	selectValueChildrenSnippetPropsRaw
-);
 
 export const root = defineComponentApiSchema<SelectRootPropsWithoutHTML>({
 	title: "Root",
@@ -314,13 +304,13 @@ export const value = defineComponentApiSchema<SelectValueApiProps>({
 			variant: "complex",
 			type: "Snippet",
 			definition: SelectValueChildrenSnippetProps,
-			stringDefinition: selectValueChildrenSnippetStringDefinition,
+			stringDefinition: stringDefinitionFromMarkdown(selectValueChildrenSnippetPropsRaw),
 		}),
 		child: childSnippet({
 			variant: "complex",
 			type: "Snippet",
 			definition: SelectValueChildSnippetProps,
-			stringDefinition: selectValueChildSnippetStringDefinition,
+			stringDefinition: stringDefinitionFromMarkdown(selectValueChildSnippetPropsRaw),
 		}),
 		ref: refProp({ elType: "HTMLSpanElement" }),
 	},

--- a/docs/src/lib/content/api-reference/select.api.ts
+++ b/docs/src/lib/content/api-reference/select.api.ts
@@ -1,5 +1,6 @@
 import {
 	arrowProps,
+	childSnippet,
 	childrenSnippet,
 	dirProp,
 	dismissibleLayerProps,
@@ -16,6 +17,7 @@ import {
 	portalProps,
 	preventOverflowTextSelectionProp,
 	preventScrollProp,
+	refProp,
 	transitionStyleDataAttrs,
 	typeSingleOrMultipleProp,
 	withChildProps,
@@ -29,13 +31,18 @@ import type {
 	SelectItemPropsWithoutHTML,
 	SelectPortalPropsWithoutHTML,
 	SelectRootPropsWithoutHTML,
+	SelectValuePropsWithoutHTML,
 	SelectScrollDownButtonPropsWithoutHTML,
 	SelectScrollUpButtonPropsWithoutHTML,
 	SelectTriggerPropsWithoutHTML,
 	SelectViewportPropsWithoutHTML,
 } from "bits-ui";
 import { ComboboxScrollAlignmentProp } from "./extended-types/combobox/index.js";
-import { DelayProp, ItemsProp } from "./extended-types/select/index.js";
+import {
+	DelayProp,
+	ItemsProp,
+	SelectValueChildSnippetProps,
+} from "./extended-types/select/index.js";
 import {
 	NoopProp,
 	OnChangeStringOrArrayProp,
@@ -275,6 +282,51 @@ export const trigger = defineComponentApiSchema<SelectTriggerPropsWithoutHTML>({
 	],
 });
 
+type SelectValueApiProps = SelectValuePropsWithoutHTML & {
+	ref?: HTMLSpanElement | null;
+};
+
+export const value = defineComponentApiSchema<SelectValueApiProps>({
+	title: "Value",
+	description:
+		"A text label of the currently selected item(s). Renders a `<span>` by default, or use the `child` snippet for full control.",
+	props: {
+		placeholder: defineStringProp({
+			description:
+				"Text shown when no value is selected.",
+		}),
+		child: childSnippet({
+			variant: "complex",
+			type: "Snippet",
+			definition: SelectValueChildSnippetProps,
+			stringDefinition: `type SelectValueSnippetProps =
+	| {
+			type: "single";
+			placeholder?: string | null;
+			selected?: { value: string; label: string };
+			setValue: (value: string) => void;
+	  }
+	| {
+			type: "multiple";
+			placeholder?: string | null;
+			selected?: { value: string; label: string }[];
+			setValue: (value: string[]) => void;
+	  };`,
+		}),
+		ref: refProp({ elType: "HTMLSpanElement" }),
+	},
+	dataAttributes: [
+		defineSimpleDataAttr({
+			name: "placeholder",
+			description: "Present when the select does not have a value.",
+		}),
+		defineSimpleDataAttr({
+			name: "select-value",
+			description: "Present on the value element.",
+		}),
+	],
+});
+
 export const viewport = defineComponentApiSchema<SelectViewportPropsWithoutHTML>({
 	title: "Viewport",
 	description:
@@ -377,6 +429,7 @@ export const portal = defineComponentApiSchema<SelectPortalPropsWithoutHTML>({
 export const select = [
 	root,
 	trigger,
+	value,
 	content,
 	contentStatic,
 	portal,

--- a/docs/src/lib/content/api-reference/slider.api.ts
+++ b/docs/src/lib/content/api-reference/slider.api.ts
@@ -12,6 +12,8 @@ import {
 	SliderRootOnValueChangeProp,
 	SliderTickLabelPositionProp,
 } from "./extended-types/slider/index.js";
+import sliderRootChildSnippetPropsRaw from "./extended-types/slider/slider-root-child-snippet-props.md?raw";
+import sliderRootChildrenSnippetPropsRaw from "./extended-types/slider/slider-root-children-snippet-props.md?raw";
 import {
 	NumberOrArrayNumberProp,
 	OrientationProp,
@@ -31,6 +33,7 @@ import {
 	defineNumberProp,
 	defineSimpleDataAttr,
 	defineUnionProp,
+	stringDefinitionFromMarkdown,
 } from "../utils.js";
 
 const orientationDataAttr = defineEnumDataAttr({
@@ -47,6 +50,7 @@ const sharedDataAttrs = [
 		description: "Present when the slider is disabled.",
 	}),
 ];
+
 
 const root = defineComponentApiSchema<SliderRootPropsWithoutHTML>({
 	title: "Root",
@@ -120,37 +124,11 @@ const root = defineComponentApiSchema<SliderRootPropsWithoutHTML>({
 			elType: "HTMLSpanElement",
 			child: {
 				definition: SliderRootChildSnippetProps,
-				stringDefinition: `type TickItem = {
-	/** The value this tick represents */
-	value: number;
-	/** The index of this tick */
-	index: number;
-};
-
-type ChildSnippetProps = {
-	/** The tick items to iterate over and render */
-	tickItems: TickItem[];
-	/** The currently active thumb */
-	thumbs: number[];
-	/** Props to apply to the root element */
-	props: Record<string, unknown>;
-};`,
+				stringDefinition: stringDefinitionFromMarkdown(sliderRootChildSnippetPropsRaw),
 			},
 			children: {
 				definition: SliderRootChildrenSnippetProps,
-				stringDefinition: `type TickItem = {
-	/** The value this tick represents */
-	value: number;
-	/** The index of this tick */
-	index: number;
-};
-
-type ChildrenSnippetProps = {
-	/** The tick items to iterate over and render */
-	tickItems: TickItem[];
-	/** The currently active thumb */
-	thumbs: number[];
-};`,
+				stringDefinition: stringDefinitionFromMarkdown(sliderRootChildrenSnippetPropsRaw),
 			},
 		}),
 	},

--- a/docs/src/lib/content/api-reference/switch.api.ts
+++ b/docs/src/lib/content/api-reference/switch.api.ts
@@ -5,12 +5,15 @@ import {
 	SwitchRootChildSnippetProps,
 	SwitchRootChildrenSnippetProps,
 } from "./extended-types/switch/index.js";
+import switchRootChildSnippetPropsRaw from "./extended-types/switch/switch-root-child-snippet-props.md?raw";
+import switchRootChildrenSnippetPropsRaw from "./extended-types/switch/switch-root-children-snippet-props.md?raw";
 import {
 	defineBooleanProp,
 	defineComponentApiSchema,
 	defineEnumDataAttr,
 	defineSimpleDataAttr,
 	defineStringProp,
+	stringDefinitionFromMarkdown,
 } from "../utils.js";
 
 const stateDataAttr = defineEnumDataAttr({
@@ -19,6 +22,7 @@ const stateDataAttr = defineEnumDataAttr({
 	options: ["checked", "unchecked"],
 	value: SwitchCheckedDataAttr,
 });
+
 
 const root = defineComponentApiSchema<SwitchRootPropsWithoutHTML>({
 	title: "Root",
@@ -46,16 +50,11 @@ const root = defineComponentApiSchema<SwitchRootPropsWithoutHTML>({
 			elType: "HTMLButtonElement",
 			children: {
 				definition: SwitchRootChildrenSnippetProps,
-				stringDefinition: `type ChildrenSnippetProps = {
-	checked: boolean;
-};`,
+				stringDefinition: stringDefinitionFromMarkdown(switchRootChildrenSnippetPropsRaw),
 			},
 			child: {
 				definition: SwitchRootChildSnippetProps,
-				stringDefinition: `type ChildSnippetProps = {
-	checked: boolean;
-	props: Record<string, unknown>;
-};`,
+				stringDefinition: stringDefinitionFromMarkdown(switchRootChildSnippetPropsRaw),
 			},
 		}),
 	},
@@ -83,16 +82,11 @@ const thumb = defineComponentApiSchema<SwitchThumbPropsWithoutHTML>({
 		elType: "HTMLSpanElement",
 		children: {
 			definition: SwitchRootChildrenSnippetProps,
-			stringDefinition: `type ChildrenSnippetProps = {
-	checked: boolean;
-};`,
+			stringDefinition: stringDefinitionFromMarkdown(switchRootChildrenSnippetPropsRaw),
 		},
 		child: {
 			definition: SwitchRootChildSnippetProps,
-			stringDefinition: `type ChildSnippetProps = {
-	checked: boolean;
-	props: Record<string, unknown>;
-};`,
+			stringDefinition: stringDefinitionFromMarkdown(switchRootChildSnippetPropsRaw),
 		},
 	}),
 	dataAttributes: [

--- a/docs/src/lib/content/api-reference/time-field.api.ts
+++ b/docs/src/lib/content/api-reference/time-field.api.ts
@@ -17,6 +17,8 @@ import {
 	TimeValidateProp,
 	TimeSegmentDataAttr,
 } from "./extended-types/shared/index.js";
+import timeFieldInputChildSnippetPropsRaw from "./extended-types/shared/time-field-input-child-snippet-props.md?raw";
+import timeFieldInputChildrenSnippetPropsRaw from "./extended-types/shared/time-field-input-children-snippet-props.md?raw";
 
 import { TimeFieldEditableSegmentPartProp } from "./extended-types/time-field/index.js";
 import {
@@ -29,7 +31,9 @@ import {
 	definePropSchema,
 	defineSimpleDataAttr,
 	defineStringProp,
+	stringDefinitionFromMarkdown,
 } from "../utils.js";
+
 
 export const root = defineComponentApiSchema<TimeFieldRootPropsWithoutHTML>({
 	title: "Root",
@@ -136,20 +140,11 @@ export const input = defineComponentApiSchema<TimeFieldInputPropsWithoutHTML>({
 			elType: "HTMLDivElement",
 			children: {
 				definition: TimeFieldInputChildrenSnippetProps,
-				stringDefinition: `import type { TimeSegmentPart } from "bits-ui";
-
-type ChildrenSnippetProps = {
-	segments: Array<{ part: TimeSegmentPart; value: string }>;
-};`,
+				stringDefinition: stringDefinitionFromMarkdown(timeFieldInputChildrenSnippetPropsRaw),
 			},
 			child: {
 				definition: TimeFieldInputChildSnippetProps,
-				stringDefinition: `import type { TimeSegmentPart } from "bits-ui";
-
-type ChildSnippetProps = {
-	props: Record<string, unknown>;
-	segments: Array<{ part: TimeSegmentPart; value: string }>;
-};`,
+				stringDefinition: stringDefinitionFromMarkdown(timeFieldInputChildSnippetPropsRaw),
 			},
 		}),
 	},

--- a/docs/src/lib/content/utils.ts
+++ b/docs/src/lib/content/utils.ts
@@ -299,3 +299,14 @@ export function defineSimpleDataAttr(
 export function defineCSSVarSchema(opts: CSSVarSchema) {
 	return opts;
 }
+
+/**
+ * Converts a fenced markdown code block imported via `?raw` into
+ * a plain string definition used by API schema prop helpers.
+ */
+export function stringDefinitionFromMarkdown(raw: string): string {
+	const fencedBlockMatch = raw
+		.trim()
+		.match(/^```[^\r\n]*\r?\n([\s\S]*?)\r?\n```$/);
+	return (fencedBlockMatch?.[1] ?? raw).trim();
+}

--- a/packages/bits-ui/src/lib/bits/menubar/components/menubar-menu.svelte
+++ b/packages/bits-ui/src/lib/bits/menubar/components/menubar-menu.svelte
@@ -25,6 +25,5 @@
 	_internal_variant="menubar"
 	{...restProps}
 	_internal_should_skip_exit_animation={() =>
-		menuState.root.skipExitAnimationForMenuValue === menuState.opts.value.current
-	}
+		menuState.root.skipExitAnimationForMenuValue === menuState.opts.value.current}
 />

--- a/packages/bits-ui/src/lib/bits/select/components/select-value.svelte
+++ b/packages/bits-ui/src/lib/bits/select/components/select-value.svelte
@@ -1,20 +1,41 @@
 <script lang="ts">
+	import { boxWith, mergeProps } from "svelte-toolbelt";
 	import { SelectValueState } from "../select.svelte.js";
 	import type { SelectValueProps } from "../types.js";
+	import { createId } from "$lib/internal/create-id.js";
 
-	let { child, ...restProps }: SelectValueProps = $props();
+	const uid = $props.id();
 
-	const valueState = SelectValueState.create();
+	let {
+		ref = $bindable(null),
+		id = createId(uid),
+		placeholder,
+		child,
+		...restProps
+	}: SelectValueProps = $props();
+
+	const valueState = SelectValueState.create({
+		id: boxWith(() => id),
+		ref: boxWith(
+			() => ref,
+			(v) => (ref = v)
+		),
+		placeholder: boxWith(() => placeholder),
+	});
+
+	const mergedProps = $derived(mergeProps(restProps, valueState.props));
 </script>
 
 {#if child}
-    {@render child({ ...valueState.snippetProps })}
+	{@render child({ ...mergedProps, ...valueState.snippetProps })}
 {:else}
-    <span {...restProps}>
-        {#if valueState.snippetProps.type === 'single'}
-            {valueState.snippetProps.selected.label}
-        {:else}
-            {valueState.snippetProps.selected.map((selected) => selected.label).join(', ')}
-        {/if}
-    </span>
+	<span {...mergedProps}>
+		{#if valueState.snippetProps.type === "single"}
+			{valueState.snippetProps.selected?.label ?? placeholder}
+		{:else if valueState.snippetProps.selected}
+			{valueState.snippetProps.selected.map((selected) => selected.label).join(", ")}
+		{:else}
+			{placeholder}
+		{/if}
+	</span>
 {/if}

--- a/packages/bits-ui/src/lib/bits/select/components/select-value.svelte
+++ b/packages/bits-ui/src/lib/bits/select/components/select-value.svelte
@@ -11,6 +11,7 @@
 		id = createId(uid),
 		placeholder,
 		child,
+		children,
 		...restProps
 	}: SelectValueProps = $props();
 
@@ -24,17 +25,22 @@
 	});
 
 	const mergedProps = $derived(mergeProps(restProps, valueState.props));
-	const childProps = $derived(mergeProps(mergedProps, valueState.snippetProps));
 </script>
 
 {#if child}
-	{@render child(childProps)}
+	{@render child({ props: mergedProps, ...valueState.snippetProps })}
 {:else}
 	<span {...mergedProps}>
-		{#if valueState.snippetProps.type === "single"}
-			{valueState.snippetProps.selected?.label ?? placeholder}
-		{:else if valueState.snippetProps.selected}
-			{valueState.snippetProps.selected.map((selected) => selected.label).join(", ")}
+		{#if children}
+			{@render children?.(valueState.snippetProps)}
+		{:else if valueState.snippetProps.selection.type === "single"}
+			{valueState.snippetProps.selection.selected?.label ?? placeholder}
+		{:else if valueState.snippetProps.selection.type === "multiple" && valueState.snippetProps.selection.selected}
+			{valueState.snippetProps.selection.selected.length > 0
+				? valueState.snippetProps.selection.selected
+						.map((selected) => selected.label)
+						.join(", ")
+				: placeholder}
 		{:else}
 			{placeholder}
 		{/if}

--- a/packages/bits-ui/src/lib/bits/select/components/select-value.svelte
+++ b/packages/bits-ui/src/lib/bits/select/components/select-value.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+	import { SelectValueState } from "../select.svelte.js";
+	import type { SelectValueProps } from "../types.js";
+
+	let { child, ...restProps }: SelectValueProps = $props();
+
+	const valueState = SelectValueState.create();
+</script>
+
+{#if child}
+    {@render child({ ...valueState.snippetProps })}
+{:else}
+    <span {...restProps}>
+        {#if valueState.snippetProps.type === 'single'}
+            {valueState.snippetProps.selected.label}
+        {:else}
+            {valueState.snippetProps.selected.map((selected) => selected.label).join(', ')}
+        {/if}
+    </span>
+{/if}

--- a/packages/bits-ui/src/lib/bits/select/components/select-value.svelte
+++ b/packages/bits-ui/src/lib/bits/select/components/select-value.svelte
@@ -24,10 +24,11 @@
 	});
 
 	const mergedProps = $derived(mergeProps(restProps, valueState.props));
+	const childProps = $derived(mergeProps(mergedProps, valueState.snippetProps));
 </script>
 
 {#if child}
-	{@render child({ ...mergedProps, ...valueState.snippetProps })}
+	{@render child(childProps)}
 {:else}
 	<span {...mergedProps}>
 		{#if valueState.snippetProps.type === "single"}

--- a/packages/bits-ui/src/lib/bits/select/exports.ts
+++ b/packages/bits-ui/src/lib/bits/select/exports.ts
@@ -1,4 +1,5 @@
 export { default as Root } from "./components/select.svelte";
+export { default as Value } from "./components/select-value.svelte";
 export { default as Content } from "./components/select-content.svelte";
 export { default as ContentStatic } from "./components/select-content-static.svelte";
 export { default as Item } from "./components/select-item.svelte";
@@ -12,6 +13,7 @@ export { default as ScrollDownButton } from "./components/select-scroll-down-but
 
 export type {
 	SelectRootProps as RootProps,
+	SelectValueProps as ValueProps,
 	SelectContentProps as ContentProps,
 	SelectContentStaticProps as ContentStaticProps,
 	SelectItemProps as ItemProps,

--- a/packages/bits-ui/src/lib/bits/select/select.svelte.ts
+++ b/packages/bits-ui/src/lib/bits/select/select.svelte.ts
@@ -38,6 +38,8 @@ import { getFloatingContentCSSVars } from "$lib/internal/floating-svelte/floatin
 import { DataTypeahead } from "$lib/internal/data-typeahead.svelte.js";
 import { DOMTypeahead } from "$lib/internal/dom-typeahead.svelte.js";
 import { PresenceManager } from "$lib/internal/presence-manager.svelte.js";
+import { DEV } from "esm-env";
+import type { SelectValueSnippetProps } from "./types.js";
 
 // prettier-ignore
 export const INTERACTION_KEYS = [kbd.ARROW_LEFT, kbd.ESCAPE, kbd.ARROW_RIGHT, kbd.SHIFT, kbd.CAPS_LOCK, kbd.CONTROL, kbd.ALT, kbd.META, kbd.ENTER, kbd.F1, kbd.F2, kbd.F3, kbd.F4, kbd.F5, kbd.F6, kbd.F7, kbd.F8, kbd.F9, kbd.F10, kbd.F11, kbd.F12];
@@ -75,19 +77,19 @@ const SelectContentContext = new Context<SelectContentState>("Select.Content | C
 
 interface SelectBaseRootStateOpts
 	extends ReadableBoxedValues<{
-			disabled: boolean;
-			required: boolean;
-			name: string;
-			loop: boolean;
-			scrollAlignment: "nearest" | "center";
-			items: { value: string; label: string; disabled?: boolean }[];
-			allowDeselect: boolean;
-			onOpenChangeComplete: OnChangeFn<boolean>;
-		}>,
-		WritableBoxedValues<{
-			open: boolean;
-			inputValue: string;
-		}> {
+		disabled: boolean;
+		required: boolean;
+		name: string;
+		loop: boolean;
+		scrollAlignment: "nearest" | "center";
+		items: { value: string; label: string; disabled?: boolean }[];
+		allowDeselect: boolean;
+		onOpenChangeComplete: OnChangeFn<boolean>;
+	}>,
+	WritableBoxedValues<{
+		open: boolean;
+		inputValue: string;
+	}> {
 	isCombobox: boolean;
 }
 
@@ -218,9 +220,9 @@ abstract class SelectBaseRootState {
 
 interface SelectSingleRootStateOpts
 	extends SelectBaseRootStateOpts,
-		WritableBoxedValues<{
-			value: string;
-		}> {}
+	WritableBoxedValues<{
+		value: string;
+	}> { }
 
 export class SelectSingleRootState extends SelectBaseRootState {
 	readonly opts: SelectSingleRootStateOpts;
@@ -298,9 +300,9 @@ export class SelectSingleRootState extends SelectBaseRootState {
 
 interface SelectMultipleRootStateOpts
 	extends SelectBaseRootStateOpts,
-		WritableBoxedValues<{
-			value: string[];
-		}> {}
+	WritableBoxedValues<{
+		value: string[];
+	}> { }
 
 class SelectMultipleRootState extends SelectBaseRootState {
 	readonly opts: SelectMultipleRootStateOpts;
@@ -363,19 +365,19 @@ class SelectMultipleRootState extends SelectBaseRootState {
 
 interface SelectRootStateOpts
 	extends ReadableBoxedValues<{
-			disabled: boolean;
-			required: boolean;
-			loop: boolean;
-			scrollAlignment: "nearest" | "center";
-			name: string;
-			items: { value: string; label: string; disabled?: boolean }[];
-			allowDeselect: boolean;
-			onOpenChangeComplete: OnChangeFn<boolean>;
-		}>,
-		WritableBoxedValues<{
-			open: boolean;
-			inputValue: string;
-		}> {
+		disabled: boolean;
+		required: boolean;
+		loop: boolean;
+		scrollAlignment: "nearest" | "center";
+		name: string;
+		items: { value: string; label: string; disabled?: boolean }[];
+		allowDeselect: boolean;
+		onOpenChangeComplete: OnChangeFn<boolean>;
+	}>,
+	WritableBoxedValues<{
+		open: boolean;
+		inputValue: string;
+	}> {
 	isCombobox: boolean;
 	type: "single" | "multiple";
 	value: Box<string> | Box<string[]>;
@@ -396,11 +398,44 @@ export class SelectRootState {
 
 type SelectRoot = SelectSingleRootState | SelectMultipleRootState;
 
+export class SelectValueState {
+	static create() {
+		return new SelectValueState(SelectRootContext.get());
+	}
+	readonly root: SelectRoot;
+
+	constructor(root: SelectRoot) {
+		this.root = root;
+		this.setValue = this.setValue.bind(this);
+	}
+
+	setValue(value: string | string[]) {
+		if (this.root.isMulti && !Array.isArray(value)) {
+			if (DEV) throw new Error(`Expected an array of strings passed to \`setValue\` got ${typeof value}.`);
+			return;
+		}
+		if (!this.root.isMulti && typeof value !== 'string') {
+			if (DEV) throw new Error(`Expected a string passed to \`setValue\` got ${typeof value}.`);
+			return;
+		}
+		this.root.opts.value.current = value;
+	}
+
+	// this way consumers get type narrowing for the value on `type`
+	readonly snippetProps = $derived.by(() => (
+		{
+			type: this.root.isMulti ? 'multiple' : 'single',
+			value: this.root.opts.value.current,
+			setValue: this.setValue,
+		} as SelectValueSnippetProps
+	))
+}
+
 interface SelectInputStateOpts
 	extends WithRefOpts,
-		ReadableBoxedValues<{
-			clearOnDeselect: boolean;
-		}> {}
+	ReadableBoxedValues<{
+		clearOnDeselect: boolean;
+	}> { }
 
 export class SelectInputState {
 	static create(opts: SelectInputStateOpts) {
@@ -559,7 +594,7 @@ export class SelectInputState {
 	);
 }
 
-interface SelectComboTriggerStateOpts extends WithRefOpts {}
+interface SelectComboTriggerStateOpts extends WithRefOpts { }
 
 export class SelectComboTriggerState {
 	static create(opts: SelectComboTriggerStateOpts) {
@@ -617,7 +652,7 @@ export class SelectComboTriggerState {
 	);
 }
 
-interface SelectTriggerStateOpts extends WithRefOpts {}
+interface SelectTriggerStateOpts extends WithRefOpts { }
 
 export class SelectTriggerState {
 	static create(opts: SelectTriggerStateOpts) {
@@ -883,10 +918,10 @@ export class SelectTriggerState {
 
 interface SelectContentStateOpts
 	extends WithRefOpts,
-		ReadableBoxedValues<{
-			onInteractOutside: (e: PointerEvent) => void;
-			onEscapeKeydown: (e: KeyboardEvent) => void;
-		}> {}
+	ReadableBoxedValues<{
+		onInteractOutside: (e: PointerEvent) => void;
+		onEscapeKeydown: (e: KeyboardEvent) => void;
+	}> { }
 
 export class SelectContentState {
 	static create(opts: SelectContentStateOpts) {
@@ -1011,13 +1046,13 @@ export class SelectContentState {
 
 interface SelectItemStateOpts
 	extends WithRefOpts,
-		ReadableBoxedValues<{
-			value: string;
-			disabled: boolean;
-			label: string;
-			onHighlight: () => void;
-			onUnhighlight: () => void;
-		}> {}
+	ReadableBoxedValues<{
+		value: string;
+		disabled: boolean;
+		label: string;
+		onHighlight: () => void;
+		onUnhighlight: () => void;
+	}> { }
 
 export class SelectItemState {
 	static create(opts: SelectItemStateOpts) {
@@ -1062,6 +1097,8 @@ export class SelectItemState {
 	handleSelect() {
 		if (this.opts.disabled.current) return;
 		const isCurrentSelectedValue = this.opts.value.current === this.root.opts.value.current;
+
+		console.log(this.opts.ref.current?.innerText)
 
 		// if allowDeselect is false and the item is already selected and we're not in a
 		// multi select, do nothing and close the menu
@@ -1149,7 +1186,7 @@ export class SelectItemState {
 				"data-disabled": boolToEmptyStrOrUndef(this.opts.disabled.current),
 				"data-highlighted":
 					this.root.highlightedValue === this.opts.value.current &&
-					!this.opts.disabled.current
+						!this.opts.disabled.current
 						? ""
 						: undefined,
 				"data-selected": this.root.includesItem(this.opts.value.current) ? "" : undefined,
@@ -1163,7 +1200,7 @@ export class SelectItemState {
 	);
 }
 
-interface SelectGroupStateOpts extends WithRefOpts {}
+interface SelectGroupStateOpts extends WithRefOpts { }
 
 export class SelectGroupState {
 	static create(opts: SelectGroupStateOpts) {
@@ -1192,7 +1229,7 @@ export class SelectGroupState {
 	);
 }
 
-interface SelectGroupHeadingStateOpts extends WithRefOpts {}
+interface SelectGroupHeadingStateOpts extends WithRefOpts { }
 
 export class SelectGroupHeadingState {
 	static create(opts: SelectGroupHeadingStateOpts) {
@@ -1221,7 +1258,7 @@ export class SelectGroupHeadingState {
 interface SelectHiddenInputStateOpts
 	extends ReadableBoxedValues<{
 		value: string | undefined;
-	}> {}
+	}> { }
 
 export class SelectHiddenInputState {
 	static create(opts: SelectHiddenInputStateOpts) {
@@ -1259,7 +1296,7 @@ export class SelectHiddenInputState {
 	);
 }
 
-interface SelectViewportStateOpts extends WithRefOpts {}
+interface SelectViewportStateOpts extends WithRefOpts { }
 
 export class SelectViewportState {
 	static create(opts: SelectViewportStateOpts) {
@@ -1301,9 +1338,9 @@ export class SelectViewportState {
 
 interface SelectScrollButtonImplStateOpts
 	extends WithRefOpts,
-		ReadableBoxedValues<{
-			delay: (tick: number) => number;
-		}> {}
+	ReadableBoxedValues<{
+		delay: (tick: number) => number;
+	}> { }
 
 export class SelectScrollButtonImplState {
 	readonly opts: SelectScrollButtonImplStateOpts;

--- a/packages/bits-ui/src/lib/bits/select/select.svelte.ts
+++ b/packages/bits-ui/src/lib/bits/select/select.svelte.ts
@@ -467,6 +467,7 @@ export class SelectValueState {
 						: undefined,
 				placeholder: this.opts.placeholder.current,
 				setValue: this.setValue,
+				disabled: this.root.opts.disabled.current,
 			};
 		}
 		const value = this.root.opts.value.current;
@@ -481,6 +482,7 @@ export class SelectValueState {
 					: undefined,
 			placeholder: this.opts.placeholder.current,
 			setValue: this.setValue,
+			disabled: this.root.opts.disabled.current,
 		};
 	});
 

--- a/packages/bits-ui/src/lib/bits/select/select.svelte.ts
+++ b/packages/bits-ui/src/lib/bits/select/select.svelte.ts
@@ -457,31 +457,32 @@ export class SelectValueState {
 	readonly snippetProps: SelectValueSnippetProps = $derived.by(() => {
 		if (this.root.isMulti) {
 			return {
-				type: "multiple" as const,
-				selected:
-					this.root.opts.value.current.length > 0
-						? this.root.opts.value.current.map((value) => ({
-								value,
-								label: this.root.getLabelForValue(value),
-							}))
-						: undefined,
-				placeholder: this.opts.placeholder.current,
-				setValue: this.setValue,
+				selection: {
+					type: "multiple" as const,
+					selected:
+						this.root.opts.value.current.length > 0
+							? this.root.opts.value.current.map((value) => ({
+									value,
+									label: this.root.getLabelForValue(value),
+								}))
+							: [],
+					setValue: this.setValue,
+				},
+				placeholder: this.opts.placeholder.current ?? null,
 				disabled: this.root.opts.disabled.current,
 			};
 		}
 		const value = this.root.opts.value.current;
 		return {
-			type: "single" as const,
-			selected:
-				value !== ""
-					? {
-							value,
-							label: value === "" ? "" : this.root.getLabelForValue(value),
-						}
-					: undefined,
-			placeholder: this.opts.placeholder.current,
-			setValue: this.setValue,
+			selection: {
+				type: "single" as const,
+				selected:
+					value !== ""
+						? { value, label: value === "" ? "" : this.root.getLabelForValue(value) }
+						: undefined,
+				setValue: this.setValue,
+			},
+			placeholder: this.opts.placeholder.current ?? null,
 			disabled: this.root.opts.disabled.current,
 		};
 	});

--- a/packages/bits-ui/src/lib/bits/select/select.svelte.ts
+++ b/packages/bits-ui/src/lib/bits/select/select.svelte.ts
@@ -101,6 +101,7 @@ abstract class SelectBaseRootState {
 	contentPresence: PresenceManager;
 	viewportNode = $state<HTMLElement | null>(null);
 	triggerNode = $state<HTMLElement | null>(null);
+	valueNode = $state<HTMLElement | null>(null);
 	valueId = $state("");
 	highlightedNode = $state<HTMLElement | null>(null);
 	readonly highlightedValue = $derived.by(() => {
@@ -190,6 +191,23 @@ abstract class SelectBaseRootState {
 	getNodeByValue(value: string): HTMLElement | null {
 		const candidateNodes = this.getCandidateNodes();
 		return candidateNodes.find((node) => node.dataset.value === value) ?? null;
+	}
+
+	/**
+	 * Resolves the display label for a value: `items` entry when present, otherwise the
+	 * mounted item's `data-label` or its text content.
+	 */
+	getLabelForValue(value: string): string {
+		if (value === "") return "";
+		const fromItems = this.opts.items.current.find((item) => item.value === value)?.label;
+		if (fromItems !== undefined) return fromItems;
+		const node = this.getNodeByValue(value);
+		if (node) {
+			const dataLabel = node.getAttribute("data-label");
+			if (dataLabel !== null && dataLabel !== "") return dataLabel;
+			return node.textContent?.trim() ?? value;
+		}
+		return value;
 	}
 
 	setOpen(open: boolean) {
@@ -398,14 +416,22 @@ export class SelectRootState {
 
 type SelectRoot = SelectSingleRootState | SelectMultipleRootState;
 
+type SelectValueStateProps = WithRefOpts<ReadableBoxedValues<{
+	placeholder: string | null | undefined;
+}>>
+
 export class SelectValueState {
-	static create() {
-		return new SelectValueState(SelectRootContext.get());
+	static create(opts: SelectValueStateProps) {
+		return new SelectValueState(opts, SelectRootContext.get());
 	}
 	readonly root: SelectRoot;
+	readonly opts: SelectValueStateProps;
+	readonly attachment: RefAttachment;
 
-	constructor(root: SelectRoot) {
+	constructor(opts: SelectValueStateProps, root: SelectRoot) {
 		this.root = root;
+		this.opts = opts;
+		this.attachment = attachRef(opts.ref, (v) => (this.root.valueNode = v));
 		this.setValue = this.setValue.bind(this);
 	}
 
@@ -422,13 +448,36 @@ export class SelectValueState {
 	}
 
 	// this way consumers get type narrowing for the value on `type`
-	readonly snippetProps = $derived.by(() => (
-		{
-			type: this.root.isMulti ? 'multiple' : 'single',
-			value: this.root.opts.value.current,
+	readonly snippetProps: SelectValueSnippetProps = $derived.by(() => {
+		if (this.root.isMulti) {
+			return {
+				type: "multiple" as const,
+				selected: this.root.opts.value.current.length > 0 ? this.root.opts.value.current.map((value) => ({
+					value,
+					label: this.root.getLabelForValue(value),
+				})) : undefined,
+				placeholder: this.opts.placeholder.current,
+				setValue: this.setValue,
+			};
+		}
+		const value = this.root.opts.value.current;
+		return {
+			type: "single" as const,
+			selected: value !== "" ? {
+				value,
+				label: value === "" ? "" : this.root.getLabelForValue(value),
+			} : undefined,
+			placeholder: this.opts.placeholder.current,
 			setValue: this.setValue,
-		} as SelectValueSnippetProps
-	))
+		};
+	});
+
+	readonly props = $derived.by(() => ({
+		id: this.opts.id.current,
+		'data-placeholder': this.root.hasValue ? undefined : "",
+		'data-select-value': '',
+		...this.attachment,
+	}));
 }
 
 interface SelectInputStateOpts
@@ -1097,8 +1146,6 @@ export class SelectItemState {
 	handleSelect() {
 		if (this.opts.disabled.current) return;
 		const isCurrentSelectedValue = this.opts.value.current === this.root.opts.value.current;
-
-		console.log(this.opts.ref.current?.innerText)
 
 		// if allowDeselect is false and the item is already selected and we're not in a
 		// multi select, do nothing and close the menu

--- a/packages/bits-ui/src/lib/bits/select/select.svelte.ts
+++ b/packages/bits-ui/src/lib/bits/select/select.svelte.ts
@@ -77,19 +77,19 @@ const SelectContentContext = new Context<SelectContentState>("Select.Content | C
 
 interface SelectBaseRootStateOpts
 	extends ReadableBoxedValues<{
-		disabled: boolean;
-		required: boolean;
-		name: string;
-		loop: boolean;
-		scrollAlignment: "nearest" | "center";
-		items: { value: string; label: string; disabled?: boolean }[];
-		allowDeselect: boolean;
-		onOpenChangeComplete: OnChangeFn<boolean>;
-	}>,
-	WritableBoxedValues<{
-		open: boolean;
-		inputValue: string;
-	}> {
+			disabled: boolean;
+			required: boolean;
+			name: string;
+			loop: boolean;
+			scrollAlignment: "nearest" | "center";
+			items: { value: string; label: string; disabled?: boolean }[];
+			allowDeselect: boolean;
+			onOpenChangeComplete: OnChangeFn<boolean>;
+		}>,
+		WritableBoxedValues<{
+			open: boolean;
+			inputValue: string;
+		}> {
 	isCombobox: boolean;
 }
 
@@ -238,9 +238,9 @@ abstract class SelectBaseRootState {
 
 interface SelectSingleRootStateOpts
 	extends SelectBaseRootStateOpts,
-	WritableBoxedValues<{
-		value: string;
-	}> { }
+		WritableBoxedValues<{
+			value: string;
+		}> {}
 
 export class SelectSingleRootState extends SelectBaseRootState {
 	readonly opts: SelectSingleRootStateOpts;
@@ -318,9 +318,9 @@ export class SelectSingleRootState extends SelectBaseRootState {
 
 interface SelectMultipleRootStateOpts
 	extends SelectBaseRootStateOpts,
-	WritableBoxedValues<{
-		value: string[];
-	}> { }
+		WritableBoxedValues<{
+			value: string[];
+		}> {}
 
 class SelectMultipleRootState extends SelectBaseRootState {
 	readonly opts: SelectMultipleRootStateOpts;
@@ -383,19 +383,19 @@ class SelectMultipleRootState extends SelectBaseRootState {
 
 interface SelectRootStateOpts
 	extends ReadableBoxedValues<{
-		disabled: boolean;
-		required: boolean;
-		loop: boolean;
-		scrollAlignment: "nearest" | "center";
-		name: string;
-		items: { value: string; label: string; disabled?: boolean }[];
-		allowDeselect: boolean;
-		onOpenChangeComplete: OnChangeFn<boolean>;
-	}>,
-	WritableBoxedValues<{
-		open: boolean;
-		inputValue: string;
-	}> {
+			disabled: boolean;
+			required: boolean;
+			loop: boolean;
+			scrollAlignment: "nearest" | "center";
+			name: string;
+			items: { value: string; label: string; disabled?: boolean }[];
+			allowDeselect: boolean;
+			onOpenChangeComplete: OnChangeFn<boolean>;
+		}>,
+		WritableBoxedValues<{
+			open: boolean;
+			inputValue: string;
+		}> {
 	isCombobox: boolean;
 	type: "single" | "multiple";
 	value: Box<string> | Box<string[]>;
@@ -416,9 +416,11 @@ export class SelectRootState {
 
 type SelectRoot = SelectSingleRootState | SelectMultipleRootState;
 
-type SelectValueStateProps = WithRefOpts<ReadableBoxedValues<{
-	placeholder: string | null | undefined;
-}>>
+type SelectValueStateProps = WithRefOpts<
+	ReadableBoxedValues<{
+		placeholder: string | null | undefined;
+	}>
+>;
 
 export class SelectValueState {
 	static create(opts: SelectValueStateProps) {
@@ -437,11 +439,15 @@ export class SelectValueState {
 
 	setValue(value: string | string[]) {
 		if (this.root.isMulti && !Array.isArray(value)) {
-			if (DEV) throw new Error(`Expected an array of strings passed to \`setValue\` got ${typeof value}.`);
+			if (DEV)
+				throw new Error(
+					`Expected an array of strings passed to \`setValue\` got ${typeof value}.`
+				);
 			return;
 		}
-		if (!this.root.isMulti && typeof value !== 'string') {
-			if (DEV) throw new Error(`Expected a string passed to \`setValue\` got ${typeof value}.`);
+		if (!this.root.isMulti && typeof value !== "string") {
+			if (DEV)
+				throw new Error(`Expected a string passed to \`setValue\` got ${typeof value}.`);
 			return;
 		}
 		this.root.opts.value.current = value;
@@ -452,10 +458,13 @@ export class SelectValueState {
 		if (this.root.isMulti) {
 			return {
 				type: "multiple" as const,
-				selected: this.root.opts.value.current.length > 0 ? this.root.opts.value.current.map((value) => ({
-					value,
-					label: this.root.getLabelForValue(value),
-				})) : undefined,
+				selected:
+					this.root.opts.value.current.length > 0
+						? this.root.opts.value.current.map((value) => ({
+								value,
+								label: this.root.getLabelForValue(value),
+							}))
+						: undefined,
 				placeholder: this.opts.placeholder.current,
 				setValue: this.setValue,
 			};
@@ -463,10 +472,13 @@ export class SelectValueState {
 		const value = this.root.opts.value.current;
 		return {
 			type: "single" as const,
-			selected: value !== "" ? {
-				value,
-				label: value === "" ? "" : this.root.getLabelForValue(value),
-			} : undefined,
+			selected:
+				value !== ""
+					? {
+							value,
+							label: value === "" ? "" : this.root.getLabelForValue(value),
+						}
+					: undefined,
 			placeholder: this.opts.placeholder.current,
 			setValue: this.setValue,
 		};
@@ -474,17 +486,17 @@ export class SelectValueState {
 
 	readonly props = $derived.by(() => ({
 		id: this.opts.id.current,
-		'data-placeholder': this.root.hasValue ? undefined : "",
-		'data-select-value': '',
+		"data-placeholder": this.root.hasValue ? undefined : "",
+		"data-select-value": "",
 		...this.attachment,
 	}));
 }
 
 interface SelectInputStateOpts
 	extends WithRefOpts,
-	ReadableBoxedValues<{
-		clearOnDeselect: boolean;
-	}> { }
+		ReadableBoxedValues<{
+			clearOnDeselect: boolean;
+		}> {}
 
 export class SelectInputState {
 	static create(opts: SelectInputStateOpts) {
@@ -643,7 +655,7 @@ export class SelectInputState {
 	);
 }
 
-interface SelectComboTriggerStateOpts extends WithRefOpts { }
+interface SelectComboTriggerStateOpts extends WithRefOpts {}
 
 export class SelectComboTriggerState {
 	static create(opts: SelectComboTriggerStateOpts) {
@@ -701,7 +713,7 @@ export class SelectComboTriggerState {
 	);
 }
 
-interface SelectTriggerStateOpts extends WithRefOpts { }
+interface SelectTriggerStateOpts extends WithRefOpts {}
 
 export class SelectTriggerState {
 	static create(opts: SelectTriggerStateOpts) {
@@ -967,10 +979,10 @@ export class SelectTriggerState {
 
 interface SelectContentStateOpts
 	extends WithRefOpts,
-	ReadableBoxedValues<{
-		onInteractOutside: (e: PointerEvent) => void;
-		onEscapeKeydown: (e: KeyboardEvent) => void;
-	}> { }
+		ReadableBoxedValues<{
+			onInteractOutside: (e: PointerEvent) => void;
+			onEscapeKeydown: (e: KeyboardEvent) => void;
+		}> {}
 
 export class SelectContentState {
 	static create(opts: SelectContentStateOpts) {
@@ -1095,13 +1107,13 @@ export class SelectContentState {
 
 interface SelectItemStateOpts
 	extends WithRefOpts,
-	ReadableBoxedValues<{
-		value: string;
-		disabled: boolean;
-		label: string;
-		onHighlight: () => void;
-		onUnhighlight: () => void;
-	}> { }
+		ReadableBoxedValues<{
+			value: string;
+			disabled: boolean;
+			label: string;
+			onHighlight: () => void;
+			onUnhighlight: () => void;
+		}> {}
 
 export class SelectItemState {
 	static create(opts: SelectItemStateOpts) {
@@ -1233,7 +1245,7 @@ export class SelectItemState {
 				"data-disabled": boolToEmptyStrOrUndef(this.opts.disabled.current),
 				"data-highlighted":
 					this.root.highlightedValue === this.opts.value.current &&
-						!this.opts.disabled.current
+					!this.opts.disabled.current
 						? ""
 						: undefined,
 				"data-selected": this.root.includesItem(this.opts.value.current) ? "" : undefined,
@@ -1247,7 +1259,7 @@ export class SelectItemState {
 	);
 }
 
-interface SelectGroupStateOpts extends WithRefOpts { }
+interface SelectGroupStateOpts extends WithRefOpts {}
 
 export class SelectGroupState {
 	static create(opts: SelectGroupStateOpts) {
@@ -1276,7 +1288,7 @@ export class SelectGroupState {
 	);
 }
 
-interface SelectGroupHeadingStateOpts extends WithRefOpts { }
+interface SelectGroupHeadingStateOpts extends WithRefOpts {}
 
 export class SelectGroupHeadingState {
 	static create(opts: SelectGroupHeadingStateOpts) {
@@ -1305,7 +1317,7 @@ export class SelectGroupHeadingState {
 interface SelectHiddenInputStateOpts
 	extends ReadableBoxedValues<{
 		value: string | undefined;
-	}> { }
+	}> {}
 
 export class SelectHiddenInputState {
 	static create(opts: SelectHiddenInputStateOpts) {
@@ -1343,7 +1355,7 @@ export class SelectHiddenInputState {
 	);
 }
 
-interface SelectViewportStateOpts extends WithRefOpts { }
+interface SelectViewportStateOpts extends WithRefOpts {}
 
 export class SelectViewportState {
 	static create(opts: SelectViewportStateOpts) {
@@ -1385,9 +1397,9 @@ export class SelectViewportState {
 
 interface SelectScrollButtonImplStateOpts
 	extends WithRefOpts,
-	ReadableBoxedValues<{
-		delay: (tick: number) => number;
-	}> { }
+		ReadableBoxedValues<{
+			delay: (tick: number) => number;
+		}> {}
 
 export class SelectScrollButtonImplState {
 	readonly opts: SelectScrollButtonImplStateOpts;

--- a/packages/bits-ui/src/lib/bits/select/types.ts
+++ b/packages/bits-ui/src/lib/bits/select/types.ts
@@ -166,15 +166,19 @@ export type SelectRootProps = SelectRootPropsWithoutHTML;
 
 export type SelectValueSnippetProps = {
 	type: 'single',
-	selected: { value: string, label: string },
+	placeholder?: string | null,
+	selected?: { value: string, label: string },
 	setValue: (value: string) => void
 } | {
 	type: 'multiple',
-	selected: { value: string, label: string }[],
+	placeholder?: string | null,
+	selected?: { value: string, label: string }[],
 	setValue: (value: string[]) => void
 }
 
 export type SelectValuePropsWithoutHTML = {
+	placeholder?: string | null;
+	ref?: HTMLSpanElement | null | undefined;
 	child?: Snippet<[SelectValueSnippetProps]>
 }
 

--- a/packages/bits-ui/src/lib/bits/select/types.ts
+++ b/packages/bits-ui/src/lib/bits/select/types.ts
@@ -176,10 +176,19 @@ export type SelectValueSnippetProps = {
 	setValue: (value: string[]) => void
 }
 
-export type SelectValuePropsWithoutHTML = {
+type SelectValueHeadlessKeys = {
 	placeholder?: string | null;
 	ref?: HTMLSpanElement | null | undefined;
-	child?: Snippet<[SelectValueSnippetProps]>
+};
+
+export type SelectValueChildSnippetProps = Expand<
+	SelectValueSnippetProps &
+		Without<BitsPrimitiveSpanAttributes, SelectValueHeadlessKeys & { child?: unknown }> &
+		Pick<SelectValueHeadlessKeys, 'ref'>
+>;
+
+export type SelectValuePropsWithoutHTML = SelectValueHeadlessKeys & {
+	child?: Snippet<[SelectValueChildSnippetProps]>
 }
 
 export type SelectValueProps = SelectValuePropsWithoutHTML &

--- a/packages/bits-ui/src/lib/bits/select/types.ts
+++ b/packages/bits-ui/src/lib/bits/select/types.ts
@@ -16,7 +16,6 @@ import type {
 } from "$lib/internal/types.js";
 import type { FloatingContentSnippetProps, StaticContentSnippetProps } from "$lib/shared/types.js";
 import type { HTMLInputAttributes } from "svelte/elements";
-import type { Snippet } from "svelte";
 
 export type SelectBaseRootPropsWithoutHTML = WithChildren<{
 	/**

--- a/packages/bits-ui/src/lib/bits/select/types.ts
+++ b/packages/bits-ui/src/lib/bits/select/types.ts
@@ -177,6 +177,7 @@ export type SelectValueSnippetProps = (
 	placeholder?: string | null;
 	// we don't have this inside the union because typescript will sometimes do weird things like making the signature setValue(value: string & string[]) => void
 	setValue: (value: string | string[]) => void;
+	disabled: boolean;
 };
 
 type SelectValueHeadlessKeys = {

--- a/packages/bits-ui/src/lib/bits/select/types.ts
+++ b/packages/bits-ui/src/lib/bits/select/types.ts
@@ -164,17 +164,20 @@ export type SelectRootPropsWithoutHTML = SelectBaseRootPropsWithoutHTML &
 
 export type SelectRootProps = SelectRootPropsWithoutHTML;
 
-export type SelectValueSnippetProps = {
-	type: 'single',
-	placeholder?: string | null,
-	selected?: { value: string, label: string },
-	setValue: (value: string) => void
-} | {
-	type: 'multiple',
-	placeholder?: string | null,
-	selected?: { value: string, label: string }[],
-	setValue: (value: string[]) => void
-}
+export type SelectValueSnippetProps = (
+	| {
+			type: "single";
+			selected?: { value: string; label: string };
+	  }
+	| {
+			type: "multiple";
+			selected?: { value: string; label: string }[];
+	  }
+) & {
+	placeholder?: string | null;
+	// we don't have this inside the union because typescript will sometimes do weird things like making the signature setValue(value: string & string[]) => void
+	setValue: (value: string | string[]) => void;
+};
 
 type SelectValueHeadlessKeys = {
 	placeholder?: string | null;
@@ -184,12 +187,12 @@ type SelectValueHeadlessKeys = {
 export type SelectValueChildSnippetProps = Expand<
 	SelectValueSnippetProps &
 		Without<BitsPrimitiveSpanAttributes, SelectValueHeadlessKeys & { child?: unknown }> &
-		Pick<SelectValueHeadlessKeys, 'ref'>
+		Pick<SelectValueHeadlessKeys, "ref">
 >;
 
 export type SelectValuePropsWithoutHTML = SelectValueHeadlessKeys & {
-	child?: Snippet<[SelectValueChildSnippetProps]>
-}
+	child?: Snippet<[SelectValueChildSnippetProps]>;
+};
 
 export type SelectValueProps = SelectValuePropsWithoutHTML &
 	Without<BitsPrimitiveSpanAttributes, SelectValuePropsWithoutHTML>;

--- a/packages/bits-ui/src/lib/bits/select/types.ts
+++ b/packages/bits-ui/src/lib/bits/select/types.ts
@@ -5,6 +5,7 @@ import type { ArrowProps, ArrowPropsWithoutHTML } from "../utilities/arrow/types
 import type {
 	BitsPrimitiveButtonAttributes,
 	BitsPrimitiveDivAttributes,
+	BitsPrimitiveSpanAttributes,
 } from "$lib/shared/attributes.js";
 import type {
 	OnChangeFn,
@@ -15,6 +16,7 @@ import type {
 } from "$lib/internal/types.js";
 import type { FloatingContentSnippetProps, StaticContentSnippetProps } from "$lib/shared/types.js";
 import type { HTMLInputAttributes } from "svelte/elements";
+import type { Snippet } from "svelte";
 
 export type SelectBaseRootPropsWithoutHTML = WithChildren<{
 	/**
@@ -161,6 +163,23 @@ export type SelectRootPropsWithoutHTML = SelectBaseRootPropsWithoutHTML &
 	(SelectSingleRootPropsWithoutHTML | SelectMultipleRootPropsWithoutHTML);
 
 export type SelectRootProps = SelectRootPropsWithoutHTML;
+
+export type SelectValueSnippetProps = {
+	type: 'single',
+	selected: { value: string, label: string },
+	setValue: (value: string) => void
+} | {
+	type: 'multiple',
+	selected: { value: string, label: string }[],
+	setValue: (value: string[]) => void
+}
+
+export type SelectValuePropsWithoutHTML = {
+	child?: Snippet<[SelectValueSnippetProps]>
+}
+
+export type SelectValueProps = SelectValuePropsWithoutHTML &
+	Without<BitsPrimitiveSpanAttributes, SelectValuePropsWithoutHTML>;
 
 export type _SharedSelectContentProps = {
 	/**

--- a/packages/bits-ui/src/lib/bits/select/types.ts
+++ b/packages/bits-ui/src/lib/bits/select/types.ts
@@ -164,36 +164,23 @@ export type SelectRootPropsWithoutHTML = SelectBaseRootPropsWithoutHTML &
 
 export type SelectRootProps = SelectRootPropsWithoutHTML;
 
-export type SelectValueSnippetProps = (
-	| {
-			type: "single";
-			selected?: { value: string; label: string };
-	  }
-	| {
-			type: "multiple";
-			selected?: { value: string; label: string }[];
-	  }
-) & {
-	placeholder?: string | null;
-	// we don't have this inside the union because typescript will sometimes do weird things like making the signature setValue(value: string & string[]) => void
-	setValue: (value: string | string[]) => void;
+export type SelectValueSnippetProps = {
+	selection:
+		| {
+				type: "single";
+				selected?: { value: string; label: string };
+				setValue: (value: string) => void;
+		  }
+		| {
+				type: "multiple";
+				selected: { value: string; label: string }[];
+				setValue: (value: string[]) => void;
+		  };
+	placeholder: string | null;
 	disabled: boolean;
 };
 
-type SelectValueHeadlessKeys = {
-	placeholder?: string | null;
-	ref?: HTMLSpanElement | null | undefined;
-};
-
-export type SelectValueChildSnippetProps = Expand<
-	SelectValueSnippetProps &
-		Without<BitsPrimitiveSpanAttributes, SelectValueHeadlessKeys & { child?: unknown }> &
-		Pick<SelectValueHeadlessKeys, "ref">
->;
-
-export type SelectValuePropsWithoutHTML = SelectValueHeadlessKeys & {
-	child?: Snippet<[SelectValueChildSnippetProps]>;
-};
+export type SelectValuePropsWithoutHTML = WithChild<{}, SelectValueSnippetProps>;
 
 export type SelectValueProps = SelectValuePropsWithoutHTML &
 	Without<BitsPrimitiveSpanAttributes, SelectValuePropsWithoutHTML>;

--- a/packages/bits-ui/src/lib/bits/tooltip/types.ts
+++ b/packages/bits-ui/src/lib/bits/tooltip/types.ts
@@ -75,66 +75,66 @@ export type TooltipProviderProps = TooltipProviderPropsWithoutHTML;
 
 export type TooltipRootPropsWithoutHTML<Payload = never> = Omit<
 	WithChildren<{
-	/**
-	 * The open state of the tooltip.
-	 *
-	 * @defaultValue false
-	 */
-	open?: boolean;
+		/**
+		 * The open state of the tooltip.
+		 *
+		 * @defaultValue false
+		 */
+		open?: boolean;
 
-	/**
-	 * A callback that will be called when the tooltip is opened or closed.
-	 */
-	onOpenChange?: OnChangeFn<boolean>;
+		/**
+		 * A callback that will be called when the tooltip is opened or closed.
+		 */
+		onOpenChange?: OnChangeFn<boolean>;
 
-	/**
-	 * A callback that will be called when the tooltip is opened or closed.
-	 */
-	onOpenChangeComplete?: OnChangeFn<boolean>;
+		/**
+		 * A callback that will be called when the tooltip is opened or closed.
+		 */
+		onOpenChangeComplete?: OnChangeFn<boolean>;
 
-	/**
-	 * The delay in milliseconds before the tooltip opens.
-	 *
-	 * @defaultValue 700
-	 */
-	delayDuration?: number;
+		/**
+		 * The delay in milliseconds before the tooltip opens.
+		 *
+		 * @defaultValue 700
+		 */
+		delayDuration?: number;
 
-	/**
-	 * Prevents tooltip from remaining open when hovering over the content.
-	 *
-	 * @defaultValue false
-	 */
-	disableHoverableContent?: boolean;
+		/**
+		 * Prevents tooltip from remaining open when hovering over the content.
+		 *
+		 * @defaultValue false
+		 */
+		disableHoverableContent?: boolean;
 
-	/**
-	 * When `true`, the tooltip will not close when you click on the trigger.
-	 *
-	 * @defaultValue false
-	 */
-	disableCloseOnTriggerClick?: boolean;
+		/**
+		 * When `true`, the tooltip will not close when you click on the trigger.
+		 *
+		 * @defaultValue false
+		 */
+		disableCloseOnTriggerClick?: boolean;
 
-	/**
-	 * When `true`, the tooltip will be disabled and will not open.
-	 *
-	 * @defaultValue false
-	 */
-	disabled?: boolean;
+		/**
+		 * When `true`, the tooltip will be disabled and will not open.
+		 *
+		 * @defaultValue false
+		 */
+		disabled?: boolean;
 
-	/**
-	 * Prevent the tooltip from opening if the focus did not come using
-	 * the keyboard.
-	 *
-	 * @defaultValue false
-	 */
-	ignoreNonKeyboardFocus?: boolean;
-	/**
-	 * The active trigger id for controlled single tooltip mode.
-	 */
-	triggerId?: string | null;
-	/**
-	 * Shared tether used to connect detached triggers and infer payload types.
-	 */
-	tether?: TooltipTether<Payload> | undefined;
+		/**
+		 * Prevent the tooltip from opening if the focus did not come using
+		 * the keyboard.
+		 *
+		 * @defaultValue false
+		 */
+		ignoreNonKeyboardFocus?: boolean;
+		/**
+		 * The active trigger id for controlled single tooltip mode.
+		 */
+		triggerId?: string | null;
+		/**
+		 * Shared tether used to connect detached triggers and infer payload types.
+		 */
+		tether?: TooltipTether<Payload> | undefined;
 	}>,
 	"children"
 > & {

--- a/packages/bits-ui/src/lib/bits/utilities/floating-layer/use-floating-layer.svelte.ts
+++ b/packages/bits-ui/src/lib/bits/utilities/floating-layer/use-floating-layer.svelte.ts
@@ -299,7 +299,8 @@ export class FloatingContentState {
 				const win = getWindow(contentNode);
 				const rafId = win.requestAnimationFrame(() => {
 					// avoid applying stale values when refs change quickly
-					if (this.contentRef.current !== contentNode || !this.opts.enabled.current) return;
+					if (this.contentRef.current !== contentNode || !this.opts.enabled.current)
+						return;
 					const zIndex = win.getComputedStyle(contentNode).zIndex;
 					if (zIndex !== this.contentZIndex) {
 						this.contentZIndex = zIndex;

--- a/packages/bits-ui/src/lib/bits/utilities/popper-layer/popper-layer-inner.svelte
+++ b/packages/bits-ui/src/lib/bits/utilities/popper-layer/popper-layer-inner.svelte
@@ -54,9 +54,7 @@
 	} = $props();
 
 	const resolvedPreventScroll = $derived(preventScroll ?? true);
-	const effectiveStrategy = $derived(
-		strategy ?? (resolvedPreventScroll ? "fixed" : "absolute")
-	);
+	const effectiveStrategy = $derived(strategy ?? (resolvedPreventScroll ? "fixed" : "absolute"));
 </script>
 
 <PopperContent

--- a/packages/bits-ui/src/lib/bits/utilities/presence-layer/presence-layer.svelte
+++ b/packages/bits-ui/src/lib/bits/utilities/presence-layer/presence-layer.svelte
@@ -12,9 +12,8 @@
 </script>
 
 {#if forceMount || open || presenceState.isPresent}
-	{@render
-		presence?.({
-			present: presenceState.isPresent,
-			transitionStatus: presenceState.transitionStatus,
-		})}
+	{@render presence?.({
+		present: presenceState.isPresent,
+		transitionStatus: presenceState.transitionStatus,
+	})}
 {/if}

--- a/tests/src/tests/collapsible/collapsible.browser.test.ts
+++ b/tests/src/tests/collapsible/collapsible.browser.test.ts
@@ -81,10 +81,14 @@ describe("Collapsible ", () => {
 			const observer = observeTransitionAttrs(t.content.element());
 
 			await t.trigger.click();
-			await vi.waitFor(() => expect(observer.history.some((entry) => entry.starting)).toBe(true));
+			await vi.waitFor(() =>
+				expect(observer.history.some((entry) => entry.starting)).toBe(true)
+			);
 
 			await t.trigger.click();
-			await vi.waitFor(() => expect(observer.history.some((entry) => entry.ending)).toBe(true));
+			await vi.waitFor(() =>
+				expect(observer.history.some((entry) => entry.ending)).toBe(true)
+			);
 
 			observer.disconnect();
 		});

--- a/tests/src/tests/context-menu/context-menu-nested-submenu-test.svelte
+++ b/tests/src/tests/context-menu/context-menu-nested-submenu-test.svelte
@@ -7,18 +7,14 @@
 	<ContextMenu.Portal>
 		<ContextMenu.Content data-testid="content">
 			<ContextMenu.Sub>
-				<ContextMenu.SubTrigger data-testid="sub-trigger">
-					Sub
-				</ContextMenu.SubTrigger>
+				<ContextMenu.SubTrigger data-testid="sub-trigger">Sub</ContextMenu.SubTrigger>
 				<ContextMenu.SubContent data-testid="sub-content">
 					<ContextMenu.Sub>
 						<ContextMenu.SubTrigger data-testid="sub-sub-trigger">
 							Sub-sub
 						</ContextMenu.SubTrigger>
 						<ContextMenu.SubContent data-testid="sub-sub-content">
-							<ContextMenu.Item data-testid="sub-sub-item">
-								Hello
-							</ContextMenu.Item>
+							<ContextMenu.Item data-testid="sub-sub-item">Hello</ContextMenu.Item>
 						</ContextMenu.SubContent>
 					</ContextMenu.Sub>
 				</ContextMenu.SubContent>

--- a/tests/src/tests/dialog/dialog.browser.test.ts
+++ b/tests/src/tests/dialog/dialog.browser.test.ts
@@ -58,12 +58,20 @@ describe("Data Attributes", () => {
 		const overlayObserver = observeTransitionAttrs(page.getByTestId("overlay").element());
 
 		await trigger.click();
-		await vi.waitFor(() => expect(contentObserver.history.some((entry) => entry.starting)).toBe(true));
-		await vi.waitFor(() => expect(overlayObserver.history.some((entry) => entry.starting)).toBe(true));
+		await vi.waitFor(() =>
+			expect(contentObserver.history.some((entry) => entry.starting)).toBe(true)
+		);
+		await vi.waitFor(() =>
+			expect(overlayObserver.history.some((entry) => entry.starting)).toBe(true)
+		);
 
 		await userEvent.keyboard(kbd.ESCAPE);
-		await vi.waitFor(() => expect(contentObserver.history.some((entry) => entry.ending)).toBe(true));
-		await vi.waitFor(() => expect(overlayObserver.history.some((entry) => entry.ending)).toBe(true));
+		await vi.waitFor(() =>
+			expect(contentObserver.history.some((entry) => entry.ending)).toBe(true)
+		);
+		await vi.waitFor(() =>
+			expect(overlayObserver.history.some((entry) => entry.ending)).toBe(true)
+		);
 
 		contentObserver.disconnect();
 		overlayObserver.disconnect();

--- a/tests/src/tests/navigation-menu/navigation-menu-test.svelte
+++ b/tests/src/tests/navigation-menu/navigation-menu-test.svelte
@@ -39,7 +39,10 @@
 				<NavigationMenu.Trigger data-testid="group-item-trigger">
 					trigger
 				</NavigationMenu.Trigger>
-				<NavigationMenu.Content data-testid="group-item-content" forceMount={contentForceMount}>
+				<NavigationMenu.Content
+					data-testid="group-item-content"
+					forceMount={contentForceMount}
+				>
 					<button data-testid="group-item-content-button1">first button</button>
 					<button data-testid="group-item-content-button2">second button </button>
 				</NavigationMenu.Content>
@@ -112,16 +115,12 @@
 				</NavigationMenu.Link>
 			</NavigationMenu.Item>
 
-			<NavigationMenu.Indicator
-				data-testid="indicator"
-				forceMount={indicatorForceMount}
+			<NavigationMenu.Indicator data-testid="indicator" forceMount={indicatorForceMount}
 			></NavigationMenu.Indicator>
 		</NavigationMenu.List>
 
 		{#if !noViewport}
-			<NavigationMenu.Viewport
-				data-testid="viewport"
-				forceMount={viewportForceMount}
+			<NavigationMenu.Viewport data-testid="viewport" forceMount={viewportForceMount}
 			></NavigationMenu.Viewport>
 		{/if}
 	</NavigationMenu.Root>

--- a/tests/src/tests/select/select-scroll-jump-test.svelte
+++ b/tests/src/tests/select/select-scroll-jump-test.svelte
@@ -31,7 +31,11 @@
 				>
 					<Select.Viewport data-testid="viewport">
 						{#each items as item (item.value)}
-							<Select.Item value={item.value} label={item.label} data-testid={`item-${item.value}`}>
+							<Select.Item
+								value={item.value}
+								label={item.label}
+								data-testid={`item-${item.value}`}
+							>
 								{item.label}
 							</Select.Item>
 						{/each}

--- a/tests/src/tests/select/select-value-child-test.svelte
+++ b/tests/src/tests/select/select-value-child-test.svelte
@@ -1,0 +1,81 @@
+<script lang="ts" module>
+	import { Select, type SelectSingleRootProps, type WithoutChildren } from "bits-ui";
+	import { generateTestId } from "../helpers/select";
+
+	export type Item = {
+		value: string;
+		label: string;
+		disabled?: boolean;
+	};
+
+export type SelectValueChildTestProps = Omit<WithoutChildren<SelectSingleRootProps>, "type"> & {
+		items: Item[];
+		placeholder?: string;
+	};
+</script>
+
+<script lang="ts">
+	import "../../app.css";
+
+	let {
+		items = [],
+		value = "",
+		open = false,
+		placeholder = "Open Listbox",
+		...restProps
+	}: SelectValueChildTestProps = $props();
+</script>
+
+<main data-testid="main">
+	<Select.Root bind:value bind:open items={items} {...restProps} type="single">
+		<Select.Trigger data-testid="trigger">
+			<Select.Value {placeholder}>
+				{#snippet child({ props, selection, placeholder: currentPlaceholder, disabled })}
+					<span data-testid="value-node" {...props}>
+						<span data-testid="selection-type">{selection.type}</span>
+						<span data-testid="selection-value">
+							{selection.type === "single" && selection.selected
+								? selection.selected.value
+								: "none"}
+						</span>
+						<span data-testid="selection-label">
+							{selection.type === "single" && selection.selected
+								? selection.selected.label
+								: currentPlaceholder}
+						</span>
+						<span data-testid="selection-disabled">{disabled ? "true" : "false"}</span>
+					</span>
+					<button
+						type="button"
+						data-testid="set-value-2"
+						onpointerdown={(e) => e.stopPropagation()}
+						onclick={(e) => {
+							e.stopPropagation();
+							if (disabled || selection.type !== "single") return;
+							selection.setValue("2");
+						}}
+					>
+						set value
+					</button>
+				{/snippet}
+			</Select.Value>
+		</Select.Trigger>
+
+		<Select.Portal>
+			<Select.Content data-testid="content">
+				<Select.Group>
+					{#each items as item (item.value)}
+						<Select.Item
+							data-testid={generateTestId(item.value)}
+							value={item.value}
+							label={item.label}
+							disabled={item.disabled}
+						>
+							{item.label}
+						</Select.Item>
+					{/each}
+				</Select.Group>
+			</Select.Content>
+		</Select.Portal>
+	</Select.Root>
+</main>

--- a/tests/src/tests/select/select-value-children-multi-test.svelte
+++ b/tests/src/tests/select/select-value-children-multi-test.svelte
@@ -1,0 +1,82 @@
+<script lang="ts" module>
+	import { Select, type SelectMultipleRootProps, type WithoutChildren } from "bits-ui";
+	import { generateTestId } from "../helpers/select";
+
+	export type Item = {
+		value: string;
+		label: string;
+		disabled?: boolean;
+	};
+
+export type SelectValueChildrenMultiTestProps = Omit<
+	WithoutChildren<SelectMultipleRootProps>,
+	"type"
+> & {
+		items: Item[];
+		placeholder?: string;
+	};
+</script>
+
+<script lang="ts">
+	import "../../app.css";
+
+	let {
+		items = [],
+		value = [],
+		open = false,
+		placeholder = "Open combobox",
+		...restProps
+	}: SelectValueChildrenMultiTestProps = $props();
+</script>
+
+<main data-testid="main">
+	<Select.Root bind:value bind:open items={items} {...restProps} type="multiple">
+		<Select.Trigger data-testid="trigger">
+			<Select.Value {placeholder}>
+				{#snippet children({ selection, placeholder: currentPlaceholder, disabled })}
+					<span data-testid="selection-type">{selection.type}</span>
+					<span data-testid="selection-values">
+						{selection.type === "multiple" && selection.selected.length > 0
+							? selection.selected.map((v) => v.value).join(",")
+							: "none"}
+					</span>
+					<span data-testid="selection-label">
+						{selection.type === "multiple" && selection.selected.length > 0
+							? selection.selected.map((v) => v.label).join(", ")
+							: currentPlaceholder}
+					</span>
+					<span data-testid="selection-disabled">{disabled ? "true" : "false"}</span>
+					<button
+						type="button"
+						data-testid="set-values-1-3"
+						onpointerdown={(e) => e.stopPropagation()}
+						onclick={(e) => {
+							e.stopPropagation();
+							if (disabled || selection.type !== "multiple") return;
+							selection.setValue(["1", "3"]);
+						}}
+					>
+						set values
+					</button>
+				{/snippet}
+			</Select.Value>
+		</Select.Trigger>
+
+		<Select.Portal>
+			<Select.Content data-testid="content">
+				<Select.Group>
+					{#each items as item (item.value)}
+						<Select.Item
+							data-testid={generateTestId(item.value)}
+							value={item.value}
+							label={item.label}
+							disabled={item.disabled}
+						>
+							{item.label}
+						</Select.Item>
+					{/each}
+				</Select.Group>
+			</Select.Content>
+		</Select.Portal>
+	</Select.Root>
+</main>

--- a/tests/src/tests/select/select.browser.test.ts
+++ b/tests/src/tests/select/select.browser.test.ts
@@ -9,6 +9,10 @@ import type { SelectMultipleTestProps } from "./select-multi-test.svelte";
 import SelectMultiTest from "./select-multi-test.svelte";
 import type { Item, SelectSingleTestProps } from "./select-test.svelte";
 import SelectTest from "./select-test.svelte";
+import type { SelectValueChildTestProps } from "./select-value-child-test.svelte";
+import SelectValueChildTest from "./select-value-child-test.svelte";
+import type { SelectValueChildrenMultiTestProps } from "./select-value-children-multi-test.svelte";
+import SelectValueChildrenMultiTest from "./select-value-children-multi-test.svelte";
 import SelectViewportTest from "./select-viewport-test.svelte";
 import { expectExists, expectNotExists, observeTransitionAttrs } from "../browser-utils";
 import SelectScrollJumpTest from "./select-scroll-jump-test.svelte";
@@ -96,6 +100,74 @@ function setupMultiple(props: Partial<SelectMultipleTestProps> = {}, items: Item
 		submit,
 		getHiddenInputs,
 		getContent,
+	};
+}
+
+function setupValueChildSingle(
+	props: Partial<SelectValueChildTestProps> = {},
+	items: Item[] = testItems
+) {
+	const returned = render(SelectValueChildTest, { ...props, items });
+	const trigger = page.getByTestId("trigger");
+	const valueNode = page.getByTestId("value-node");
+	const selectionType = page.getByTestId("selection-type");
+	const selectionValue = page.getByTestId("selection-value");
+	const selectionLabel = page.getByTestId("selection-label");
+	const selectionDisabled = page.getByTestId("selection-disabled");
+	const setValueButton = page.getByTestId("set-value-2");
+
+	function getContent() {
+		return page.getByTestId("content");
+	}
+
+	function getHiddenInput(name = "theme") {
+		return returned.container.querySelector(`input[name="${name}"]`);
+	}
+
+	return {
+		trigger,
+		valueNode,
+		selectionType,
+		selectionValue,
+		selectionLabel,
+		selectionDisabled,
+		setValueButton,
+		getContent,
+		getHiddenInput,
+	};
+}
+
+function setupValueChildrenMultiple(
+	props: Partial<SelectValueChildrenMultiTestProps> = {},
+	items: Item[] = testItems
+) {
+	const returned = render(SelectValueChildrenMultiTest, { ...props, items });
+	const trigger = page.getByTestId("trigger");
+	const selectionType = page.getByTestId("selection-type");
+	const selectionValues = page.getByTestId("selection-values");
+	const selectionLabel = page.getByTestId("selection-label");
+	const selectionDisabled = page.getByTestId("selection-disabled");
+	const setValuesButton = page.getByTestId("set-values-1-3");
+
+	function getContent() {
+		return page.getByTestId("content");
+	}
+
+	function getHiddenInputs(name = "themes") {
+		return Array.from(
+			returned.container.querySelectorAll<HTMLInputElement>(`input[name="${name}"]`)
+		);
+	}
+
+	return {
+		trigger,
+		selectionType,
+		selectionValues,
+		selectionLabel,
+		selectionDisabled,
+		setValuesButton,
+		getContent,
+		getHiddenInputs,
 	};
 }
 
@@ -933,6 +1005,72 @@ describe("select - multiple", () => {
 		});
 		await t.submit.click();
 		expect(submittedValues).toHaveLength(0);
+	});
+});
+
+describe("select - value", () => {
+	it("should expose child snippet props in single mode and update when setValue is called", async () => {
+		const t = setupValueChildSingle({ name: "theme", placeholder: "Pick a theme" });
+
+		await expect.element(t.selectionType).toHaveTextContent("single");
+		await expect.element(t.selectionValue).toHaveTextContent("none");
+		await expect.element(t.selectionLabel).toHaveTextContent("Pick a theme");
+		await expect.element(t.selectionDisabled).toHaveTextContent("false");
+		await expect.element(t.valueNode).toHaveAttribute("data-select-value");
+		await expect.element(t.valueNode).toHaveAttribute("data-placeholder");
+
+		await t.setValueButton.click();
+
+		await expect.element(t.selectionValue).toHaveTextContent("2");
+		await expect.element(t.selectionLabel).toHaveTextContent("B");
+		await expect.element(t.valueNode).not.toHaveAttribute("data-placeholder");
+
+		const hiddenInput = t.getHiddenInput();
+		expect(hiddenInput).not.toBeNull();
+		await expect.element(hiddenInput!).toHaveValue("2");
+
+		await t.trigger.click();
+		await expectExists(t.getContent());
+		await expectSelected(page.getByTestId("2"));
+	});
+
+	it("should expose children snippet props in multiple mode and update when setValue is called", async () => {
+		const t = setupValueChildrenMultiple({ name: "themes", placeholder: "Pick themes" });
+
+		await expect.element(t.selectionType).toHaveTextContent("multiple");
+		await expect.element(t.selectionValues).toHaveTextContent("none");
+		await expect.element(t.selectionLabel).toHaveTextContent("Pick themes");
+		await expect.element(t.selectionDisabled).toHaveTextContent("false");
+
+		await t.setValuesButton.click();
+
+		await expect.element(t.selectionValues).toHaveTextContent("1,3");
+		await expect.element(t.selectionLabel).toHaveTextContent("A, C");
+		const hiddenInputs = t.getHiddenInputs();
+		expect(hiddenInputs).toHaveLength(2);
+		await expect.element(hiddenInputs[0]).toHaveValue("1");
+		await expect.element(hiddenInputs[1]).toHaveValue("3");
+
+		await t.trigger.click();
+		await expectExists(t.getContent());
+		await expectSelected([page.getByTestId("1"), page.getByTestId("3")]);
+	});
+
+	it("should pass disabled state to value snippets so consumers can block setValue", async () => {
+		const t = setupValueChildSingle({
+			name: "theme",
+			placeholder: "Pick a theme",
+			disabled: true,
+		});
+
+		await expect.element(t.selectionDisabled).toHaveTextContent("true");
+		await t.setValueButton.click();
+		await expect.element(t.selectionValue).toHaveTextContent("none");
+		await expect.element(t.selectionLabel).toHaveTextContent("Pick a theme");
+
+		const hiddenInput = t.getHiddenInput();
+		expect(hiddenInput).not.toBeNull();
+		await expect.element(hiddenInput!).toHaveValue("");
 	});
 });
 

--- a/tests/src/tests/tooltip/tooltip-tether-gap-test.svelte
+++ b/tests/src/tests/tooltip/tooltip-tether-gap-test.svelte
@@ -12,10 +12,20 @@
 <main data-testid="main" style="position: relative; width: 360px; height: 240px; padding: 24px;">
 	<Tooltip.Provider delayDuration={0}>
 		<div data-testid="automation-card" style="display: flex; align-items: center; gap: 16px;">
-			<Tooltip.Trigger id="trigger-left" data-testid="trigger-left" {tether} payload={{ label: "Left" }}>
+			<Tooltip.Trigger
+				id="trigger-left"
+				data-testid="trigger-left"
+				{tether}
+				payload={{ label: "Left" }}
+			>
 				Left
 			</Tooltip.Trigger>
-			<Tooltip.Trigger id="trigger-right" data-testid="trigger-right" {tether} payload={{ label: "Right" }}>
+			<Tooltip.Trigger
+				id="trigger-right"
+				data-testid="trigger-right"
+				{tether}
+				payload={{ label: "Right" }}
+			>
 				Right
 			</Tooltip.Trigger>
 		</div>


### PR DESCRIPTION
This PR introduces a `<Select.Value/>` component that allows users to create re-usable components using the value of the select.

You can use `Select.Value` in two different ways:
```svelte
<!-- uses the label from the items list or the text content of the item node -->
<Select.Value/> 

<!-- use the child snippet for more control and to be able to set the value -->
<Select.Value>
  {#snippet child({ selection, placeholder, disabled })}
    <!-- ... -->
  {/snippet}
</Select.Value>
```

https://github.com/user-attachments/assets/db351261-6cd0-4de5-9950-69a6b9368d50
