### PR TITLE
fix(AspectRatio): match Radix primitive structure for DOM parity

### DIFF
--- a/packages/bits-ui/src/lib/bits/aspect-ratio/aspect-ratio.svelte.ts
+++ b/packages/bits-ui/src/lib/bits/aspect-ratio/aspect-ratio.svelte.ts
@@ -27,11 +27,9 @@ export class AspectRatioRootState {
 			({
 				id: this.opts.id.current,
 				style: {
-					position: "absolute",
-					top: 0,
-					right: 0,
-					bottom: 0,
-					left: 0,
+					position: "relative",
+					width: "100%",
+					paddingBottom: `${this.opts.ratio.current ? 100 / this.opts.ratio.current : 0}%`,
 				},
 				[aspectRatioAttrs.root]: "",
 				...this.attachment,

--- a/packages/bits-ui/src/lib/bits/aspect-ratio/components/aspect-ratio.svelte
+++ b/packages/bits-ui/src/lib/bits/aspect-ratio/components/aspect-ratio.svelte
@@ -27,12 +27,12 @@
 	const mergedProps = $derived(mergeProps(restProps, rootState.props));
 </script>
 
-<div style:position="relative" style:width="100%" style:padding-bottom="{ratio ? 100 / ratio : 0}%">
-	{#if child}
-		{@render child({ props: mergedProps })}
-	{:else}
-		<div {...mergedProps}>
+{#if child}
+	{@render child({ props: mergedProps })}
+{:else}
+	<div {...mergedProps}>
+		<div style:position="absolute" style:inset="0">
 			{@render children?.()}
 		</div>
-	{/if}
-</div>
+	</div>
+{/if}


### PR DESCRIPTION
## Summary

- Moves the wrapper styles (`position: relative`, `width: 100%`, `padding-bottom`) from hard-coded `style:` directives into `rootState.props` so that they are merged with user-provided props via `mergeProps`
- The outer `<div>` now receives `mergedProps` — meaning `class`, `style`, `ref`, and all HTML attributes the user passes attach to the **outer** container, matching the Radix primitive exactly
- The inner `<div>` is now a pure implementation detail with hard-coded `style:position="absolute" style:inset="0"` and no user-accessible props

## Motivation

The `@radix-ui/react-aspect-ratio` source renders two divs:

```jsx
// outer — receives all user props (className, style, ref, …)
<Primitive.div style={{ position: 'relative', width: '100%', paddingBottom: `${100 / ratio}%`, ...style }} {...props} ref={forwardedRef}>
  // inner — implementation detail only
  <Primitive.div style={{ position: 'absolute', top: 0, right: 0, bottom: 0, left: 0 }}>
    {children}
  </Primitive.div>
</Primitive.div>
```

**Source:** https://github.com/radix-ui/primitives/blob/main/packages/react/aspect-ratio/src/aspect-ratio.tsx

Before this change, bits-ui applied user props to the **inner** div and hard-coded the wrapper styles on the outer div with `style:` directives. This meant `class="overflow-hidden rounded-xl"` would clip the inner absolute-positioned box instead of the outer padded wrapper — a subtle but observable difference from the React primitive.

## Test plan

- [ ] `<AspectRatio.Root ratio={16/9} class="overflow-hidden rounded-xl">` — border-radius and overflow clipping apply to the outer wrapper ✓
- [ ] `ref` binds to the outer container element ✓
- [ ] `style` passed by the user merges with (and can extend) the wrapper styles ✓
- [ ] `svelte-check` passes with 0 errors ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)