### PR TITLE
chore: update workflows to Node 24 and latest action versions

### DIFF
--- a/.github/workflows/build-preview.yml
+++ b/.github/workflows/build-preview.yml
@@ -13,11 +13,11 @@ jobs:
     build-preview:
         runs-on: macos-latest
         steps:
-            - uses: actions/checkout@v4
-            - uses: pnpm/action-setup@v4
-            - uses: actions/setup-node@v4
+            - uses: actions/checkout@v6
+            - uses: pnpm/action-setup@v5
+            - uses: actions/setup-node@v6
               with:
-                  node-version: 20
+                  node-version: 24
                   cache: pnpm
 
             - name: Install dependencies
@@ -27,7 +27,7 @@ jobs:
               run: pnpm build
 
             - name: Upload build artifact
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@v7
               with:
                   name: preview-build
                   path: docs/.svelte-kit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,11 +26,11 @@ jobs:
         name: Run svelte-check
         runs-on: macos-latest
         steps:
-            - uses: actions/checkout@v4
-            - uses: pnpm/action-setup@v4
-            - uses: actions/setup-node@v4
+            - uses: actions/checkout@v6
+            - uses: pnpm/action-setup@v5
+            - uses: actions/setup-node@v6
               with:
-                  node-version: 20
+                  node-version: 24
                   cache: pnpm
 
             - name: Install dependencies
@@ -43,11 +43,11 @@ jobs:
         runs-on: macos-latest
         name: Lint
         steps:
-            - uses: actions/checkout@v4
-            - uses: pnpm/action-setup@v4
-            - uses: actions/setup-node@v4
+            - uses: actions/checkout@v6
+            - uses: pnpm/action-setup@v5
+            - uses: actions/setup-node@v6
               with:
-                  node-version: 20
+                  node-version: 24
                   cache: pnpm
 
             - name: Install dependencies

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -18,7 +18,7 @@ jobs:
         if: ${{ github.event.workflow_run.conclusion == 'success' }}
         steps:
             - name: Download build artifact
-              uses: actions/download-artifact@v4
+              uses: actions/download-artifact@v8
               id: preview-build-artifact
               with:
                   name: preview-build

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -15,11 +15,11 @@ jobs:
             deployments: write
         name: Deploy Production Site to Cloudflare Pages
         steps:
-            - uses: actions/checkout@v4
-            - uses: pnpm/action-setup@v4
-            - uses: actions/setup-node@v4
+            - uses: actions/checkout@v6
+            - uses: pnpm/action-setup@v5
+            - uses: actions/setup-node@v6
               with:
-                  node-version: 20
+                  node-version: 24
                   cache: pnpm
 
             - name: Install dependencies

--- a/.github/workflows/preview-release.yml
+++ b/.github/workflows/preview-release.yml
@@ -10,11 +10,11 @@ jobs:
         timeout-minutes: 5
         runs-on: macos-latest
         steps:
-            - uses: actions/checkout@v4
-            - uses: pnpm/action-setup@v4
-            - uses: actions/setup-node@v4
+            - uses: actions/checkout@v6
+            - uses: pnpm/action-setup@v5
+            - uses: actions/setup-node@v6
               with:
-                  node-version: 20
+                  node-version: 24
                   cache: pnpm
 
             - name: install dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,11 +17,11 @@ jobs:
         name: Release
         runs-on: macos-latest
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v6
               with:
                   fetch-depth: 0
-            - uses: pnpm/action-setup@v4
-            - uses: actions/setup-node@v4
+            - uses: pnpm/action-setup@v5
+            - uses: actions/setup-node@v6
               with:
                   node-version: 24
                   cache: pnpm

--- a/.github/workflows/reproduire-close.yml
+++ b/.github/workflows/reproduire-close.yml
@@ -11,7 +11,7 @@ jobs:
     stale:
         runs-on: macos-latest
         steps:
-            - uses: actions/stale@v9
+            - uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f # v10.2.0
               with:
                   days-before-stale: -1 # Issues and PR will never be flagged stale automatically.
                   stale-issue-label: needs reproduction # Label that flags an issue as stale.

--- a/.github/workflows/reproduire-close.yml
+++ b/.github/workflows/reproduire-close.yml
@@ -11,7 +11,7 @@ jobs:
     stale:
         runs-on: macos-latest
         steps:
-            - uses: actions/stale@28ca1036281a5e5922ead5184a1bbf96e5fc984e # v9.0.0
+            - uses: actions/stale@v9
               with:
                   days-before-stale: -1 # Issues and PR will never be flagged stale automatically.
                   stale-issue-label: needs reproduction # Label that flags an issue as stale.

--- a/.github/workflows/reproduire.yml
+++ b/.github/workflows/reproduire.yml
@@ -10,7 +10,7 @@ jobs:
     reproduire:
         runs-on: macos-latest
         steps:
-            - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+            - uses: actions/checkout@v6
             - uses: Hebilicious/reproduire@4b686ae9cbb72dad60f001d278b6e3b2ce40a9ac # v0.0.9-mp
               with:
                   label: needs reproduction

--- a/.github/workflows/reproduire.yml
+++ b/.github/workflows/reproduire.yml
@@ -10,7 +10,7 @@ jobs:
     reproduire:
         runs-on: macos-latest
         steps:
-            - uses: actions/checkout@v6
+            - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
             - uses: Hebilicious/reproduire@4b686ae9cbb72dad60f001d278b6e3b2ce40a9ac # v0.0.9-mp
               with:
                   label: needs reproduction

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,11 +22,11 @@ jobs:
         runs-on: macos-latest
         name: Test Utils
         steps:
-            - uses: actions/checkout@v4
-            - uses: pnpm/action-setup@v4
-            - uses: actions/setup-node@v4
+            - uses: actions/checkout@v6
+            - uses: pnpm/action-setup@v5
+            - uses: actions/setup-node@v6
               with:
-                  node-version: 20
+                  node-version: 24
                   cache: pnpm
 
             - name: Install dependencies
@@ -38,11 +38,11 @@ jobs:
         name: Test - Chromium
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v4
-            - uses: pnpm/action-setup@v4
-            - uses: actions/setup-node@v4
+            - uses: actions/checkout@v6
+            - uses: pnpm/action-setup@v5
+            - uses: actions/setup-node@v6
               with:
-                  node-version: 20
+                  node-version: 24
 
             - name: Install dependencies
               run: pnpm install --frozen-lockfile


### PR DESCRIPTION
Node 20 is going to be [deprecated in runners soon](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)

- Node version: 20 → 24 across all workflows
- actions/checkout: v4 → v6
- actions/setup-node: v4 → v6
- pnpm/action-setup: v4 → v5
- actions/upload-artifact: v4 → v7
- actions/download-artifact: v4 → v8
- actions/stale: pinned SHA → v10.2.0 pinned SHA
- reproduire checkout pinned SHA v4.1.1 → v4.1.7