### PR TITLE
fix(docs): stabilize TOC sticky positioning and reduce sidebar top padding

### DIFF
--- a/docs/src/lib/components/doc-page.svelte
+++ b/docs/src/lib/components/doc-page.svelte
@@ -43,7 +43,7 @@
 
 <div
 	class={cn(
-		"relative flex flex-row-reverse pb-6 pl-4 pr-4 pt-8 sm:pt-16 md:pl-0 lg:gap-10 xl:grid-cols-[1fr_220px]",
+		"relative flex flex-row-reverse pl-4 pr-4 pt-8 sm:pt-16 md:pl-0 lg:gap-10 xl:grid-cols-[1fr_220px]",
 		page.error ?? "xl:grid"
 	)}
 >

--- a/docs/src/lib/components/doc-page.svelte
+++ b/docs/src/lib/components/doc-page.svelte
@@ -50,7 +50,7 @@
 	{#if !page.error}
 		<aside class="order-2 hidden text-sm xl:block">
 			<div
-				class="-mt-13 sticky top-16 flex h-[calc(100vh-3.5rem)] flex-col gap-4 overflow-hidden pt-6"
+				class="sticky top-[var(--header-height)] -mt-16 flex h-[calc(100vh-var(--header-height))] flex-col gap-4 overflow-hidden pt-6"
 			>
 				{#key metadata.title}
 					<Toc toc={{ items: fullToc }} />

--- a/docs/src/lib/components/navigation/sidebar-nav.svelte
+++ b/docs/src/lib/components/navigation/sidebar-nav.svelte
@@ -15,7 +15,7 @@
 			<ScrollArea.Viewport
 				class="h-full max-h-[calc(100vh-var(--header-height))] w-full shrink-0 "
 			>
-				<div class="h-full py-6 pr-4 lg:py-8">
+				<div class="h-full pb-6 pr-4 pt-4 lg:pb-8">
 					<nav class="space-y-3">
 						<div class="flex w-full flex-col pb-[50px]">
 							{#each items as item, index (index)}

--- a/docs/src/lib/components/navigation/sidebar-nav.svelte
+++ b/docs/src/lib/components/navigation/sidebar-nav.svelte
@@ -9,10 +9,12 @@
 
 {#if items.length}
 	<aside
-		class="border-border fixed top-14 hidden h-[calc(100vh-3.5rem)] w-full shrink-0 border-r md:sticky md:block"
+		class="border-border fixed top-[var(--header-height)] hidden h-[calc(100vh-var(--header-height))] w-full shrink-0 border-r md:sticky md:block"
 	>
 		<ScrollArea.Root>
-			<ScrollArea.Viewport class="h-full max-h-[calc(100vh-3.5rem)] w-full shrink-0 ">
+			<ScrollArea.Viewport
+				class="h-full max-h-[calc(100vh-var(--header-height))] w-full shrink-0 "
+			>
 				<div class="h-full py-6 pr-4 lg:py-8">
 					<nav class="space-y-3">
 						<div class="flex w-full flex-col pb-[50px]">

--- a/docs/src/lib/components/navigation/sidebar-nav.svelte
+++ b/docs/src/lib/components/navigation/sidebar-nav.svelte
@@ -9,7 +9,7 @@
 
 {#if items.length}
 	<aside
-		class="border-border fixed top-10 hidden h-[calc(100vh-3.5rem)] w-full shrink-0 border-r md:sticky md:block"
+		class="border-border fixed top-14 hidden h-[calc(100vh-3.5rem)] w-full shrink-0 border-r md:sticky md:block"
 	>
 		<ScrollArea.Root>
 			<ScrollArea.Viewport class="h-full max-h-[calc(100vh-3.5rem)] w-full shrink-0 ">

--- a/docs/src/lib/styles/app.css
+++ b/docs/src/lib/styles/app.css
@@ -16,6 +16,8 @@
 }
 
 :root {
+	--header-height: 71px;
+
 	/* Colors */
 	--background: hsl(0 0% 100%);
 	--background-alt: hsl(0 0% 100%);

--- a/docs/src/routes/(docs)/+layout.svelte
+++ b/docs/src/routes/(docs)/+layout.svelte
@@ -21,7 +21,7 @@
 
 <Metadata />
 <SiteHeader />
-<div class="min-h-[calc(100vh-64px)]">
+<div class="min-h-[calc(100vh-var(--header-height))]">
 	<div
 		class="flex-1 items-start md:grid md:grid-cols-[220px_minmax(0,1fr)] md:gap-6 lg:grid-cols-[250px_minmax(0,1fr)] lg:gap-10"
 	>


### PR DESCRIPTION
Fixed sticky behavior of sidebar and ToC at top & bottom of page

Before:

https://github.com/user-attachments/assets/95cb05fc-f7ce-4d23-b3aa-122d951023b2

