### PR TITLE
fix(menu): use preventScroll when focusing items on hover and content on item-leave

### DIFF
--- a/.changeset/upset-cups-try.md
+++ b/.changeset/upset-cups-try.md
@@ -1,0 +1,5 @@
+---
+"bits-ui": patch
+---
+
+fix(Menu): prevent page scroll-jump on item hover when `scroll-padding` is set

--- a/packages/bits-ui/src/lib/bits/menu/menu.svelte.ts
+++ b/packages/bits-ui/src/lib/bits/menu/menu.svelte.ts
@@ -1117,7 +1117,7 @@ export class MenuContentState {
 		if (this.#isPointerMovingToSubmenu() || this.parentMenu.root.isUsingKeyboard.current)
 			return;
 		const contentNode = this.parentMenu.contentNode;
-		contentNode?.focus();
+		contentNode?.focus({ preventScroll: true });
 		this.rovingFocusGroup.setCurrentTabStopId("");
 	}
 
@@ -1213,7 +1213,7 @@ class MenuItemSharedState {
 			if (defaultPrevented) return;
 			const item = e.currentTarget;
 			if (!isHTMLElement(item)) return;
-			item.focus();
+			item.focus({ preventScroll: true });
 		}
 	}
 

--- a/tests/src/tests/dropdown-menu/dropdown-menu-scroll-padding-test.svelte
+++ b/tests/src/tests/dropdown-menu/dropdown-menu-scroll-padding-test.svelte
@@ -1,0 +1,40 @@
+<script lang="ts" module>
+	import { DropdownMenu } from "bits-ui";
+	export type DropdownMenuScrollPaddingTestProps = {
+		contentProps?: Omit<DropdownMenu.ContentProps, "children" | "child">;
+	};
+</script>
+
+<script lang="ts">
+	let { contentProps = {} }: DropdownMenuScrollPaddingTestProps = $props();
+	const rows = Array.from({ length: 80 }, (_, i) => i + 1);
+</script>
+
+<svelte:head>
+	<style>
+		:root {
+			scroll-padding-top: 200px;
+		}
+	</style>
+</svelte:head>
+
+<div data-testid="page">
+	{#each rows as row, i (i)}
+		<div style="height: 24px;">Row {row}</div>
+	{/each}
+
+	<DropdownMenu.Root>
+		<DropdownMenu.Trigger data-testid="trigger">Open</DropdownMenu.Trigger>
+		<DropdownMenu.Portal>
+			<DropdownMenu.Content {...contentProps} data-testid="content" preventScroll={false}>
+				<DropdownMenu.Item data-testid="item-1">Item 1</DropdownMenu.Item>
+				<DropdownMenu.Item data-testid="item-2">Item 2</DropdownMenu.Item>
+				<DropdownMenu.Item data-testid="item-3">Item 3</DropdownMenu.Item>
+			</DropdownMenu.Content>
+		</DropdownMenu.Portal>
+	</DropdownMenu.Root>
+
+	{#each rows as row, i (i)}
+		<div style="height: 24px;">After row {row}</div>
+	{/each}
+</div>

--- a/tests/src/tests/dropdown-menu/dropdown-menu.browser.test.ts
+++ b/tests/src/tests/dropdown-menu/dropdown-menu.browser.test.ts
@@ -14,6 +14,7 @@ import {
 } from "../browser-utils";
 import DropdownMenuTest from "./dropdown-menu-test.svelte";
 import DropdownMenuMultipleTest from "./dropdown-menu-multiple-test.svelte";
+import DropdownMenuScrollPaddingTest from "./dropdown-menu-scroll-padding-test.svelte";
 
 const kbd = getTestKbd();
 const OPEN_KEYS = [kbd.ENTER, kbd.ARROW_DOWN, kbd.SPACE];
@@ -761,4 +762,36 @@ it("keyboard navigation should not cause unwanted jumps between menus", async ()
 	await expectNotExists(content1);
 	await userEvent.keyboard(kbd.ARROW_DOWN);
 	await expectNotExists(content1);
+});
+
+it("should call `focus` with `preventScroll: true` on hover and item-leave so `scroll-padding` does not scroll the page", async () => {
+	const t = render(DropdownMenuScrollPaddingTest);
+	onTestFinished(() => t.unmount());
+
+	await page.getByTestId("trigger").click();
+	await expectExists(page.getByTestId("content"));
+
+	const focusSpy = vi.spyOn(HTMLElement.prototype, "focus");
+	try {
+		// hover one item then another to trigger both onpointermove (item focus)
+		// and onItemLeave (content focus)
+		await page.getByTestId("item-1").hover();
+		await page.getByTestId("item-2").hover();
+
+		const relevantCalls = focusSpy.mock.calls
+			.map(([options], i) => ({
+				options,
+				testid: (focusSpy.mock.contexts[i] as HTMLElement).getAttribute("data-testid"),
+			}))
+			.filter(
+				({ testid }) => testid === "item-1" || testid === "item-2" || testid === "content"
+			);
+
+		expect(relevantCalls.length).toBeGreaterThan(0);
+		for (const { options } of relevantCalls) {
+			expect(options).toEqual({ preventScroll: true });
+		}
+	} finally {
+		focusSpy.mockRestore();
+	}
 });

--- a/tests/src/tests/dropdown-menu/dropdown-menu.browser.test.ts
+++ b/tests/src/tests/dropdown-menu/dropdown-menu.browser.test.ts
@@ -773,6 +773,7 @@ it("should call `focus` with `preventScroll: true` on hover and item-leave so `s
 
 	const focusSpy = vi.spyOn(HTMLElement.prototype, "focus");
 	try {
+		const scrollYBeforeHover = window.scrollY;
 		// hover one item then another to trigger both onpointermove (item focus)
 		// and onItemLeave (content focus)
 		await page.getByTestId("item-1").hover();
@@ -787,10 +788,14 @@ it("should call `focus` with `preventScroll: true` on hover and item-leave so `s
 				({ testid }) => testid === "item-1" || testid === "item-2" || testid === "content"
 			);
 
-		expect(relevantCalls.length).toBeGreaterThan(0);
-		for (const { options } of relevantCalls) {
-			expect(options).toEqual({ preventScroll: true });
-		}
+		expect(window.scrollY).toBe(scrollYBeforeHover);
+		expect(relevantCalls).toEqual(
+			expect.arrayContaining([
+				{ testid: "item-1", options: { preventScroll: true } },
+				{ testid: "item-2", options: { preventScroll: true } },
+				{ testid: "content", options: { preventScroll: true } },
+			])
+		);
 	} finally {
 		focusSpy.mockRestore();
 	}


### PR DESCRIPTION
Closes #2024

  ## Root cause

  The DropdownMenu (and all components that share `MenuContentState` / `MenuItemSharedState`) calls `.focus()` in two pointer handlers without passing `{
  preventScroll: true }`:

  | Location | Trigger |
  |---|---|
  | `MenuItemSharedState.onpointermove` (`menu.svelte.ts:1216`) | hovering an item |
  | `MenuContentState.onItemLeave` (`menu.svelte.ts:1120`) | leaving an item back to the content |

  When the consumer sets `scroll-padding-top` on the document root (a common pattern with sticky navbars), the browser honors that padding on every focus and scrolls the page to push the focused element out of the padding zone — even when the element is already visible.

  The leave-handler is the primary cause of the visible jump in the issue's StackBlitz: each cross-item hover triggers `pointerleave` on the previous item, which calls `contentNode.focus()` and yanks the page upward.

  ## Fix

  Pass `{ preventScroll: true }` to both focus calls. This matches the existing guidance in the file (`focusWithoutScroll` / `focus()` in `internal/focus.ts`) and the hover-focus mirrors upstream Radix UI's `menu.tsx`:

  ```diff
   onItemLeave(e: BitsPointerEvent) {
       ...
       const contentNode = this.parentMenu.contentNode;
  -    contentNode?.focus();
  +    contentNode?.focus({ preventScroll: true });
       this.rovingFocusGroup.setCurrentTabStopId("");
   }

   onpointermove(e: BitsPointerEvent) {
       ...
       const item = e.currentTarget;
       if (!isHTMLElement(item)) return;
  -    item.focus();
  +    item.focus({ preventScroll: true });
   }
  ```

  ## Test

  Added a new browser test (`should call focus with preventScroll: true on hover and item-leave`) that:
  1. Renders a DropdownMenu inside a page with `scroll-padding-top` set on `:root`
  2. Hovers two items in sequence (exercising both `onpointermove` and `onItemLeave`)
  3. Spies on `HTMLElement.prototype.focus` and asserts every call on `item-1`, `item-2`, and `content` was made with `{ preventScroll: true }`

  The test fails on `main` (only the second focus call passes the assertion) and passes with the fix.

  ## Reproduction

  The issue's StackBlitz: https://stackblitz.com/edit/vp6mdsbf?file=src%2Froutes%2F%2Bpage.svelte

  Hover items 1 → 2 → 3; the page scrolls up by ~20px on each cross-item hover. With the fix the page stays still.