### PR TITLE
Fix: Date typing improvements

### DIFF
--- a/packages/bits-ui/src/lib/bits/date-field/date-field.svelte.ts
+++ b/packages/bits-ui/src/lib/bits/date-field/date-field.svelte.ts
@@ -1259,7 +1259,7 @@ class DateFieldYearSegmentState extends BaseNumericSegmentState {
 			return mergedIntStr;
 		});
 
-		if (this.#pressedKeys.length === 4 || this.#pressedKeys.length === this.#backspaceCount) {
+		if (this.#pressedKeys.length === 4) {
 			moveToNext = true;
 		}
 

--- a/packages/bits-ui/src/lib/bits/date-field/date-field.svelte.ts
+++ b/packages/bits-ui/src/lib/bits/date-field/date-field.svelte.ts
@@ -211,6 +211,7 @@ export class DateFieldRootState {
 	descriptionNode = $state<HTMLElement | null>(null);
 	validationNode = $state<HTMLElement | null>(null);
 	states = initSegmentStates();
+	#segmentClearedValue = false;
 	dayPeriodNode = $state<HTMLElement | null>(null);
 	rangeRoot: DateRangeFieldRootState | undefined = undefined;
 	name = $state("");
@@ -311,6 +312,10 @@ export class DateFieldRootState {
 
 		$effect(() => {
 			if (this.value.current === undefined) {
+				if (this.#segmentClearedValue) {
+					this.#segmentClearedValue = false;
+					return;
+				}
 				this.segmentValues = initializeSegmentValues(this.inferredGranularity);
 			}
 		});
@@ -680,6 +685,7 @@ export class DateFieldRootState {
 				})
 			);
 		} else {
+			this.#segmentClearedValue = true;
 			this.setValue(undefined);
 			this.segmentValues = newSegmentValues;
 		}

--- a/packages/bits-ui/src/lib/bits/date-field/date-field.svelte.ts
+++ b/packages/bits-ui/src/lib/bits/date-field/date-field.svelte.ts
@@ -1280,15 +1280,16 @@ class DateFieldYearSegmentState extends BaseNumericSegmentState {
 				this.announcer.announce(null);
 				return null;
 			}
-			const str = prev.toString();
-			if (str.length === 1) {
+			// Use integer division to strip the last significant digit, so that
+			// zero-padded values like "0001" don't leave a confusing "000" remnant
+			// that causes subsequent typing to misinterpret the year.
+			const next = Math.floor(Number.parseInt(prev) / 10);
+			if (next === 0) {
 				this.announcer.announce(null);
 				return null;
 			}
-			const next = str.slice(0, -1);
 			this.announcer.announce(next);
-
-			return `${next}`;
+			return prependYearZeros(next);
 		});
 
 		if (moveToPrev) {

--- a/tests/src/tests/date-field/date-field.browser.test.ts
+++ b/tests/src/tests/date-field/date-field.browser.test.ts
@@ -644,6 +644,8 @@ describe("date field", () => {
 		await expect.element(t.year).toHaveTextContent("009");
 		await userEvent.keyboard(kbd.BACKSPACE);
 		await expect.element(t.year).toHaveTextContent("yyyy");
+		await userEvent.keyboard(`{0}`);
+		await userEvent.keyboard(`{0}`);
 		await userEvent.keyboard(`{8}`);
 		await userEvent.keyboard(`{7}`);
 		await expect.element(t.year).toHaveTextContent("0087");

--- a/tests/src/tests/date-field/date-field.browser.test.ts
+++ b/tests/src/tests/date-field/date-field.browser.test.ts
@@ -643,7 +643,7 @@ describe("date field", () => {
 		await userEvent.keyboard(kbd.BACKSPACE);
 		await expect.element(t.year).toHaveTextContent("009");
 		await userEvent.keyboard(kbd.BACKSPACE);
-		await expect.element(t.year).toHaveTextContent("00");
+		await expect.element(t.year).toHaveTextContent("yyyy");
 		await userEvent.keyboard(`{8}`);
 		await userEvent.keyboard(`{7}`);
 		await expect.element(t.year).toHaveTextContent("0087");


### PR DESCRIPTION
This PR fixes [this issue](https://github.com/huntabyte/bits-ui/issues/2038) regarding unexpected behaviour when typing into a date field.

This can be broken down into three fixes:

Firstly, pressing backspace when the year segment only had one character caused the entire date to be cleared, frustratingly meaning the user had to enter the day and month again. We now have a private `#segmentClearedValue` variable which is used to specify whether the segment was cleared by the user, in which case we should not clear the whole input. This method ensures if this code is triggered from anywhere else its behaviour is unchanged.

Secondly, there was an issue regarding when to move to the next segment when backspace had been used. The existing implementation thinks you should move forward after typing enough characters to match the number of backspaces, however this causes an issue when someone makes a typo. e.g. if someone makes a mistake at the start of entering the year and they type `1`, `Backspace`, `2` the focus will jump to the next segment before the user gets a chance to type the rest of the year. This fix now sticks with the same segment until that segment is completed.

Thirdly, there were issues stemming from padding incomplete segments with preceding zeros. These zeros were then treated as part of the segment's value, which caused confusion when completing or editing a segment, particularly noticeable when backspacing in the year segment. This fix uses integer division to remove the last character and then reapplies the padding before it is shown. This ensures the full padding is always shown to the user but the preceding zeros don't impact the backspace process.

The `should handle backspacing the year segment appropriately` date-field test has also been updated to reflect the new behaviour. 

This has been tested manually, and tests have been run to confirm the only failures were pre-existing.

If there are any changes you'd like, please let me know!