### PR TITLE
fix(docs): epicenter sponsor logo visibility on light backgrounds + tagline

### DIFF
--- a/docs/src/lib/components/sidebar-sponsor-mobile.svelte
+++ b/docs/src/lib/components/sidebar-sponsor-mobile.svelte
@@ -10,17 +10,18 @@
 	></div>
 
 	<div
-		class="relative z-10 size-8 shrink-0 opacity-80 transition-opacity group-hover:opacity-100"
+		class="relative z-10 size-8 shrink-0 overflow-hidden rounded-md opacity-80 transition-opacity group-hover:opacity-100"
 	>
 		<svg viewBox="0 0 400 400" xmlns="http://www.w3.org/2000/svg">
-			<circle cx="170" cy="170" r="100" fill="#cccccc" opacity="1" />
-			<circle cx="230" cy="230" r="100" fill="#ffffff" opacity="1" />
+			<rect width="400" height="400" fill="#000" />
+			<circle cx="170" cy="170" r="100" fill="#ccc" />
+			<circle cx="230" cy="230" r="100" fill="#fff" />
 		</svg>
 	</div>
 
 	<div class="relative z-10 min-w-0 flex-1">
 		<h3 class="text-foreground text-sm font-semibold tracking-tight">Epicenter</h3>
-		<p class="text-foreground/70 truncate text-xs">Open source, local first apps</p>
+		<p class="text-foreground/70 truncate text-xs">Local-first, open source apps</p>
 	</div>
 
 	<span

--- a/docs/src/lib/components/sidebar-sponsor.svelte
+++ b/docs/src/lib/components/sidebar-sponsor.svelte
@@ -14,16 +14,19 @@
 			<span class="text-muted-foreground text-[10px] font-medium uppercase tracking-wide"
 				>Special Sponsor</span
 			>
-			<div class="size-10 opacity-80 transition-opacity group-hover:opacity-100">
+			<div
+				class="size-10 overflow-hidden rounded-lg opacity-80 transition-opacity group-hover:opacity-100"
+			>
 				<svg viewBox="0 0 400 400" xmlns="http://www.w3.org/2000/svg">
-					<circle cx="170" cy="170" r="100" fill="#cccccc" opacity="1" />
-					<circle cx="230" cy="230" r="100" fill="#ffffff" opacity="1" />
+					<rect width="400" height="400" fill="#000" />
+					<circle cx="170" cy="170" r="100" fill="#ccc" />
+					<circle cx="230" cy="230" r="100" fill="#fff" />
 				</svg>
 			</div>
 		</div>
 		<div class="space-y-1">
 			<h3 class="text-foreground text-lg font-semibold tracking-tight">Epicenter</h3>
-			<p class="text-foreground/85 text-xs leading-relaxed">Open source, local first apps</p>
+			<p class="text-foreground/85 text-xs leading-relaxed">Local-first, open source apps</p>
 		</div>
 	</div>
 </a>


### PR DESCRIPTION
Ports [huntabyte/shadcn-svelte#2662](https://github.com/huntabyte/shadcn-svelte/pull/2662) to bits-ui.

- Adds a black `<rect>` background to the Epicenter SVG logo so it renders correctly in light mode
- Clips the logo wrapper with `overflow-hidden` + `rounded-lg`/`rounded-md`
- Fixes tagline: `"Open source, local first apps"` → `"Local-first, open source apps"`