### PR TITLE
feat(docs): add clickable anchor links to headings

### DIFF
--- a/docs/src/lib/components/markdown/h1.svelte
+++ b/docs/src/lib/components/markdown/h1.svelte
@@ -1,10 +1,18 @@
 <script lang="ts">
 	import type { HTMLAttributes } from "svelte/elements";
 	import { cn } from "$lib/utils/styles.js";
+	import HeadingAnchor from "./heading-anchor.svelte";
 
-	let { class: className, children, ...restProps }: HTMLAttributes<HTMLHeadingElement> = $props();
+	let {
+		class: className,
+		children,
+		id,
+		...restProps
+	}: HTMLAttributes<HTMLHeadingElement> = $props();
 </script>
 
-<h1 class={cn("mt-2 scroll-m-20 text-4xl font-bold", className)} {...restProps}>
-	{@render children?.()}
+<h1 class={cn("mt-2 scroll-m-20 text-4xl font-bold", className)} {id} {...restProps}>
+	<HeadingAnchor {id}>
+		{@render children?.()}
+	</HeadingAnchor>
 </h1>

--- a/docs/src/lib/components/markdown/h1.svelte
+++ b/docs/src/lib/components/markdown/h1.svelte
@@ -12,7 +12,7 @@
 </script>
 
 <h1 class={cn("mt-2 scroll-m-20 text-4xl font-bold", className)} {id} {...restProps}>
-	<HeadingAnchor {id}>
+	<HeadingAnchor id={id ?? undefined}>
 		{@render children?.()}
 	</HeadingAnchor>
 </h1>

--- a/docs/src/lib/components/markdown/h2.svelte
+++ b/docs/src/lib/components/markdown/h2.svelte
@@ -1,8 +1,14 @@
 <script lang="ts">
 	import type { HTMLAttributes } from "svelte/elements";
 	import { cn } from "$lib/utils/styles.js";
+	import HeadingAnchor from "./heading-anchor.svelte";
 
-	let { class: className, children, ...restProps }: HTMLAttributes<HTMLHeadingElement> = $props();
+	let {
+		class: className,
+		children,
+		id,
+		...restProps
+	}: HTMLAttributes<HTMLHeadingElement> = $props();
 </script>
 
 <h2
@@ -10,7 +16,10 @@
 		"mt-12 scroll-m-[70px] text-[27px] font-semibold tracking-[-0.01em] first:mt-0",
 		className
 	)}
+	{id}
 	{...restProps}
 >
-	{@render children?.()}
+	<HeadingAnchor {id}>
+		{@render children?.()}
+	</HeadingAnchor>
 </h2>

--- a/docs/src/lib/components/markdown/h2.svelte
+++ b/docs/src/lib/components/markdown/h2.svelte
@@ -19,7 +19,7 @@
 	{id}
 	{...restProps}
 >
-	<HeadingAnchor {id}>
+	<HeadingAnchor id={id ?? undefined}>
 		{@render children?.()}
 	</HeadingAnchor>
 </h2>

--- a/docs/src/lib/components/markdown/h3.svelte
+++ b/docs/src/lib/components/markdown/h3.svelte
@@ -16,7 +16,7 @@
 	{id}
 	{...restProps}
 >
-	<HeadingAnchor {id}>
+	<HeadingAnchor id={id ?? undefined}>
 		{@render children?.()}
 	</HeadingAnchor>
 </h3>

--- a/docs/src/lib/components/markdown/h3.svelte
+++ b/docs/src/lib/components/markdown/h3.svelte
@@ -1,13 +1,22 @@
 <script lang="ts">
 	import type { HTMLAttributes } from "svelte/elements";
 	import { cn } from "$lib/utils/styles.js";
+	import HeadingAnchor from "./heading-anchor.svelte";
 
-	let { class: className, children, ...restProps }: HTMLAttributes<HTMLHeadingElement> = $props();
+	let {
+		class: className,
+		children,
+		id,
+		...restProps
+	}: HTMLAttributes<HTMLHeadingElement> = $props();
 </script>
 
 <h3
 	class={cn("mt-12 scroll-m-[70px] text-xl font-semibold tracking-tight", className)}
+	{id}
 	{...restProps}
 >
-	{@render children?.()}
+	<HeadingAnchor {id}>
+		{@render children?.()}
+	</HeadingAnchor>
 </h3>

--- a/docs/src/lib/components/markdown/h4.svelte
+++ b/docs/src/lib/components/markdown/h4.svelte
@@ -1,10 +1,22 @@
 <script lang="ts">
 	import type { HTMLAttributes } from "svelte/elements";
 	import { cn } from "$lib/utils/styles.js";
+	import HeadingAnchor from "./heading-anchor.svelte";
 
-	let { class: className, children, ...restProps }: HTMLAttributes<HTMLHeadingElement> = $props();
+	let {
+		class: className,
+		children,
+		id,
+		...restProps
+	}: HTMLAttributes<HTMLHeadingElement> = $props();
 </script>
 
-<h4 class={cn("-mb-2 mt-8 scroll-m-20 text-lg font-bold tracking-tight", className)} {...restProps}>
-	{@render children?.()}
+<h4
+	class={cn("-mb-2 mt-8 scroll-m-20 text-lg font-bold tracking-tight", className)}
+	{id}
+	{...restProps}
+>
+	<HeadingAnchor {id}>
+		{@render children?.()}
+	</HeadingAnchor>
 </h4>

--- a/docs/src/lib/components/markdown/h4.svelte
+++ b/docs/src/lib/components/markdown/h4.svelte
@@ -16,7 +16,7 @@
 	{id}
 	{...restProps}
 >
-	<HeadingAnchor {id}>
+	<HeadingAnchor id={id ?? undefined}>
 		{@render children?.()}
 	</HeadingAnchor>
 </h4>

--- a/docs/src/lib/components/markdown/h5.svelte
+++ b/docs/src/lib/components/markdown/h5.svelte
@@ -1,10 +1,22 @@
 <script lang="ts">
 	import type { HTMLAttributes } from "svelte/elements";
 	import { cn } from "$lib/utils/styles.js";
+	import HeadingAnchor from "./heading-anchor.svelte";
 
-	let { class: className, children, ...restProps }: HTMLAttributes<HTMLHeadingElement> = $props();
+	let {
+		class: className,
+		children,
+		id,
+		...restProps
+	}: HTMLAttributes<HTMLHeadingElement> = $props();
 </script>
 
-<h5 class={cn("mt-8 scroll-m-20 text-lg font-semibold tracking-tight", className)} {...restProps}>
-	{@render children?.()}
+<h5
+	class={cn("mt-8 scroll-m-20 text-lg font-semibold tracking-tight", className)}
+	{id}
+	{...restProps}
+>
+	<HeadingAnchor {id}>
+		{@render children?.()}
+	</HeadingAnchor>
 </h5>

--- a/docs/src/lib/components/markdown/h5.svelte
+++ b/docs/src/lib/components/markdown/h5.svelte
@@ -16,7 +16,7 @@
 	{id}
 	{...restProps}
 >
-	<HeadingAnchor {id}>
+	<HeadingAnchor id={id ?? undefined}>
 		{@render children?.()}
 	</HeadingAnchor>
 </h5>

--- a/docs/src/lib/components/markdown/h6.svelte
+++ b/docs/src/lib/components/markdown/h6.svelte
@@ -16,7 +16,7 @@
 	{id}
 	{...restProps}
 >
-	<HeadingAnchor {id}>
+	<HeadingAnchor id={id ?? undefined}>
 		{@render children?.()}
 	</HeadingAnchor>
 </h6>

--- a/docs/src/lib/components/markdown/h6.svelte
+++ b/docs/src/lib/components/markdown/h6.svelte
@@ -1,10 +1,22 @@
 <script lang="ts">
 	import type { HTMLAttributes } from "svelte/elements";
 	import { cn } from "$lib/utils/styles.js";
+	import HeadingAnchor from "./heading-anchor.svelte";
 
-	let { class: className, children, ...restProps }: HTMLAttributes<HTMLHeadingElement> = $props();
+	let {
+		class: className,
+		children,
+		id,
+		...restProps
+	}: HTMLAttributes<HTMLHeadingElement> = $props();
 </script>
 
-<h6 class={cn("mt-8 scroll-m-20 text-base font-semibold tracking-tight", className)} {...restProps}>
-	{@render children?.()}
+<h6
+	class={cn("mt-8 scroll-m-20 text-base font-semibold tracking-tight", className)}
+	{id}
+	{...restProps}
+>
+	<HeadingAnchor {id}>
+		{@render children?.()}
+	</HeadingAnchor>
 </h6>

--- a/docs/src/lib/components/markdown/heading-anchor.svelte
+++ b/docs/src/lib/components/markdown/heading-anchor.svelte
@@ -1,0 +1,24 @@
+<script lang="ts">
+	import type { Snippet } from "svelte";
+
+	let {
+		id,
+		children,
+	}: {
+		id?: string;
+		children?: Snippet;
+	} = $props();
+</script>
+
+{#if id}
+	<a class="group no-underline" href="#{id}">
+		<span class="underline-offset-4 group-hover:underline">
+			{@render children?.()}
+		</span>
+		<span aria-hidden="true" class="ml-2 text-muted-foreground opacity-0 group-hover:opacity-100">
+			#
+		</span>
+	</a>
+{:else}
+	{@render children?.()}
+{/if}


### PR DESCRIPTION
## Summary

Port of [shadcn-ui/ui@bc2db187](https://github.com/shadcn-ui/ui/commit/bc2db187aabeb6707cc32f3de1a5553c96894b2d).

- Adds a new `HeadingAnchor` Svelte component that wraps heading content with a clickable `#` anchor link
- Updates all MDX heading components (`h1`–`h6`) to explicitly accept and pass through the `id` prop (already set by `rehype-slug`) and wrap children with `HeadingAnchor`
- On hover, headings reveal a `#` symbol and underline the text, linking to `#<heading-id>` for easy deep-linking

## Implementation notes

The bits-ui docs already use `rehype-slug` (in `mdsx.config.js`) which auto-generates `id` attributes on headings from their text content. The `HeadingAnchor` component reuses those existing IDs rather than computing them from scratch (as shadcn does). The result is equivalent: every heading becomes a shareable anchor link.

## Test plan

- [ ] Build the docs site and verify headings show `#` on hover and link to `#<id>`
- [ ] Verify headings without an `id` (no `rehype-slug` id) render children as plain text (no broken link)
- [ ] Check that existing deep links / in-page navigation still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)