### PR TITLE
chore: migrate CF Pages deploys to cloudflare/wrangler-action

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -27,11 +27,9 @@ jobs:
                   run-id: ${{ github.event.workflow_run.id }}
 
             - name: Deploy to Cloudflare Pages
-              uses: AdrianGonz97/refined-cf-pages-action@v1
+              uses: cloudflare/wrangler-action@v3
               with:
                   apiToken: ${{ secrets.CF_API_TOKEN }}
                   accountId: ${{ secrets.CF_ACCOUNT_ID }}
-                  githubToken: ${{ secrets.GITHUB_TOKEN }}
-                  projectName: bits-ui
-                  deploymentName: Preview
-                  directory: ${{ steps.preview-build-artifact.outputs.download-path }}/cloudflare
+                  gitHubToken: ${{ secrets.GITHUB_TOKEN }}
+                  command: pages deploy ${{ steps.preview-build-artifact.outputs.download-path }}/cloudflare --project-name=bits-ui


### PR DESCRIPTION
\`AdrianGonz97/refined-cf-pages-action\` is [deprecated](https://github.com/marketplace/actions/cloudflare-pages-github-action). Replaces it with the official \`cloudflare/wrangler-action@v3\` using \`wrangler pages deploy\`.