### PR TITLE
fix(AlertDialog): pass `disabled` through to button in `AlertDialog.Cancel`

### DIFF
--- a/.changeset/tall-cameras-ask.md
+++ b/.changeset/tall-cameras-ask.md
@@ -1,0 +1,5 @@
+---
+"bits-ui": patch
+---
+
+fix(AlertDialog): pass `disabled` through to button in `AlertDialog.Cancel`

--- a/packages/bits-ui/src/lib/bits/dialog/dialog.svelte.ts
+++ b/packages/bits-ui/src/lib/bits/dialog/dialog.svelte.ts
@@ -484,6 +484,7 @@ export class AlertDialogCancelState {
 				onclick: this.onclick,
 				onkeydown: this.onkeydown,
 				tabindex: 0,
+				disabled: this.opts.disabled.current,
 				...this.root.sharedProps,
 				...this.attachment,
 			}) as const


### PR DESCRIPTION
Fixes #2065 