### PR TITLE
Fix Firefox warning messages

### DIFF
--- a/packages/bits-ui/src/lib/bits/utilities/floating-layer/use-floating-layer.svelte.ts
+++ b/packages/bits-ui/src/lib/bits/utilities/floating-layer/use-floating-layer.svelte.ts
@@ -191,7 +191,7 @@ export class FloatingContentState {
 	arrowX = $derived.by(() => this.floating.middlewareData.arrow?.x ?? 0);
 	arrowY = $derived.by(() => this.floating.middlewareData.arrow?.y ?? 0);
 	cannotCenterArrow = $derived.by(() => this.floating.middlewareData.arrow?.centerOffset !== 0);
-	contentZIndex = $state<string>();
+	contentZIndex = $state<string>("auto");
 	arrowBaseSide = $derived(OPPOSITE_SIDE[this.placedSide]);
 	wrapperProps = $derived.by(
 		() =>


### PR DESCRIPTION
On Firefox there are warning messages in the console because the z-index is not correct. These messages appear cosmetic and the code appears to work. I get quite a number of the warnings, which clutters the console when debugging.

To reproduce, create a dropdown menu, open the code in Firefox, look at the console. I typically see ~5 messages every time I click a dropdown menu. When I apply this fix the messages disappear. I see no functionality problems with this fix applied.