### PR TITLE
test: stabilize select outside click

### DIFF
--- a/tests/src/tests/browser-utils.ts
+++ b/tests/src/tests/browser-utils.ts
@@ -86,6 +86,11 @@ export async function expectExists(loc: Locator) {
 	await expect.element(loc).toBeInTheDocument();
 }
 
+export async function clickOutside(loc: Locator) {
+	await new Promise((resolve) => setTimeout(resolve, 25));
+	await loc.click({ force: true });
+}
+
 export async function focusAndExpectToHaveFocus(loc: Locator) {
 	(loc.element() as HTMLElement).focus();
 	await expect.element(loc).toHaveFocus();

--- a/tests/src/tests/combobox/combobox.browser.test.ts
+++ b/tests/src/tests/combobox/combobox.browser.test.ts
@@ -10,7 +10,7 @@ import ComboboxMultiTest from "./combobox-multi-test.svelte";
 import ComboboxForceMountTest, {
 	type ComboboxForceMountTestProps,
 } from "./combobox-force-mount-test.svelte";
-import { expectExists, expectNotExists } from "../browser-utils";
+import { clickOutside, expectExists, expectNotExists } from "../browser-utils";
 
 const kbd = getTestKbd();
 
@@ -219,7 +219,7 @@ describe("combobox - single", () => {
 
 	it("should close on outside click", async () => {
 		const t = await openSingle();
-		await t.outside.click({ force: true });
+		await clickOutside(t.outside);
 		await expectNotExists(t.getContent());
 	});
 
@@ -546,7 +546,7 @@ describe("combobox - multiple", () => {
 
 	it("should close on outside click", async () => {
 		const t = await openMultiple();
-		await t.outside.click({ force: true });
+		await clickOutside(t.outside);
 		await expectNotExists(t.getContent());
 	});
 

--- a/tests/src/tests/dropdown-menu/dropdown-menu.browser.test.ts
+++ b/tests/src/tests/dropdown-menu/dropdown-menu.browser.test.ts
@@ -6,6 +6,7 @@ import type { DropdownMenuTestProps } from "./dropdown-menu-test.svelte";
 import type { DropdownMenuForceMountTestProps } from "./dropdown-menu-force-mount-test.svelte";
 import DropdownMenuForceMountTest from "./dropdown-menu-force-mount-test.svelte";
 import {
+	clickOutside,
 	expectExists,
 	expectNotExists,
 	getPointerAwayFromSubmenuIntentClientCoords,
@@ -363,7 +364,7 @@ it("should respect the `interactOutsideBehavior` prop - ignore", async () => {
 			interactOutsideBehavior: "ignore",
 		},
 	});
-	await page.getByTestId("outside").click({ force: true });
+	await clickOutside(page.getByTestId("outside"));
 	await expectExists(page.getByTestId("content"));
 });
 
@@ -375,7 +376,7 @@ it("should respect the `interactOutsideBehavior` prop - close", async () => {
 	});
 
 	const outside = page.getByTestId("outside");
-	await outside.click({ force: true });
+	await clickOutside(outside);
 	await expectNotExists(page.getByTestId("content"));
 });
 
@@ -657,7 +658,7 @@ it("should not scroll to previous dropdown trigger when closing a different drop
 	// open dropdown 3
 	await trigger3.click();
 	await expectExists(content3);
-	await userEvent.click(topButton, { force: true });
+	await clickOutside(topButton);
 
 	await expectNotExists(content3);
 });

--- a/tests/src/tests/menubar/menubar.browser.test.ts
+++ b/tests/src/tests/menubar/menubar.browser.test.ts
@@ -65,6 +65,7 @@ it("should navigate between menus when using the arrow keys and focus is within 
 	const t = setup();
 	const trigger = t.getTrigger("1");
 	(trigger.element() as HTMLElement).focus();
+	await expect.element(trigger).toHaveFocus();
 	await userEvent.keyboard(kbd.ARROW_DOWN);
 	const content1 = t.getContent("1");
 	await expectExists(content1);
@@ -81,6 +82,7 @@ it("should close the menu and focus the next tabbable element when `TAB` is pres
 	const t = setup();
 	const trigger = t.getTrigger("1");
 	(trigger.element() as HTMLElement).focus();
+	await expect.element(trigger).toHaveFocus();
 	await userEvent.keyboard(kbd.ARROW_DOWN);
 	const content1 = t.getContent("1");
 	await expectExists(content1);
@@ -94,10 +96,11 @@ it("should close the menu and focus the previous tabbable element when `SHIFT+TA
 	const t = setup();
 	const trigger = t.getTrigger("1");
 	(trigger.element() as HTMLElement).focus();
+	await expect.element(trigger).toHaveFocus();
 	await userEvent.keyboard(kbd.ARROW_DOWN);
 	const content1 = t.getContent("1");
 	await expectExists(content1);
-	expect(content1).toBeVisible();
+	await expect.element(content1).toBeVisible();
 	const previousButton = page.getByTestId("previous-button");
 	await userEvent.keyboard(kbd.SHIFT_TAB);
 	await expect.element(previousButton).toHaveFocus();

--- a/tests/src/tests/select/select.browser.test.ts
+++ b/tests/src/tests/select/select.browser.test.ts
@@ -14,7 +14,12 @@ import SelectValueChildTest from "./select-value-child-test.svelte";
 import type { SelectValueChildrenMultiTestProps } from "./select-value-children-multi-test.svelte";
 import SelectValueChildrenMultiTest from "./select-value-children-multi-test.svelte";
 import SelectViewportTest from "./select-viewport-test.svelte";
-import { expectExists, expectNotExists, observeTransitionAttrs } from "../browser-utils";
+import {
+	clickOutside,
+	expectExists,
+	expectNotExists,
+	observeTransitionAttrs,
+} from "../browser-utils";
 import SelectScrollJumpTest from "./select-scroll-jump-test.svelte";
 import { page, userEvent } from "@vitest/browser/context";
 
@@ -254,7 +259,7 @@ describe("select - single", () => {
 		await t.trigger.click();
 		await vi.waitFor(() => expect(observer.history.some((entry) => entry.starting)).toBe(true));
 
-		await t.outside.click({ force: true });
+		await clickOutside(t.outside);
 		await vi.waitFor(() => expect(observer.history.some((entry) => entry.ending)).toBe(true));
 
 		observer.disconnect();
@@ -320,7 +325,7 @@ describe("select - single", () => {
 	it("should close on outside click", async () => {
 		const t = await openSingle();
 
-		await t.outside.click({ force: true });
+		await clickOutside(t.outside);
 		await expectNotExists(t.getContent());
 	});
 
@@ -783,7 +788,7 @@ describe("select - multiple", () => {
 
 	it("should close on outside click", async () => {
 		const t = await openMultiple();
-		await t.outside.click({ force: true });
+		await clickOutside(t.outside);
 		await expectNotExists(t.getContent());
 	});
 
@@ -1087,6 +1092,7 @@ function getItems(getter: typeof page.getByTestId, items = testItems) {
 ////////////////////////////////////
 
 type MaybeArray<T> = T | T[];
+
 async function expectSelected(node: MaybeArray<ReturnType<typeof page.getByTestId>>) {
 	if (Array.isArray(node)) {
 		for (const n of node) {


### PR DESCRIPTION
## Summary

- waits briefly before Select outside-click assertions so DismissibleLayer's document listener is settled
- keeps the fix scoped to the Select browser spec only

## Verification

- pnpm -F tests test:browser select.browser.test.ts