### PR TITLE
fix(Select): guard IME composition-commit Enter (keyCode 229)

### DIFF
--- a/.changeset/select-ime-enter-keycode-229.md
+++ b/.changeset/select-ime-enter-keycode-229.md
@@ -1,0 +1,5 @@
+---
+"bits-ui": patch
+---
+
+fix(Select): don't commit the highlighted item on an IME composition-commit Enter in Safari (`keyCode === 229`), matching the guard already used in Command. This also fixes Combobox, which shares the same input keydown handler.

--- a/packages/bits-ui/src/lib/bits/select/select.svelte.ts
+++ b/packages/bits-ui/src/lib/bits/select/select.svelte.ts
@@ -565,7 +565,10 @@ export class SelectInputState {
 			return;
 		}
 
-		if (e.key === kbd.ENTER && !e.isComposing) {
+		// `e.keyCode === 229` covers Safari + Japanese IME, where `isComposing` is not
+		// set while composing, so an IME-commit Enter would otherwise select an item.
+		// Mirrors the Enter guard in `command.svelte.ts`.
+		if (e.key === kbd.ENTER && !e.isComposing && e.keyCode !== 229) {
 			e.preventDefault();
 
 			const isCurrentSelectedValue =

--- a/tests/src/tests/combobox/combobox.browser.test.ts
+++ b/tests/src/tests/combobox/combobox.browser.test.ts
@@ -186,6 +186,31 @@ describe("combobox - single", () => {
 		await expect.element(page.getByTestId("input")).toHaveValue("B");
 	});
 
+	it("should not select an item on enter while composing with an IME (keyCode 229)", async () => {
+		await openSingle();
+		await expect.element(page.getByTestId("input")).toHaveFocus();
+		await userEvent.keyboard(kbd.ARROW_DOWN);
+		await expect.element(page.getByTestId("2")).toHaveAttribute("data-highlighted");
+
+		// Safari + Japanese IME deliver the composition-commit Enter with `keyCode === 229`
+		// and `isComposing === false`, so it must not commit the highlighted item.
+		page.getByTestId("input").element().dispatchEvent(
+			new KeyboardEvent("keydown", {
+				key: "Enter",
+				keyCode: 229,
+				bubbles: true,
+				cancelable: true,
+			})
+		);
+		await tick();
+		await expect.element(page.getByTestId("content")).toBeVisible();
+		await expect.element(page.getByTestId("input")).not.toHaveValue("B");
+
+		// a normal Enter (keyCode 13, not composing) still commits the selection
+		await userEvent.keyboard(kbd.ENTER);
+		await expect.element(page.getByTestId("input")).toHaveValue("B");
+	});
+
 	it("should render an input if the `name` prop is passed", async () => {
 		const t = setupSingle();
 		await expect.element(t.getHiddenInput()).toBeInTheDocument();


### PR DESCRIPTION
## Problem

`SelectInputState.onkeydown` (in `select.svelte.ts`, shared by both the `Select` and `Combobox` inputs) commits the highlighted item on Enter as long as the user is not composing:

```ts
if (e.key === kbd.ENTER && !e.isComposing) {
```

In Safari with a Japanese (or other CJK) IME, the Enter that commits the IME composition arrives with `isComposing === false` and `keyCode === 229`. So `!e.isComposing` is true, the guard misses it, and the highlighted item gets selected (and the menu closes) while the user only meant to confirm what they typed.

`Command` already guards against exactly this in `command.svelte.ts`, with a comment explaining why:

```ts
// e.keyCode === 229 is for the Japanese IME && Safari as `isComposing` does not
// work with Japanese IME and Safari in combination.
if (!e.isComposing && e.keyCode !== 229) {
```

The select input handler was missing the `keyCode === 229` half of that check, so `Select`/`Combobox` and `Command` behave differently for the same IME.

## Change

- Add `&& e.keyCode !== 229` to the Enter guard in `select.svelte.ts`, mirroring `Command`.
- Add a `Combobox` regression test: with item 2 highlighted, an Enter delivered with `keyCode === 229` leaves the menu open and selects nothing, while a normal Enter still commits the selection.

The fix lives in `SelectInputState`, which is also used by `combobox-input.svelte`, so this covers both components.

## Verification

I traced the keydown path to confirm the fix: without it, the `keyCode === 229` Enter passes the old guard and reaches `toggleItem` + `handleClose`; with it, the Enter branch is skipped and the event falls through to the `INTERACTION_KEYS` early return, so the menu stays open and nothing is selected. A plain Enter (`keyCode 13`) still selects, which the existing "select item with the enter key" test covers.

I was not able to run the browser test suite locally (the `pnpm` postinstall scripts fail on my Windows setup and the runner needs a downloaded browser), so the new test is unrun here. It follows the existing `dispatchEvent` idiom used in the accordion tests and the Enter/highlight assertions from the existing combobox test, so CI should exercise it. Happy to adjust the test or its placement.
