### PR TITLE
fix(Command): rename item's data-selected attribute to data-highlighted

### DIFF
--- a/.changeset/heavy-hairs-hover.md
+++ b/.changeset/heavy-hairs-hover.md
@@ -1,0 +1,5 @@
+---
+"bits-ui": minor
+---
+
+breaking(Command): rename `Command.Item`'s transient `data-selected` attribute to `data-highlighted` to prevent Chromium `:has([data-selected])` invalidation collisions with Calendar/Select persistent selection (#2044) — migrate `[data-selected]`/`data-selected:` styles on Command items to `data-highlighted`; `aria-selected` is unchanged

--- a/docs/src/lib/components/demos/command-demo-dialog.svelte
+++ b/docs/src/lib/components/demos/command-demo-dialog.svelte
@@ -61,21 +61,21 @@
 							</Command.GroupHeading>
 							<Command.GroupItems>
 								<Command.Item
-									class="rounded-button data-selected:bg-muted outline-hidden flex h-10 cursor-pointer select-none items-center gap-2 px-3 py-2.5 text-sm capitalize"
+									class="rounded-button data-highlighted:bg-muted outline-hidden flex h-10 cursor-pointer select-none items-center gap-2 px-3 py-2.5 text-sm capitalize"
 									keywords={["getting started", "tutorial"]}
 								>
 									<Sticker class="size-4" />
 									Introduction
 								</Command.Item>
 								<Command.Item
-									class="rounded-button data-selected:bg-muted outline-hidden flex h-10 cursor-pointer select-none items-center gap-2 px-3 py-2.5 text-sm capitalize"
+									class="rounded-button data-highlighted:bg-muted outline-hidden flex h-10 cursor-pointer select-none items-center gap-2 px-3 py-2.5 text-sm capitalize"
 									keywords={["child", "custom element", "snippets"]}
 								>
 									<CodeBlock class="size-4 " />
 									Delegation
 								</Command.Item>
 								<Command.Item
-									class="rounded-button data-selected:bg-muted outline-hidden flex h-10 cursor-pointer select-none items-center gap-2 px-3 py-2.5 text-sm capitalize"
+									class="rounded-button data-highlighted:bg-muted outline-hidden flex h-10 cursor-pointer select-none items-center gap-2 px-3 py-2.5 text-sm capitalize"
 									keywords={["css", "theme", "colors", "fonts", "tailwind"]}
 								>
 									<Palette class="size-4" />
@@ -92,21 +92,21 @@
 							</Command.GroupHeading>
 							<Command.GroupItems>
 								<Command.Item
-									class="rounded-button data-selected:bg-muted outline-hidden flex h-10 cursor-pointer select-none items-center gap-2 px-3 py-2.5 text-sm capitalize"
+									class="rounded-button data-highlighted:bg-muted outline-hidden flex h-10 cursor-pointer select-none items-center gap-2 px-3 py-2.5 text-sm capitalize"
 									keywords={["dates", "times"]}
 								>
 									<CalendarBlank class="size-4" />
 									Calendar
 								</Command.Item>
 								<Command.Item
-									class="rounded-button data-selected:bg-muted outline-hidden flex h-10 cursor-pointer select-none items-center gap-2 px-3 py-2.5 text-sm capitalize"
+									class="rounded-button data-highlighted:bg-muted outline-hidden flex h-10 cursor-pointer select-none items-center gap-2 px-3 py-2.5 text-sm capitalize"
 									keywords={["buttons", "forms"]}
 								>
 									<RadioButton class="size-4" />
 									Radio Group
 								</Command.Item>
 								<Command.Item
-									class="rounded-button data-selected:bg-muted outline-hidden flex h-10 cursor-pointer select-none items-center gap-2 px-3 py-2.5 text-sm capitalize"
+									class="rounded-button data-highlighted:bg-muted outline-hidden flex h-10 cursor-pointer select-none items-center gap-2 px-3 py-2.5 text-sm capitalize"
 									keywords={["inputs", "text", "autocomplete"]}
 								>
 									<Textbox class="size-4" />

--- a/docs/src/lib/components/demos/command-demo.svelte
+++ b/docs/src/lib/components/demos/command-demo.svelte
@@ -28,21 +28,21 @@
 				</Command.GroupHeading>
 				<Command.GroupItems>
 					<Command.Item
-						class="rounded-button data-selected:bg-muted outline-hidden flex h-10 cursor-pointer select-none items-center gap-2 px-3 py-2.5 text-sm capitalize"
+						class="rounded-button data-highlighted:bg-muted outline-hidden flex h-10 cursor-pointer select-none items-center gap-2 px-3 py-2.5 text-sm capitalize"
 						keywords={["getting started", "tutorial"]}
 					>
 						<Sticker class="size-4" />
 						Introduction
 					</Command.Item>
 					<Command.Item
-						class="rounded-button data-selected:bg-muted outline-hidden flex h-10 cursor-pointer select-none items-center gap-2 px-3 py-2.5 text-sm capitalize"
+						class="rounded-button data-highlighted:bg-muted outline-hidden flex h-10 cursor-pointer select-none items-center gap-2 px-3 py-2.5 text-sm capitalize"
 						keywords={["child", "custom element", "snippets"]}
 					>
 						<CodeBlock class="size-4 " />
 						Delegation
 					</Command.Item>
 					<Command.Item
-						class="rounded-button data-selected:bg-muted outline-hidden flex h-10 cursor-pointer select-none items-center gap-2 px-3 py-2.5 text-sm capitalize"
+						class="rounded-button data-highlighted:bg-muted outline-hidden flex h-10 cursor-pointer select-none items-center gap-2 px-3 py-2.5 text-sm capitalize"
 						keywords={["css", "theme", "colors", "fonts", "tailwind"]}
 					>
 						<Palette class="size-4" />
@@ -57,21 +57,21 @@
 				</Command.GroupHeading>
 				<Command.GroupItems>
 					<Command.Item
-						class="rounded-button data-selected:bg-muted outline-hidden flex h-10 cursor-pointer select-none items-center gap-2 px-3 py-2.5 text-sm capitalize"
+						class="rounded-button data-highlighted:bg-muted outline-hidden flex h-10 cursor-pointer select-none items-center gap-2 px-3 py-2.5 text-sm capitalize"
 						keywords={["dates", "times"]}
 					>
 						<CalendarBlank class="size-4" />
 						Calendar
 					</Command.Item>
 					<Command.Item
-						class="rounded-button data-selected:bg-muted outline-hidden flex h-10 cursor-pointer select-none items-center gap-2 px-3 py-2.5 text-sm capitalize"
+						class="rounded-button data-highlighted:bg-muted outline-hidden flex h-10 cursor-pointer select-none items-center gap-2 px-3 py-2.5 text-sm capitalize"
 						keywords={["buttons", "forms"]}
 					>
 						<RadioButton class="size-4" />
 						Radio Group
 					</Command.Item>
 					<Command.Item
-						class="rounded-button data-selected:bg-muted outline-hidden flex h-10 cursor-pointer select-none items-center gap-2 px-3 py-2.5 text-sm capitalize"
+						class="rounded-button data-highlighted:bg-muted outline-hidden flex h-10 cursor-pointer select-none items-center gap-2 px-3 py-2.5 text-sm capitalize"
 						keywords={["inputs", "text", "autocomplete"]}
 					>
 						<Textbox class="size-4" />

--- a/docs/src/lib/components/demos/command-grid-demo.svelte
+++ b/docs/src/lib/components/demos/command-grid-demo.svelte
@@ -184,7 +184,7 @@
 						<Command.GroupItems class="grid grid-cols-8 gap-2 px-2">
 							{#each group.items as groupItem (groupItem)}
 								<Command.Item
-									class="rounded-button bg-muted data-selected:ring-foreground outline-hidden flex aspect-square size-full cursor-pointer select-none items-center justify-center text-2xl ring-2 ring-transparent aria-disabled:cursor-not-allowed aria-disabled:opacity-50"
+									class="rounded-button bg-muted data-highlighted:ring-foreground outline-hidden flex aspect-square size-full cursor-pointer select-none items-center justify-center text-2xl ring-2 ring-transparent aria-disabled:cursor-not-allowed aria-disabled:opacity-50"
 									keywords={groupItem.keywords}
 									disabled={groupItem.disabled}
 								>
@@ -216,7 +216,7 @@
 						<Command.GroupItems>
 							{#each group.items as groupItem (groupItem)}
 								<Command.Item
-									class="rounded-button data-selected:bg-muted outline-hidden flex h-10 cursor-pointer select-none items-center gap-2 px-3 py-2.5 text-sm capitalize"
+									class="rounded-button data-highlighted:bg-muted outline-hidden flex h-10 cursor-pointer select-none items-center gap-2 px-3 py-2.5 text-sm capitalize"
 									keywords={groupItem.keywords}
 									disabled={groupItem.disabled}
 									onSelect={groupItem.action}

--- a/docs/src/lib/components/examples/command/framer/framer.css
+++ b/docs/src/lib/components/examples/command/framer/framer.css
@@ -63,7 +63,7 @@
 		transition: all 150ms ease;
 		transition-property: none;
 
-		&[data-selected] {
+		&[data-highlighted] {
 			background: var(--blue9);
 			color: #ffffff;
 

--- a/docs/src/lib/components/examples/command/linear/linear.css
+++ b/docs/src/lib/components/examples/command/linear/linear.css
@@ -75,7 +75,7 @@
 		transition-property: none;
 		position: relative;
 
-		&[data-selected] {
+		&[data-highlighted] {
 			background: var(--gray3);
 
 			svg {

--- a/docs/src/lib/components/examples/command/raycast/raycast.css
+++ b/docs/src/lib/components/examples/command/raycast/raycast.css
@@ -153,7 +153,7 @@
 		transition: all 150ms ease;
 		transition-property: none;
 
-		&[data-selected] {
+		&[data-highlighted] {
 			background: var(--gray4);
 			color: var(--gray12);
 		}

--- a/docs/src/lib/components/examples/command/vercel/vercel.css
+++ b/docs/src/lib/components/examples/command/vercel/vercel.css
@@ -66,7 +66,7 @@
 		transition: all 150ms ease;
 		transition-property: none;
 
-		&[data-selected] {
+		&[data-highlighted] {
 			background: var(--grayA3);
 			color: var(--gray12);
 		}

--- a/docs/src/lib/components/search.svelte
+++ b/docs/src/lib/components/search.svelte
@@ -127,7 +127,7 @@
 									{#each results as { title, href, snippet, category } (title + href)}
 										<Command.LinkItem
 											{href}
-											class="rounded-button data-selected:bg-muted outline-hidden flex cursor-pointer select-none flex-col items-start gap-1 px-3 py-2.5 text-sm"
+											class="rounded-button data-highlighted:bg-muted outline-hidden flex cursor-pointer select-none flex-col items-start gap-1 px-3 py-2.5 text-sm"
 											onSelect={() => {
 												searchQuery = "";
 												open = false;

--- a/docs/src/lib/content/api-reference/command.api.ts
+++ b/docs/src/lib/content/api-reference/command.api.ts
@@ -242,8 +242,8 @@ const item = defineComponentApiSchema<CommandItemPropsWithoutHTML>({
 			description: "Present when the item is disabled.",
 		}),
 		defineSimpleDataAttr({
-			name: "selected",
-			description: "Present when the item is selected.",
+			name: "highlighted",
+			description: "Present when the item is highlighted, via keyboard navigation or pointer hover.",
 		}),
 		defineSimpleDataAttr({
 			name: "command-item",

--- a/docs/src/lib/styles/command/command.css
+++ b/docs/src/lib/styles/command/command.css
@@ -231,7 +231,7 @@
 			height: 14px;
 		}
 
-		&[data-selected] {
+		&[data-highlighted] {
 			color: var(--gray12);
 
 			&:hover .activeTheme {

--- a/packages/bits-ui/src/lib/bits/command/command.svelte.ts
+++ b/packages/bits-ui/src/lib/bits/command/command.svelte.ts
@@ -439,7 +439,7 @@ export class CommandRootState {
 		const node = this.opts.ref.current;
 		if (!node) return;
 		const selectedNode = node.querySelector<HTMLElement>(
-			`${COMMAND_VALID_ITEM_SELECTOR}[data-selected]`
+			`${COMMAND_VALID_ITEM_SELECTOR}[data-highlighted]`
 		);
 		if (!selectedNode) return;
 		return selectedNode;
@@ -1477,7 +1477,7 @@ export class CommandItemState {
 				"aria-disabled": boolToStr(this.opts.disabled.current),
 				"aria-selected": boolToStr(this.isSelected),
 				"data-disabled": boolToEmptyStrOrUndef(this.opts.disabled.current),
-				"data-selected": boolToEmptyStrOrUndef(this.isSelected),
+				"data-highlighted": boolToEmptyStrOrUndef(this.isSelected),
 				"data-value": this.trueValue,
 				"data-group": this.#group?.trueValue,
 				[commandAttrs.item]: "",

--- a/tests/src/tests/command/command-grid.browser.test.ts
+++ b/tests/src/tests/command/command-grid.browser.test.ts
@@ -25,12 +25,12 @@ function setup(props: Partial<ComponentProps<typeof CommandGridTest>> = {}) {
 it("should select the first item by default", async () => {
 	setup();
 
-	await expect.element(page.getByText("Introduction")).toHaveAttribute("data-selected");
+	await expect.element(page.getByText("Introduction")).toHaveAttribute("data-highlighted");
 });
 
 it("should allow forcing the selected value", async () => {
 	setup({ value: "Introduction" });
-	await expect.element(page.getByText("Introduction")).toHaveAttribute("data-selected");
+	await expect.element(page.getByText("Introduction")).toHaveAttribute("data-highlighted");
 });
 
 it("should render the separator when search is empty and remove it when search is not empty", async () => {
@@ -74,13 +74,13 @@ it("should restore original order when search is cleared", async () => {
 	input.focus();
 	await userEvent.keyboard("d");
 	await expect.element(t.input).toHaveValue("d");
-	await expect.element(page.getByText("Delegation")).toHaveAttribute("data-selected");
+	await expect.element(page.getByText("Delegation")).toHaveAttribute("data-highlighted");
 	await expect
 		.element(page.getByTestId("group-a-items").element().children[0])
 		.toHaveTextContent("Delegation");
 	await userEvent.keyboard(kbd.BACKSPACE);
 	await expect.element(t.input).toHaveValue("");
-	await expect.element(page.getByText("Introduction")).toHaveAttribute("data-selected");
+	await expect.element(page.getByText("Introduction")).toHaveAttribute("data-highlighted");
 	await expect
 		.element(page.getByTestId("group-a-items").element().children[0])
 		.toHaveTextContent("Introduction");
@@ -92,18 +92,18 @@ it("should hide the group if all items are filtered out", async () => {
 	await userEvent.type(t.input.element(), "radio");
 	await expect.element(page.getByTestId("group-a")).not.toBeVisible();
 	await expect.element(page.getByTestId("group-b")).toBeVisible();
-	await expect.element(page.getByText("Radio Group")).toHaveAttribute("data-selected");
+	await expect.element(page.getByText("Radio Group")).toHaveAttribute("data-highlighted");
 });
 
 it("should navigate to the correct column in the next row", async () => {
 	const t = setup();
-	await expect.element(page.getByText("Introduction")).toHaveAttribute("data-selected");
+	await expect.element(page.getByText("Introduction")).toHaveAttribute("data-highlighted");
 	await userEvent.type(t.input.element(), kbd.ARROW_DOWN);
-	await expect.element(page.getByText("Calendar")).toHaveAttribute("data-selected");
+	await expect.element(page.getByText("Calendar")).toHaveAttribute("data-highlighted");
 	await userEvent.type(t.input.element(), kbd.ARROW_UP);
-	await expect.element(page.getByText("Introduction")).toHaveAttribute("data-selected");
+	await expect.element(page.getByText("Introduction")).toHaveAttribute("data-highlighted");
 	await userEvent.type(t.input.element(), kbd.ARROW_RIGHT);
-	await expect.element(page.getByText("Delegation")).toHaveAttribute("data-selected");
+	await expect.element(page.getByText("Delegation")).toHaveAttribute("data-highlighted");
 	await userEvent.type(t.input.element(), kbd.ARROW_DOWN);
-	await expect.element(page.getByText("Radio Group")).toHaveAttribute("data-selected");
+	await expect.element(page.getByText("Radio Group")).toHaveAttribute("data-highlighted");
 });

--- a/tests/src/tests/command/command-scroll.browser.test.ts
+++ b/tests/src/tests/command/command-scroll.browser.test.ts
@@ -24,7 +24,7 @@ it("should scroll initial value into view when it's not the first item", async (
 	setup({ value: "Popover" });
 
 	const item = page.getByText("Popover");
-	await expect.element(item).toHaveAttribute("data-selected");
+	await expect.element(item).toHaveAttribute("data-highlighted");
 
 	// check that the item is visible in the viewport
 	const itemElement = item.element() as HTMLElement;
@@ -45,7 +45,7 @@ it("should scroll initial value in the middle of the list into view", async () =
 	setup({ value: "Radio Group" });
 
 	const item = page.getByText("Radio Group");
-	await expect.element(item).toHaveAttribute("data-selected");
+	await expect.element(item).toHaveAttribute("data-highlighted");
 
 	const itemElement = item.element() as HTMLElement;
 	const viewport = page.getByTestId("viewport").element() as HTMLElement;
@@ -65,7 +65,7 @@ it("should respect disableInitialScroll prop and not scroll", async () => {
 	setup({ value: "Popover", disableInitialScroll: true });
 
 	const item = page.getByText("Popover");
-	await expect.element(item).toHaveAttribute("data-selected");
+	await expect.element(item).toHaveAttribute("data-highlighted");
 
 	const viewport = page.getByTestId("viewport").element() as HTMLElement;
 
@@ -80,7 +80,7 @@ it("should not scroll when initial value is the first item", async () => {
 	setup({ value: "Introduction" });
 
 	const item = page.getByText("Introduction");
-	await expect.element(item).toHaveAttribute("data-selected");
+	await expect.element(item).toHaveAttribute("data-highlighted");
 
 	const viewport = page.getByTestId("viewport").element() as HTMLElement;
 

--- a/tests/src/tests/command/command.browser.test.ts
+++ b/tests/src/tests/command/command.browser.test.ts
@@ -27,29 +27,29 @@ it("should select the first item by default", async () => {
 
 	// since we aren't hardcoding a value for the item, we need to wait for
 	// the component to render before we can check if the first item is selected
-	await expect.element(page.getByText("Introduction")).toHaveAttribute("data-selected");
+	await expect.element(page.getByText("Introduction")).toHaveAttribute("data-highlighted");
 });
 
 it("should allow forcing the selected value", async () => {
 	setup({ value: "Introduction" });
 
-	await expect.element(page.getByText("Introduction")).toHaveAttribute("data-selected");
+	await expect.element(page.getByText("Introduction")).toHaveAttribute("data-highlighted");
 });
 
 it("should respect initial value when it's not the first item", async () => {
 	setup({ value: "Radio Group" });
 
 	// ensure the initial value is selected, not the first item
-	await expect.element(page.getByText("Radio Group")).toHaveAttribute("data-selected");
-	await expect.element(page.getByText("Introduction")).not.toHaveAttribute("data-selected");
+	await expect.element(page.getByText("Radio Group")).toHaveAttribute("data-highlighted");
+	await expect.element(page.getByText("Introduction")).not.toHaveAttribute("data-highlighted");
 });
 
 it("should respect initial value for items in the first group", async () => {
 	setup({ value: "Styling" });
 
 	// ensure the provided value is selected, not the first item
-	await expect.element(page.getByText("Styling")).toHaveAttribute("data-selected");
-	await expect.element(page.getByText("Introduction")).not.toHaveAttribute("data-selected");
+	await expect.element(page.getByText("Styling")).toHaveAttribute("data-highlighted");
+	await expect.element(page.getByText("Introduction")).not.toHaveAttribute("data-highlighted");
 });
 
 it("should render the separator when search is empty and remove it when search is not empty", async () => {
@@ -88,13 +88,13 @@ it("should restore original order when search is cleared", async () => {
 	(t.input.element() as HTMLElement).focus();
 	await userEvent.keyboard("d");
 	await expect.element(t.input).toHaveValue("d");
-	await expect.element(page.getByText("Delegation")).toHaveAttribute("data-selected");
+	await expect.element(page.getByText("Delegation")).toHaveAttribute("data-highlighted");
 	await expect
 		.element(page.getByTestId("group-a-items").element().children[0])
 		.toHaveTextContent("Delegation");
 	await userEvent.keyboard(kbd.BACKSPACE);
 	await expect.element(t.input).toHaveValue("");
-	await expect.element(page.getByText("Introduction")).toHaveAttribute("data-selected");
+	await expect.element(page.getByText("Introduction")).toHaveAttribute("data-highlighted");
 	await expect
 		.element(page.getByTestId("group-a-items").element().children[0])
 		.toHaveTextContent("Introduction");
@@ -106,5 +106,5 @@ it("should hide the group if all items are filtered out", async () => {
 	await userEvent.type(t.input, "radio");
 	await expect.element(page.getByTestId("group-a")).not.toBeVisible();
 	await expect.element(page.getByTestId("group-b")).toBeVisible();
-	await expect.element(page.getByText("Radio Group")).toHaveAttribute("data-selected");
+	await expect.element(page.getByText("Radio Group")).toHaveAttribute("data-highlighted");
 });


### PR DESCRIPTION
# fix(Command): rename `Command.Item`'s `data-selected` to `data-highlighted`

Fixes #2044

## Problem

`Command.Item` toggles `data-selected` on every pointer-hover transition (2 attribute mutations per item change). Calendar, RangeCalendar, Select, and Pagination use the same attribute name for **persistent** selection.

Chromium's `:has()` invalidation is document-global: every attribute name appearing inside any `:has()` argument goes into one flat feature set, and any mutation of such an attribute triggers an ancestor walk that invalidates every `:has()`-anchored element's subtree. So a single consumer rule written for the *calendar* —

```css
.\[\&\:has\(\[data-selected\]\)\]\:bg-accent:has([data-selected]) { background-color: var(--accent); }
```

— combined with a broad anchor like shadcn-svelte's `<body class="group/body">` (every `group-has-*/body:*` utility makes `<body>` a `:has()` anchor) turns each Command hover into a whole-document style recalc.

Measured on a shadcn-svelte-style page (~3,700 elements, real shadcn-svelte.com stylesheet):

| | avg per `data-selected` toggle |
|---|---|
| stylesheet as shipped | **247.45 ms** |
| identical stylesheet with only that one rule removed | 0.01 ms |

Hovering across items produces 250 ms+ frames per transition — the combobox freezes and skips items. On shadcn-svelte.com itself: 108.5 ms per toggle vs 0.00 ms for a control attribute.

Standalone repro with the benchmark harness (loads the real shadcn-svelte.com stylesheet in full/stripped variants): https://github.com/jose-manuel-silva/bits-ui-2044-repro

## Fix

Rename the transient hover/keyboard-navigation attribute to `data-highlighted`, the convention bits-ui already uses for exactly this state in `Select`, `Combobox`, `Menu`, and `RangeCalendar`'s hover range preview. This breaks the name collision, so selection-styling `:has([data-selected])` rules no longer observe Command's hover churn. `aria-selected` is unchanged (Base UI and cmdk keep it for the active option).

`data-selected` on Calendar/RangeCalendar/Select/Pagination is untouched — there it denotes genuine persistent selection and only mutates on click.

## Breaking change

Consumers styling Command items via `[data-selected]` / Tailwind `data-selected:` must switch to `[data-highlighted]` / `data-highlighted:`. Changeset is marked `minor`; happy to bump to `major` if preferred.

A dual-emission deprecation period (emitting both attributes for a release cycle) unfortunately can't work here: the `data-selected` *mutations themselves* are what trigger the `:has()` invalidation, so keeping the old attribute keeps the bug. The rename has to be clean.

shadcn-svelte's `command` component will need the corresponding one-line class updates (can PR that separately once this lands).

## Changes

- `packages/bits-ui/src/lib/bits/command/command.svelte.ts` — emit `data-highlighted` on `Command.Item` (inherited by `Command.LinkItem`); update the internal `#getSelectedItem()` selector.
- `tests/src/tests/command/{command,command-scroll,command-grid}.browser.test.ts` — assertions updated.
- `docs/src/lib/content/api-reference/command.api.ts` — data-attribute table: `selected` → `highlighted`.
- `docs/src/lib/styles/command/command.css`, example CSS (vercel/linear/framer/raycast), `command-demo*.svelte`, `command-grid-demo.svelte`, `search.svelte` — docs-site styling migrated.
- `.changeset/heavy-hairs-hover.md`

Left alone: Combobox tests' `data-selected` assertions (persistent selection — the model Command is being aligned to) and `theme-switcher.svelte`'s author-owned `data-selected={isActive}` button attribute.

## Note on #2074

Open PR #2074 (`fix(Command): item selection logic`) adds a test asserting `data-selected` on Command items. The source regions don't overlap, but whichever PR lands second needs a small test update — happy to rebase this branch once #2074 merges.

## Test plan

- `pnpm vitest run src/tests/command` — 42/42 pass (chromium + webkit).
- `pnpm run check` + `pnpm run build` in `packages/bits-ui` — clean.
- Repro benchmark from #2044: with the rename, hover produces zero `data-selected` mutations and no long frames with the full shadcn stylesheet loaded.

---

*Written by Fable 5, reviewed by me.*
