### PR TITLE
fix: cancel DismissibleLayer afterSleep timer on destroy (#2080)

### DIFF
--- a/.changeset/calm-layers-rest.md
+++ b/.changeset/calm-layers-rest.md
@@ -1,0 +1,5 @@
+---
+"bits-ui": patch
+---
+
+fix(DismissibleLayer): cancel pending `afterSleep` timer on destroy to prevent `derived_inert` and stale document listeners (#2080)

--- a/packages/bits-ui/src/lib/bits/utilities/dismissible-layer/use-dismissable-layer.svelte.ts
+++ b/packages/bits-ui/src/lib/bits/utilities/dismissible-layer/use-dismissable-layer.svelte.ts
@@ -59,8 +59,21 @@ export class DismissibleLayerState {
 		});
 
 		let unsubEvents = noop;
+		// Track the deferred afterSleep timer so teardown can cancel it. Without this,
+		// a layer destroyed within the 1ms window still fires the callback and reads a
+		// destroyed $derived (`ref.current`) → `derived_inert` (and can re-attach document
+		// listeners to a dead instance). See https://github.com/huntabyte/bits-ui/issues/2080
+		let pendingTimer: ReturnType<typeof afterSleep> | null = null;
+		let destroyed = false;
+		const clearPendingTimer = () => {
+			if (pendingTimer != null) {
+				clearTimeout(pendingTimer);
+				pendingTimer = null;
+			}
+		};
 
 		const cleanup = () => {
+			clearPendingTimer();
 			this.#resetState();
 			globalThis.bitsDismissableLayers.delete(this);
 			this.#handleInteractOutside.destroy();
@@ -69,8 +82,11 @@ export class DismissibleLayerState {
 
 		watch([() => this.opts.enabled.current, () => this.opts.ref.current], () => {
 			if (!this.opts.enabled.current || !this.opts.ref.current) return;
-			afterSleep(1, () => {
-				if (!this.opts.ref.current) return;
+			clearPendingTimer();
+			pendingTimer = afterSleep(1, () => {
+				pendingTimer = null;
+				// `destroyed` must short-circuit before any `this.opts.ref.current` read.
+				if (destroyed || !this.opts.ref.current) return;
 				globalThis.bitsDismissableLayers.set(this, this.#behaviorType);
 
 				unsubEvents();
@@ -80,6 +96,8 @@ export class DismissibleLayerState {
 		});
 
 		onDestroyEffect(() => {
+			destroyed = true;
+			clearPendingTimer();
 			this.#resetState.destroy();
 			globalThis.bitsDismissableLayers.delete(this);
 			this.#handleInteractOutside.destroy();

--- a/tests/src/tests/dialog/dialog.browser.test.ts
+++ b/tests/src/tests/dialog/dialog.browser.test.ts
@@ -748,3 +748,61 @@ describe("Scroll Lock", () => {
 		expect(document.body.style.paddingRight).toBe(initialPadding);
 	});
 });
+
+/**
+ * Regression for https://github.com/huntabyte/bits-ui/issues/2080
+ *
+ * DismissibleLayer used to schedule afterSleep(1) without cancelling on destroy.
+ * Unmounting (or remounting) within that window left a timer that read a destroyed
+ * $derived and could re-attach document pointerdown listeners to a dead instance.
+ */
+describe("DismissibleLayer teardown (derived_inert / #2080)", () => {
+	function installDerivedInertCounter() {
+		const counts = { inert: 0 };
+		const orig = console.warn.bind(console);
+		console.warn = (...args: unknown[]) => {
+			const text = args.map(String).join(" ");
+			if (text.includes("derived_inert")) counts.inert += 1;
+			orig(...args);
+		};
+		return {
+			counts,
+			restore: () => {
+				console.warn = orig;
+			},
+		};
+	}
+
+	it("should not emit derived_inert when unmounted while open", async () => {
+		const counter = installDerivedInertCounter();
+		try {
+			const t = render(DialogTest, { open: true });
+			await expectExists(page.getByTestId("content"));
+			// Unmount while the layer is live — races the afterSleep(1) attach window.
+			await t.unmount();
+			await new Promise((r) => setTimeout(r, 50));
+			expect(counter.counts.inert).toBe(0);
+		} finally {
+			counter.restore();
+		}
+	});
+
+	it("should not auto-dismiss on sequential open after close via trigger-cycle", async () => {
+		const counter = installDerivedInertCounter();
+		try {
+			await open();
+			await page.getByTestId("close").click();
+			await expectNotExists(page.getByTestId("content"));
+
+			// Immediate pointer reopen — stale document listeners used to fire
+			// onInteractOutside on the new layer (~10ms debounce) and close it.
+			await page.getByTestId("trigger").click();
+			await expectExists(page.getByTestId("content"));
+			await new Promise((r) => setTimeout(r, 50));
+			await expectExists(page.getByTestId("content"));
+			expect(counter.counts.inert).toBe(0);
+		} finally {
+			counter.restore();
+		}
+	});
+});


### PR DESCRIPTION
## Context

Hi maintainers 👋

Thank you for Bits UI — we rely on it heavily for Dialog / Sheet / Popover surfaces in a Svelte 5 app, and we are grateful for the care that goes into the headless layer.

While working through browser-test noise on our side, we kept hitting Svelte’s `derived_inert` warning when floating layers unmounted quickly. That led us to **#2080**, which already describes the race clearly. We would like to offer a small, focused patch as a **proposal** — happy to iterate if you prefer a different shape.

## Root cause (what we validated)

In `DismissibleLayerState` (`use-dismissable-layer.svelte.ts`), setup schedules:

```ts
afterSleep(1, () => {
  if (!this.opts.ref.current) return;
  globalThis.bitsDismissableLayers.set(this, this.#behaviorType);
  unsubEvents = this.#addEventListeners();
});
```

What we observed when a layer is destroyed **within that ~1 ms window** (common under vitest-browser cleanup, rapid navigation, or CPU contention):

1. `onDestroyEffect` runs while `unsubEvents` is still a no-op (the real subscribe has not happened yet).
2. The pending `afterSleep` timer is **not** cancelled.
3. ~1 ms later the callback still runs on a destroyed instance and reads `this.opts.ref.current` → Svelte emits `derived_inert`.
4. If that read is still truthy, document-level `pointerdown` listeners can be attached to a dead layer and never cleaned up — aligning with the comment on #2080 about reopened dialogs self-closing ~10 ms later (stale `onInteractOutside` + debounce).

We confirmed stacks in a real SvelteKit + vitest-browser suite (`bits-ui@2.18.1`) converging on:

- `get current` (svelte-toolbelt Box / `ref` derived)
- `#markResponsibleLayer` / the deferred attach path
- document-level `pointerdown`

This is the same family of teardown race already documented in #2080; we are not claiming a new root cause, only re-validating it end-to-end before suggesting a fix.

## Proposed change

Minimal lifecycle hygiene, aligned with the suggested fix in #2080 and with patterns already used elsewhere in this repo (e.g. clearing timers in Select / Popover / Menu):

1. Keep a handle to the `afterSleep` timer (`pendingTimer`).
2. Cancel it in both `cleanup()` and `onDestroyEffect`.
3. Set a `destroyed` flag on teardown and **short-circuit on `destroyed` before any `this.opts.ref.current` read** (so JS never touches the destroyed derived).

No public API changes. No behavior change for the happy path (layer lives longer than 1 ms).

## Tests

Added two browser regressions under `tests/src/tests/dialog/dialog.browser.test.ts`:

- unmount while open → assert `console.warn` does **not** contain `derived_inert`
- close → immediate pointer reopen → dialog stays open ≥ 50 ms and no `derived_inert`

Local verification (after `pnpm build:packages`):

```bash
cd tests
pnpm exec vitest run --project=browser --browser=chromium   src/tests/dialog/dialog.browser.test.ts
```

**Result:** `43 passed | 1 todo` (full dialog browser file, Chromium).

> Note: this environment cannot run WebKit (macOS 12 + Playwright limitation), so CI coverage on WebKit will need your pipeline — happy to adjust if anything fails there.

We also exercised the same patch against our app’s LookupModal / ResponsiveSheet vitest-browser suite (open → unmount, open → close → open) with **zero** `derived_inert` warnings after the change.

## Invitation / next steps

This is offered as a collaborative starting point, not a demand that the fix must land exactly this way. If you would rather:

- extract a shared “cancel deferred work on destroy” helper,
- guard additional call sites in the same family (Avatar / floating / link-preview were mentioned in related issues), or
- reshape the tests,

we are very happy to follow your guidance and update the PR.

Closes #2080

Thank you for considering this, and for the excellent library 🙏