### PR TITLE
feat(Checkbox): Pass `form` prop to the hidden input

### DIFF
--- a/.changeset/light-shirts-rule.md
+++ b/.changeset/light-shirts-rule.md
@@ -1,0 +1,5 @@
+---
+"bits-ui": minor
+---
+
+feat(Checkbox): pass `form` to the hidden input

--- a/docs/src/lib/content/api-reference/checkbox.api.ts
+++ b/docs/src/lib/content/api-reference/checkbox.api.ts
@@ -58,6 +58,9 @@ export const root = defineComponentApiSchema<CheckboxRootPropsWithoutHTML>({
 			description:
 				"The name of the checkbox. If provided a hidden input will be render to use for form submission. If not provided, the hidden input will not be rendered.",
 		}),
+		form: defineStringProp({
+			description: "The id of a form element the hidden input will be attached.",
+		}),
 		value: defineStringProp({
 			description:
 				"The value of the checkbox. This is what is submitted with the form when the checkbox is checked.",

--- a/packages/bits-ui/src/lib/bits/checkbox/checkbox.svelte.ts
+++ b/packages/bits-ui/src/lib/bits/checkbox/checkbox.svelte.ts
@@ -131,6 +131,7 @@ interface CheckboxRootStateOpts
 			required: boolean;
 			readonly: boolean;
 			name: string | undefined;
+			form: string | undefined;
 			value: string | undefined;
 			type: HTMLButtonAttributes["type"];
 		}>,
@@ -296,6 +297,7 @@ export class CheckboxInputState {
 				disabled: this.root.trueDisabled,
 				required: this.root.trueRequired,
 				name: this.root.trueName,
+				form: this.root.opts.form.current,
 				value: this.root.opts.value.current,
 				readonly: this.root.trueReadonly,
 				onfocus: this.onfocus,

--- a/packages/bits-ui/src/lib/bits/checkbox/components/checkbox.svelte
+++ b/packages/bits-ui/src/lib/bits/checkbox/components/checkbox.svelte
@@ -16,6 +16,7 @@
 		disabled = false,
 		required = false,
 		name = undefined,
+		form = undefined,
 		value = "on",
 		id = createId(uid),
 		indeterminate = $bindable(false),
@@ -61,6 +62,7 @@
 			disabled: boxWith(() => disabled ?? false),
 			required: boxWith(() => required),
 			name: boxWith(() => name),
+			form: boxWith(() => form),
 			value: boxWith(() => value),
 			id: boxWith(() => id),
 			ref: boxWith(

--- a/packages/bits-ui/src/lib/bits/checkbox/types.ts
+++ b/packages/bits-ui/src/lib/bits/checkbox/types.ts
@@ -43,6 +43,13 @@ export type CheckboxRootPropsWithoutHTML = WithChild<
 		name?: any;
 
 		/**
+		 * The id of the form to link the hidden input to.
+		 *
+		 * @default undefined
+		 */
+		form?: string;
+
+		/**
 		 * The value of the checkbox used in form submission and to identify
 		 * the checkbox when in a `Checkbox.Group`. If not provided while in a
 		 * `Checkbox.Group`, the checkbox will use a random identifier.

--- a/tests/src/tests/checkbox/checkbox.browser.test.ts
+++ b/tests/src/tests/checkbox/checkbox.browser.test.ts
@@ -76,9 +76,10 @@ describe("Single Checkbox", () => {
 		});
 
 		it("should render the checkbox input if a name prop is passed", async () => {
-			setup({ name: "checkbox" });
+			setup({ name: "checkbox", form: "login" });
 			await expectExists(getHiddenInput());
 			await expect.element(getHiddenInput()).toHaveAttribute("type", "checkbox");
+			await expect.element(getHiddenInput()).toHaveAttribute("form", "login");
 		});
 
 		it("should not have input as part of tab order", async () => {


### PR DESCRIPTION
This PR adds handling of the `form` prop for checkboxes so it is applied to the hidden input (if rendered). This way the checkbox component can be attached to forms they are not a dom child of.