### PR TITLE
fix(Menu): correct roles on GroupHeading and Separator

### DIFF
--- a/.changeset/menu-heading-separator-roles.md
+++ b/.changeset/menu-heading-separator-roles.md
@@ -1,0 +1,5 @@
+---
+"bits-ui": patch
+---
+
+fix(Menu): `Menu.GroupHeading` no longer sets `role="group"`, `Menu.Separator` now sets `role="separator"`

--- a/packages/bits-ui/src/lib/bits/menu/menu.svelte.ts
+++ b/packages/bits-ui/src/lib/bits/menu/menu.svelte.ts
@@ -1627,7 +1627,6 @@ export class MenuGroupHeadingState {
 		() =>
 			({
 				id: this.opts.id.current,
-				role: "group",
 				[this.group.root.getBitsAttr("group-heading")]: "",
 				...this.attachment,
 			}) as const
@@ -1655,7 +1654,7 @@ export class MenuSeparatorState {
 		() =>
 			({
 				id: this.opts.id.current,
-				role: "group",
+				role: "separator",
 				[this.root.getBitsAttr("separator")]: "",
 				...this.attachment,
 			}) as const

--- a/tests/src/tests/dropdown-menu/dropdown-menu.browser.test.ts
+++ b/tests/src/tests/dropdown-menu/dropdown-menu.browser.test.ts
@@ -119,6 +119,24 @@ it("should have bits data attrs", async () => {
 	await expect.element(subContent).toHaveAttribute(`data-dropdown-menu-sub-content`);
 });
 
+it("should not expose the group heading and separator as groups", async () => {
+	const t = await setup();
+	await t.trigger.click();
+
+	// The group itself is the only `group` in the menu — a heading is the group's
+	// accessible name (referenced by `aria-labelledby`, which works off the id, not the
+	// role), and a separator is a separator. Exposing either as `role="group"` puts empty
+	// groups into the a11y tree. This also matches `Select`/`Command`, whose group
+	// headings set no role at all.
+	await expect.element(page.getByTestId("group")).toHaveAttribute("role", "group");
+	await expect.element(page.getByTestId("separator")).toHaveAttribute("role", "separator");
+	expect(page.getByTestId("group-heading").element().hasAttribute("role")).toBe(false);
+
+	// The heading still names its group.
+	const headingId = page.getByTestId("group-heading").element().id;
+	await expect.element(page.getByTestId("group")).toHaveAttribute("aria-labelledby", headingId);
+});
+
 it.each(OPEN_KEYS)("should open when %s is pressed & respects binding", async (key) => {
 	await openWithKbd({}, key);
 	await expect.element(page.getByTestId("item")).toHaveFocus();


### PR DESCRIPTION
Fixes #2090.

`Menu.GroupHeading` and `Menu.Separator` both render `role="group"`, so a menu that uses them ends up with empty groups in the accessibility tree — a group whose only content is a heading, and another whose only content is a divider.

https://github.com/huntabyte/bits-ui/blob/main/packages/bits-ui/src/lib/bits/menu/menu.svelte.ts#L1630
https://github.com/huntabyte/bits-ui/blob/main/packages/bits-ui/src/lib/bits/menu/menu.svelte.ts#L1658

Both look like copy-paste from `MenuGroupState` right above them.

## The fix follows conventions already in this repo

- **`GroupHeading` → no role.** `SelectGroupHeadingState` and `CommandGroupHeadingState` set only an `id`, and that is enough: the heading names its group through the group's `aria-labelledby`, which references it by `id` and does not depend on a role.
- **`Separator` → `role="separator"`.** The top-level `SeparatorRootState` already resolves `decorative ? "none" : "separator"`, so the menu one was the odd one out.

`MenuGroupState`, `MenuRadioGroupState` and `MenuCheckboxGroupState` keep `role="group"` — correct for those.

## Testing

Added a case to `dropdown-menu.browser.test.ts` asserting the group is the only `group`, the separator is a `separator`, the heading carries no role, and the heading still names its group via `aria-labelledby`. Reverting either line of the fix turns it red.

`pnpm -F tests test:browser --browser chromium`:
- `dropdown-menu` — 45 passed
- `context-menu` + `menubar` (same `menu.svelte.ts`) — 49 passed, 1 skipped

`pnpm lint` clean, `prettier --check` clean, changeset included (patch).

## Note for consumers

Anyone who worked around this by overriding `role` after spreading props (that was us) can drop the override once this lands — `GroupHeading` will render no role at all, so a stale `role={undefined}` override stays harmless either way.
