### PR TITLE
fix: render `id` on Popper-based content elements

### DIFF
--- a/.changeset/spotty-pandas-repeat.md
+++ b/.changeset/spotty-pandas-repeat.md
@@ -1,0 +1,5 @@
+---
+"bits-ui": patch
+---
+
+fix: render the `id` attribute on Popper-based content elements (Tooltip, Popover, Select, Combobox, DropdownMenu, ContextMenu, Menubar, LinkPreview) so `aria-describedby` on triggers resolves correctly

--- a/packages/bits-ui/src/lib/bits/utilities/popper-layer/popper-layer-inner.svelte
+++ b/packages/bits-ui/src/lib/bits/utilities/popper-layer/popper-layer-inner.svelte
@@ -122,6 +122,7 @@
 										dismissibleProps,
 										focusScopeProps,
 										{
+											id,
 											style: {
 												pointerEvents: contentPointerEvents,
 											},

--- a/tests/src/tests/tooltip/tooltip.browser.test.ts
+++ b/tests/src/tests/tooltip/tooltip.browser.test.ts
@@ -62,6 +62,13 @@ it("should have bits data attrs", async () => {
 	}
 });
 
+it("should render an id on the content and reference it via aria-describedby on the trigger", async () => {
+	const t = await open();
+	const contentId = (t.content.element() as HTMLElement).id;
+	expect(contentId).not.toBe("");
+	await expect.element(t.trigger).toHaveAttribute("aria-describedby", contentId);
+});
+
 it("should use provider delay duration if provided and the tooltip.root did not provide one", async () => {
 	const t = setup();
 	expect(t.trigger).toHaveAttribute("data-delay-duration", "0");


### PR DESCRIPTION
## Summary

Fixes #2093

`Tooltip.Content` (and all other Popper-based content: Popover, Select, Combobox, DropdownMenu, ContextMenu, Menubar, LinkPreview) rendered without an `id` attribute, so the trigger's `aria-describedby` — which reads `contentNode.id` — resolved to an empty string, breaking the accessible description association.

## Root cause

In `popper-layer-inner.svelte`, the `id` prop is destructured (and passed to `DismissibleLayer` / `TextSelectionLayer`), but it was never included in the `mergeProps()` call that builds the props handed to the `popper` snippet. None of the other merged prop sources (`floatingProps`, `dismissibleProps`, `focusScopeProps`) contribute an `id`, so it never reached the rendered element. The force-mount path forwards through the same component, so both paths are covered by the one-line fix.

## Changes

- Add `id` to the `mergeProps()` call in `popper-layer-inner.svelte`
- Add a browser test asserting `Tooltip.Content` renders a non-empty `id` and that the trigger's `aria-describedby` references it (the existing singleton test compared `"" === ""` and could not catch this)
- Changeset (patch)

## Testing

- New test fails before the fix (`expected '' not to be ''`) and passes after
- Full chromium browser suites for all popper-layer consumers pass: tooltip, popover, link-preview, select, combobox, dropdown-menu, context-menu, menubar (367 tests)
- `pnpm build:packages` (svelte-package + publint) clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)