### PR TITLE
fix(RadioGroup): don't select item on pointer-driven focus

### DIFF
--- a/.changeset/salty-jars-wave.md
+++ b/.changeset/salty-jars-wave.md
@@ -1,0 +1,5 @@
+---
+"bits-ui": patch
+---
+
+fix(RadioGroup): don't select item on pointer-driven focus- #2098

--- a/packages/bits-ui/src/lib/bits/radio-group/radio-group.svelte.ts
+++ b/packages/bits-ui/src/lib/bits/radio-group/radio-group.svelte.ts
@@ -44,6 +44,12 @@ export class RadioGroupRootState {
 	readonly hasValue = $derived.by(() => this.opts.value.current !== "");
 	readonly rovingFocusGroup: RovingFocusGroup;
 	readonly attachment: RefAttachment;
+	/**
+	 * Whether focus is currently being moved by keyboard navigation within the
+	 * group. Items only select on focus during keyboard navigation — pointer
+	 * (and programmatic) focus waits for the click to commit the selection.
+	 */
+	isKeyboardNavigating = false;
 
 	constructor(opts: RadioGroupRootStateOpts) {
 		this.opts = opts;
@@ -139,6 +145,7 @@ export class RadioGroupItemState {
 
 	onfocus(_: BitsFocusEvent) {
 		if (!this.root.hasValue || this.#isReadonly) return;
+		if (!this.root.isKeyboardNavigating) return;
 		this.root.setValue(this.opts.value.current);
 	}
 
@@ -151,7 +158,14 @@ export class RadioGroupItemState {
 			}
 			return;
 		}
-		this.root.rovingFocusGroup.handleKeydown(this.opts.ref.current, e, true);
+		// `handleKeydown` moves focus synchronously, so the flag is observed by
+		// the newly focused item's `onfocus` before it resets.
+		this.root.isKeyboardNavigating = true;
+		try {
+			this.root.rovingFocusGroup.handleKeydown(this.opts.ref.current, e, true);
+		} finally {
+			this.root.isKeyboardNavigating = false;
+		}
 	}
 
 	readonly snippetProps = $derived.by(() => ({ checked: this.#isChecked }));

--- a/tests/src/tests/radio-group/radio-group.browser.test.ts
+++ b/tests/src/tests/radio-group/radio-group.browser.test.ts
@@ -89,6 +89,28 @@ describe("Value Changes", () => {
 			.toHaveTextContent("true");
 	});
 
+	it("should not change the value when an unselected item receives focus without keyboard navigation", async () => {
+		setup({ value: "b" });
+
+		const aItem = page.getByTestId("a-item");
+		(aItem.element() as HTMLElement).focus();
+		await expect.element(aItem).toHaveFocus();
+
+		await expect.element(page.getByTestId("b-indicator")).toHaveTextContent("true");
+		await expect.element(page.getByTestId("a-indicator")).toHaveTextContent("false");
+	});
+
+	it("should select the newly focused item when navigating with the keyboard and a value is set", async () => {
+		setup({ value: "a" });
+
+		(page.getByTestId("a-item").element() as HTMLElement).focus();
+		await userEvent.keyboard(kbd.ARROW_DOWN);
+
+		await expect.element(page.getByTestId("b-item")).toHaveFocus();
+		await expect.element(page.getByTestId("b-indicator")).toHaveTextContent("true");
+		await expect.element(page.getByTestId("a-indicator")).toHaveTextContent("false");
+	});
+
 	it("should respect the value prop & binding", async () => {
 		setup({ value: "b" });
 		const binding = page.getByTestId("binding");


### PR DESCRIPTION
Addresses https://github.com/huntabyte/bits-ui/issues/2097

Pointer press focuses the item, and the focus handler committed the selection whenever the group had a value — checking the radio on mousedown before the click. Gate select-on-focus behind a root flag set only while roving-focus keydown handling moves focus, so arrow/Home/End navigation still selects the newly focused item while pointer and programmatic focus wait for the click to commit. Matches native radios, Radix, and Base UI.