### PR TITLE
fix/year backspace clearing

### DIFF
--- a/.changeset/fuzzy-years-focus.md
+++ b/.changeset/fuzzy-years-focus.md
@@ -1,0 +1,5 @@
+---
+"bits-ui": patch
+---
+
+fix(DateField): keep focus on the year while correcting its first digit

--- a/packages/bits-ui/src/lib/bits/date-field/date-field.svelte.ts
+++ b/packages/bits-ui/src/lib/bits/date-field/date-field.svelte.ts
@@ -1226,7 +1226,7 @@ class DateFieldYearSegmentState extends BaseNumericSegmentState {
 
 			if (prev === null) {
 				this.announcer.announce(num);
-				return `000${num}`;
+				return `${num}`;
 			}
 
 			const str = prev.toString() + num.toString();
@@ -1266,10 +1266,6 @@ class DateFieldYearSegmentState extends BaseNumericSegmentState {
 			moveToNext = true;
 		}
 
-		if (this.#backspaceCount > 0 && this.#pressedKeys.length === this.#backspaceCount) {
-			moveToNext = true;
-		}
-
 		if (moveToNext) {
 			moveToNextSegment(e, this.root.getFieldNode());
 		}
@@ -1295,7 +1291,7 @@ class DateFieldYearSegmentState extends BaseNumericSegmentState {
 			const next = str.slice(0, -1);
 			this.announcer.announce(Number.parseInt(next));
 			return next;
-	});
+		});
 
 		if (moveToPrev) {
 			moveToPrevSegment(e, this.root.getFieldNode());

--- a/packages/bits-ui/src/lib/bits/date-field/date-field.svelte.ts
+++ b/packages/bits-ui/src/lib/bits/date-field/date-field.svelte.ts
@@ -211,6 +211,7 @@ export class DateFieldRootState {
 	descriptionNode = $state<HTMLElement | null>(null);
 	validationNode = $state<HTMLElement | null>(null);
 	states = initSegmentStates();
+	#segmentClearedValue = false;
 	dayPeriodNode = $state<HTMLElement | null>(null);
 	rangeRoot: DateRangeFieldRootState | undefined = undefined;
 	name = $state("");
@@ -311,6 +312,10 @@ export class DateFieldRootState {
 
 		$effect(() => {
 			if (this.value.current === undefined) {
+				if (this.#segmentClearedValue) {
+					this.#segmentClearedValue = false;
+					return;
+				}
 				this.segmentValues = initializeSegmentValues(this.inferredGranularity);
 			}
 		});
@@ -680,6 +685,7 @@ export class DateFieldRootState {
 				})
 			);
 		} else {
+			this.#segmentClearedValue = true;
 			this.setValue(undefined);
 			this.segmentValues = newSegmentValues;
 		}
@@ -1234,6 +1240,9 @@ class DateFieldYearSegmentState extends BaseNumericSegmentState {
 					str.length <= 4
 				) {
 					this.announcer.announce(mergedInt);
+					if (str.length === 4) {
+						moveToNext = true;
+					}
 					return str;
 				}
 
@@ -1253,7 +1262,11 @@ class DateFieldYearSegmentState extends BaseNumericSegmentState {
 			return mergedIntStr;
 		});
 
-		if (this.#pressedKeys.length === 4 || this.#pressedKeys.length === this.#backspaceCount) {
+		if (this.#pressedKeys.length === 4) {
+			moveToNext = true;
+		}
+
+		if (this.#backspaceCount > 0 && this.#pressedKeys.length === this.#backspaceCount) {
 			moveToNext = true;
 		}
 
@@ -1280,10 +1293,9 @@ class DateFieldYearSegmentState extends BaseNumericSegmentState {
 				return null;
 			}
 			const next = str.slice(0, -1);
-			this.announcer.announce(next);
-
-			return `${next}`;
-		});
+			this.announcer.announce(Number.parseInt(next));
+			return next;
+	});
 
 		if (moveToPrev) {
 			moveToPrevSegment(e, this.root.getFieldNode());

--- a/tests/src/tests/date-field/date-field.browser.test.ts
+++ b/tests/src/tests/date-field/date-field.browser.test.ts
@@ -650,6 +650,20 @@ describe("date field", () => {
 		await expect.element(hour).toHaveFocus();
 	});
 
+	it("should keep focus on the year after correcting its first digit", async () => {
+		const t = setup({ granularity: "hour" });
+		const { getHour } = getTimeSegments(page.getByTestId);
+
+		await t.year.click();
+		await userEvent.keyboard("1");
+		await userEvent.keyboard(kbd.BACKSPACE);
+		await userEvent.keyboard("2");
+
+		await expect.element(t.year).toHaveTextContent("2");
+		await expect.element(t.year).toHaveFocus();
+		await expect.element(getHour()).not.toHaveFocus();
+	});
+
 	it("should allow going from 12PM -> 12AM without changing the display hour to 0", async () => {
 		setup({
 			value: new CalendarDateTime(2023, 10, 12, 12, 30, 0, 0),

--- a/tests/src/tests/date-field/date-field.browser.test.ts
+++ b/tests/src/tests/date-field/date-field.browser.test.ts
@@ -1103,6 +1103,14 @@ describe("date field", () => {
 		await userEvent.keyboard(kbd.ARROW_DOWN);
 		await expect.element(hour).toHaveTextContent("19");
 	});
+
+	it("should not affect day/month segments when backspacing the year", async () => {
+		const t = setup({ value: new CalendarDate(2023, 10, 12) });
+		await t.year.click();
+		await userEvent.keyboard(kbd.BACKSPACE);
+		await expect.element(t.day).toHaveTextContent("12");
+		await expect.element(t.month).toHaveTextContent("10");
+	});
 });
 
 /**


### PR DESCRIPTION
## Overview

Fixes the DatePicker year-segment backspace behavior described in #2038.

This builds on the work started in #2046 by @joe-herbert, which correctly identified and fixed two of the three underlying issues:

1. Backspacing the year segment down to a single character was clearing the entire date value instead of just the year.
2. Focus was advancing to the next segment prematurely after a typo + backspace + retype sequence.

Both of those fixes are preserved here.

## What changed from #2046

The zero-padding approach used in `#handleYearBackspace` used integer division (`Math.floor(parseInt(prev) / 10)`) and re-padded the result back to 4 digits. In practice this reintroduced a leading zero mid-edit that shouldn't appear until the field is blurred, e.g.:
`"1980"` → backspace → `"0198"` (expected `"198"`)

The fix here replaces that with plain string slicing. Padding back to 4 digits on blur is handled separately by the existing `onfocusout` logic, which was untouched and already correct. This also brings the year segment's backspace behavior in line with how day/month already worked.

A small follow-on fix was also needed in `#handleYearNumberKey`: after backspacing partway through the year, retyping the missing digits wasn't triggering the auto-advance to the next segment, because the advance check only counted raw keystrokes since the last backspace rather than the resulting string length. Fixed by also checking `str.length === 4`.

## CI

One check (`Test / Test - Chromium`) has intermittently failed in this PR's history on `should close on outside click` in `select` and `combobox`, and separately on a `context-menu` test, all via the same shared assertion helper (`expectNotExists` in `src/tests/browser-utils.ts:82`), all unrelated to `date-field.svelte.ts`. The date-field suite itself has passed cleanly on every run, including after this PR's changes. This looks like pre-existing flakiness in that shared helper, happy to open a separate issue with the failure pattern if useful, but wanted to flag it here rather than have it look connected to this change.

## Credit
Thanks @Fardeen0-0 for flagging this issue and picking up where #2046 left off in identifying the CI failures