### PR TITLE
fix(Tooltip): close trigger on pointerdown for any pointer button

### DIFF
--- a/.changeset/pink-jars-clap.md
+++ b/.changeset/pink-jars-clap.md
@@ -1,0 +1,5 @@
+---
+"bits-ui": patch
+---
+
+fix(Tooltip): close `Tooltip.Trigger` on `pointerdown` for any pointer button so right/middle click dismiss the tooltip and cancel a pending delayed open

--- a/docs/content/components/tooltip.md
+++ b/docs/content/components/tooltip.md
@@ -394,7 +394,7 @@ This is ideal for toolbars, nav items, or any group of controls where the user's
 
 ## Close on Trigger Click
 
-By default, the tooltip will close when the user clicks the trigger. If you want to disable this behavior, you can set the `disableCloseOnTriggerClick` prop to `true`.
+By default, the tooltip will close when the user presses the trigger with any pointer button, including right and middle click. If you want to disable this behavior, you can set the `disableCloseOnTriggerClick` prop to `true`.
 
 ```svelte /disableCloseOnTriggerClick/
 <Tooltip.Root disableCloseOnTriggerClick>

--- a/docs/src/lib/content/api-reference/tooltip.api.ts
+++ b/docs/src/lib/content/api-reference/tooltip.api.ts
@@ -64,7 +64,7 @@ const disabled = defineBooleanProp({
 const disableCloseOnTriggerClick = defineBooleanProp({
 	default: false,
 	description:
-		"Whether or not to close the tooltip when pressing the escape key. This is useful when the content contains interactive elements.",
+		"Whether or not to prevent the tooltip from closing when the trigger is pressed with any pointer button.",
 });
 
 const skipDelayDuration = defineNumberProp({

--- a/packages/bits-ui/src/lib/bits/tooltip/tooltip.svelte.ts
+++ b/packages/bits-ui/src/lib/bits/tooltip/tooltip.svelte.ts
@@ -359,6 +359,11 @@ export class TooltipRootState {
 		this.opts.open.current = false;
 	};
 
+	/** Stops a pending delayed open without touching the open state. */
+	cancelPendingOpen = () => {
+		this.#timerFn.stop();
+	};
+
 	#handleDelayedOpen = () => {
 		this.#timerFn.stop();
 
@@ -614,6 +619,18 @@ export class TooltipTriggerState {
 
 	#onpointerdown: PointerEventHandler<HTMLElement> = () => {
 		if (this.#isDisabled()) return;
+		const root = this.#getRoot();
+
+		// close on pointerdown regardless of button so right/middle click dismiss the
+		// tooltip too, and so a pending open timer is cancelled before `contextmenu` fires
+		if (root && !root.disableCloseOnTriggerClick) {
+			if (root.opts.open.current) {
+				root.handleClose();
+			} else {
+				root.cancelPendingOpen();
+			}
+		}
+
 		this.#isPointerDown.current = true;
 
 		this.domContext.getDocument().addEventListener(

--- a/tests/src/tests/tooltip/tooltip.browser.test.ts
+++ b/tests/src/tests/tooltip/tooltip.browser.test.ts
@@ -770,3 +770,54 @@ it("tether: should close when pointer idles in the sibling gap", async () => {
 	await expectNotExists(page.getByTestId("content"));
 	await expect.element(page.getByTestId("open-binding")).toHaveTextContent("false");
 });
+
+function dispatchPointerDown(el: HTMLElement, button: number) {
+	el.dispatchEvent(
+		new PointerEvent("pointerdown", {
+			bubbles: true,
+			pointerType: "mouse",
+			button,
+		})
+	);
+}
+
+it("should close when the trigger is clicked", async () => {
+	const t = await open();
+	await t.trigger.click();
+	await expectNotExists(page.getByTestId("content"));
+});
+
+it("should close when the trigger is right clicked", async () => {
+	const t = await open();
+	await t.trigger.click({ button: "right" });
+	await expectNotExists(page.getByTestId("content"));
+});
+
+it("should close when the trigger is middle clicked", async () => {
+	const t = await open();
+	dispatchPointerDown(t.trigger.element() as HTMLElement, 1);
+	await expectNotExists(page.getByTestId("content"));
+});
+
+it("should not close on non-primary button press when `disableCloseOnTriggerClick` is true", async () => {
+	const t = await open({ disableCloseOnTriggerClick: true });
+	dispatchPointerDown(t.trigger.element() as HTMLElement, 2);
+	await expect.element(t.content).toBeVisible();
+});
+
+it("should cancel a pending delayed open when the trigger is right clicked", async () => {
+	// offset the trigger so the real pointer (parked over the previous test's trigger)
+	// can't land on it and restart the delay timer mid-test
+	const t = setup({
+		delayDuration: 300,
+		triggerProps: { style: "margin: 200px 0 0 300px" },
+	});
+	const el = t.trigger.element() as HTMLElement;
+
+	el.dispatchEvent(new PointerEvent("pointerenter", { bubbles: true, pointerType: "mouse" }));
+	await expectNotExists(page.getByTestId("content"));
+
+	dispatchPointerDown(el, 2);
+	await new Promise<void>((resolve) => setTimeout(resolve, 500));
+	await expectNotExists(page.getByTestId("content"));
+});


### PR DESCRIPTION
Closes #2099

`Tooltip.Trigger` only closed from its `click` handler, so right and middle click left the tooltip open under the native context menu. The dismissible layer doesn't catch it either — it rejects outside interactions with `e.button > 0`.

Close on `pointerdown` regardless of button, as Radix does. The handler already had the matching `isPointerDown` + `pointerup` bookkeeping; only the close was missing.

Two notes:

- Gated by `disableCloseOnTriggerClick`, matching `onInteractOutside`, which already exempts the trigger when that prop is set.
- Cancelling a pending open is split from closing. `handleClose()` writes `open.current = false` unconditionally, which would fire a spurious `onOpenChange(false)` on every pointerdown; `cancelPendingOpen()` just stops the timer.

Also fixed the `disableCloseOnTriggerClick` API-reference description, which described the escape key.

Five tests added; three fail without the fix. Middle-click and pending-open use a synthetic `pointerdown` because WebKit intermittently delivers no events at all for `click({ button: "middle" })`.