### PR TITLE
test: fix the two races behind the recurring CI failures

### DIFF
--- a/tests/src/tests/alert-dialog/alert-dialog.browser.test.ts
+++ b/tests/src/tests/alert-dialog/alert-dialog.browser.test.ts
@@ -4,7 +4,7 @@ import { render } from "vitest-browser-svelte";
 import { getTestKbd } from "../utils.js";
 import AlertDialogTest, { type AlertDialogTestProps } from "./alert-dialog-test.svelte";
 import AlertDialogForceMountTest from "./alert-dialog-force-mount-test.svelte";
-import { expectExists, expectNotExists } from "../browser-utils";
+import { expectExists, expectNotExists, waitForDismissibleLayer } from "../browser-utils";
 
 const kbd = getTestKbd();
 
@@ -22,6 +22,7 @@ async function open(props: AlertDialogTestProps = {}) {
 	await t.trigger.click();
 
 	await expectExists(content);
+	await waitForDismissibleLayer(content);
 
 	const cancel = page.getByTestId("cancel");
 	const action = page.getByTestId("action");

--- a/tests/src/tests/browser-utils.ts
+++ b/tests/src/tests/browser-utils.ts
@@ -86,6 +86,35 @@ export async function expectExists(loc: Locator) {
 	await expect.element(loc).toBeInTheDocument();
 }
 
+type RegisteredLayer = { opts: { ref: { current: HTMLElement | null } } };
+
+/**
+ * Waits until `loc`'s dismissible layer has attached its document listeners.
+ *
+ * `DismissibleLayerState` defers attachment by a tick so the interaction that opened the
+ * layer can't immediately dismiss it, so a `pointerdown` dispatched before that runs is
+ * silently ignored — the layer never sees it and nothing re-delivers it. Content being in
+ * the DOM is therefore not enough to assert on outside-click dismissal: on a loaded CI
+ * machine the deferred callback can land after the test's click, and the assertion fails
+ * for every retry because the load persists.
+ *
+ * Waits on the layer registry the implementation itself reads, so it stays correct however
+ * long attachment is delayed.
+ */
+export async function waitForDismissibleLayer(loc: Locator) {
+	const node = loc.element() as HTMLElement;
+	const getLayers = () =>
+		(globalThis as { bitsDismissableLayers?: Map<RegisteredLayer, unknown> })
+			.bitsDismissableLayers;
+
+	await vi.waitFor(() => {
+		const registered = [...(getLayers() ?? [])].some(
+			([layer]) => layer.opts.ref.current === node
+		);
+		expect(registered, "dismissible layer never attached its listeners").toBe(true);
+	});
+}
+
 export async function focusAndExpectToHaveFocus(loc: Locator) {
 	(loc.element() as HTMLElement).focus();
 	await expect.element(loc).toHaveFocus();

--- a/tests/src/tests/combobox/combobox.browser.test.ts
+++ b/tests/src/tests/combobox/combobox.browser.test.ts
@@ -10,7 +10,7 @@ import ComboboxMultiTest from "./combobox-multi-test.svelte";
 import ComboboxForceMountTest, {
 	type ComboboxForceMountTestProps,
 } from "./combobox-force-mount-test.svelte";
-import { expectExists, expectNotExists } from "../browser-utils";
+import { expectExists, expectNotExists, waitForDismissibleLayer } from "../browser-utils";
 
 const kbd = getTestKbd();
 
@@ -119,6 +119,7 @@ async function openSingle(
 		await returned.user.keyboard(openWith);
 	}
 	await expectExists(page.getByTestId("content"));
+	await waitForDismissibleLayer(page.getByTestId("content"));
 	const content = page.getByTestId("content");
 	const group = page.getByTestId("group");
 	const groupHeading = page.getByTestId("group-label");
@@ -148,6 +149,7 @@ async function openMultiple(
 		await returned.user.keyboard(openWith);
 	}
 	await expectExists(page.getByTestId("content"));
+	await waitForDismissibleLayer(page.getByTestId("content"));
 	const content = page.getByTestId("content");
 	return {
 		...returned,

--- a/tests/src/tests/context-menu/context-menu.browser.test.ts
+++ b/tests/src/tests/context-menu/context-menu.browser.test.ts
@@ -12,6 +12,7 @@ import {
 	getPointerAwayFromSubmenuIntentClientCoords,
 	getPointerLeaveTowardSubmenuClientCoords,
 	getPointerMidpointTowardSubmenuClientCoords,
+	waitForDismissibleLayer,
 } from "../browser-utils";
 import ContextMenuIntegrationTest from "./context-menu-integration-test.svelte";
 import ContextMenuNestedTest from "./context-menu-nested-test.svelte";
@@ -51,6 +52,7 @@ async function open(props: ContextMenuSetupProps = {}) {
 	await expectNotExists(t.getContent());
 	await t.trigger.click({ button: "right" });
 	await expectExists(t.getContent());
+	await waitForDismissibleLayer(t.getContent());
 	return { ...t };
 }
 
@@ -518,6 +520,7 @@ it("should allow switching between context menus via right-click", async () => {
 	render(ContextMenuIntegrationTest);
 	await page.getByTestId("context-trigger-1").click({ button: "right" });
 	await expectExists(page.getByTestId("context-content-1"));
+	await waitForDismissibleLayer(page.getByTestId("context-content-1"));
 	await page.getByTestId("context-trigger-2").click({ button: "right" });
 	await expectNotExists(page.getByTestId("context-content-1"));
 	await expectExists(page.getByTestId("context-content-2"));
@@ -529,6 +532,7 @@ it("should open inside of a dialog", async () => {
 	await expectExists(page.getByTestId("dialog-content"));
 	await page.getByTestId("context-trigger-3").click({ button: "right" });
 	await expectExists(page.getByTestId("context-content-3"));
+	await waitForDismissibleLayer(page.getByTestId("context-content-3"));
 	await expectExists(page.getByTestId("dialog-content"));
 	await page.getByTestId("dialog-content").click({ force: true });
 	await expectExists(page.getByTestId("dialog-content"));
@@ -559,6 +563,7 @@ it("should close a nested popover when interacting with a sibling select trigger
 	render(ContextMenuIntegrationTest);
 	await page.getByTestId("popover-trigger-1").click();
 	await expectExists(page.getByTestId("popover-content-1"));
+	await waitForDismissibleLayer(page.getByTestId("popover-content-1"));
 	await page.getByTestId("select-trigger-1").click();
 	await new Promise((resolve) => setTimeout(resolve, 50));
 	await expectNotExists(page.getByTestId("popover-content-1"));
@@ -569,6 +574,7 @@ it("should close a nested select when interacting with the popover trigger insid
 	render(ContextMenuIntegrationTest);
 	await page.getByTestId("select-trigger-1").click();
 	await expectExists(page.getByTestId("select-content-1"));
+	await waitForDismissibleLayer(page.getByTestId("select-content-1"));
 	await page.getByTestId("popover-trigger-1").click();
 	await new Promise((resolve) => setTimeout(resolve, 50));
 	await expectNotExists(page.getByTestId("select-content-1"));
@@ -579,6 +585,7 @@ it("should close the first nested select when opening the sibling select inside 
 	render(ContextMenuIntegrationTest);
 	await page.getByTestId("select-trigger-1").click();
 	await expectExists(page.getByTestId("select-content-1"));
+	await waitForDismissibleLayer(page.getByTestId("select-content-1"));
 	await page.getByTestId("select-trigger-2").click();
 	await new Promise((resolve) => setTimeout(resolve, 50));
 	await expectNotExists(page.getByTestId("select-content-1"));
@@ -612,6 +619,7 @@ it("should allow overriding the pointer events style", async () => {
 	const trigger = page.getByTestId("trigger");
 	await trigger.click({ button: "right" });
 	await expectExists(page.getByTestId("content"));
+	await waitForDismissibleLayer(page.getByTestId("content"));
 	await trigger.click({ button: "right", force: true });
 	await expectNotExists(page.getByTestId("content"));
 });

--- a/tests/src/tests/date-picker/date-picker.browser.test.ts
+++ b/tests/src/tests/date-picker/date-picker.browser.test.ts
@@ -3,7 +3,12 @@ import { getTestKbd } from "../utils";
 import { expect, it, describe } from "vitest";
 import { render } from "vitest-browser-svelte";
 import DatePickerTest, { type DatePickerTestProps } from "./date-picker-test.svelte";
-import { expectExists, expectNotClickableLoc, expectNotExists } from "../browser-utils";
+import {
+	expectExists,
+	expectNotClickableLoc,
+	expectNotExists,
+	waitForDismissibleLayer,
+} from "../browser-utils";
 import { page, userEvent, type Locator } from "@vitest/browser/context";
 
 const kbd = getTestKbd();
@@ -62,6 +67,7 @@ async function open(props: DatePickerTestProps = {}, openWith: "click" | (string
 		await userEvent.keyboard(openWith);
 	}
 	await expectExists(t.getContent());
+	await waitForDismissibleLayer(t.getContent());
 	const content = page.getByTestId("content");
 	const calendar = page.getByTestId("calendar");
 

--- a/tests/src/tests/date-range-picker/date-range-picker.browser.test.ts
+++ b/tests/src/tests/date-range-picker/date-range-picker.browser.test.ts
@@ -5,7 +5,12 @@ import { render } from "vitest-browser-svelte";
 import DateRangePickerTest, {
 	type DateRangePickerTestProps,
 } from "./date-range-picker-test.svelte";
-import { expectExists, expectNotClickableLoc, expectNotExists } from "../browser-utils";
+import {
+	expectExists,
+	expectNotClickableLoc,
+	expectNotExists,
+	waitForDismissibleLayer,
+} from "../browser-utils";
 import { page, userEvent, type Locator } from "@vitest/browser/context";
 
 const kbd = getTestKbd();
@@ -101,6 +106,7 @@ async function open(
 		await userEvent.keyboard(openWith);
 	}
 	await expectExists(t.getContent());
+	await waitForDismissibleLayer(t.getContent());
 	const content = page.getByTestId("content");
 	const calendar = page.getByTestId("calendar");
 

--- a/tests/src/tests/dialog/dialog.browser.test.ts
+++ b/tests/src/tests/dialog/dialog.browser.test.ts
@@ -5,7 +5,12 @@ import type { Component } from "svelte";
 import { getTestKbd } from "../utils.js";
 import DialogTest, { type DialogTestProps } from "./dialog-test.svelte";
 import DialogNestedTest from "./dialog-nested-test.svelte";
-import { expectExists, expectNotExists, observeTransitionAttrs } from "../browser-utils";
+import {
+	expectExists,
+	expectNotExists,
+	observeTransitionAttrs,
+	waitForDismissibleLayer,
+} from "../browser-utils";
 import DialogForceMountTest from "./dialog-force-mount-test.svelte";
 import DialogIntegrationTest from "./dialog-integration-test.svelte";
 import DialogTooltipTest from "./dialog-tooltip-test.svelte";
@@ -30,6 +35,7 @@ async function open(props: DialogTestProps = {}, component: Component = DialogTe
 	await expectNotExists(page.getByTestId("content"));
 	await t.trigger.click();
 	await expectExists(page.getByTestId("content"));
+	await waitForDismissibleLayer(page.getByTestId("content"));
 	return t;
 }
 

--- a/tests/src/tests/dropdown-menu/dropdown-menu.browser.test.ts
+++ b/tests/src/tests/dropdown-menu/dropdown-menu.browser.test.ts
@@ -11,6 +11,7 @@ import {
 	getPointerAwayFromSubmenuIntentClientCoords,
 	getPointerLeaveTowardSubmenuClientCoords,
 	getPointerMidpointTowardSubmenuClientCoords,
+	waitForDismissibleLayer,
 } from "../browser-utils";
 import DropdownMenuTest from "./dropdown-menu-test.svelte";
 import DropdownMenuMultipleTest from "./dropdown-menu-multiple-test.svelte";
@@ -50,6 +51,7 @@ async function open(props: DropdownMenuSetupProps = {}) {
 	await expectNotExists(t.getContent());
 	await t.trigger.click();
 	await expectExists(t.getContent());
+	await waitForDismissibleLayer(t.getContent());
 	return { ...t };
 }
 
@@ -60,6 +62,7 @@ async function openWithKbd(props: DropdownMenuSetupProps = {}, key: string = kbd
 	await expect.element(t.trigger).toHaveFocus();
 	await userEvent.keyboard(key);
 	await expectExists(page.getByTestId("content"));
+	await waitForDismissibleLayer(page.getByTestId("content"));
 	return t;
 }
 
@@ -657,6 +660,7 @@ it("should not scroll to previous dropdown trigger when closing a different drop
 	// open dropdown 3
 	await trigger3.click();
 	await expectExists(content3);
+	await waitForDismissibleLayer(content3);
 	await userEvent.click(topButton, { force: true });
 
 	await expectNotExists(content3);
@@ -757,6 +761,7 @@ it("keyboard navigation should not cause unwanted jumps between menus", async ()
 
 	await trigger1.click();
 	await expectExists(content1);
+	await waitForDismissibleLayer(content1);
 	await trigger2.click();
 	await expectExists(content2);
 	await expectNotExists(content1);

--- a/tests/src/tests/menubar/menubar.browser.test.ts
+++ b/tests/src/tests/menubar/menubar.browser.test.ts
@@ -25,6 +25,7 @@ it("should navigate triggers within the menubar using arrow keys", async () => {
 	const t = setup();
 	const trigger = t.getTrigger("1");
 	(trigger.element() as HTMLElement).focus();
+	await expect.element(trigger).toHaveFocus();
 	await userEvent.keyboard(kbd.ARROW_RIGHT);
 	await expect.element(t.getTrigger("2")).toHaveFocus();
 	await userEvent.keyboard(kbd.ARROW_RIGHT);
@@ -39,6 +40,7 @@ it("should respect `loop: false`", async () => {
 	const t = setup({ loop: false });
 	const trigger = t.getTrigger("1");
 	(trigger.element() as HTMLElement).focus();
+	await expect.element(trigger).toHaveFocus();
 	await userEvent.keyboard(kbd.ARROW_RIGHT);
 	await expect.element(t.getTrigger("2")).toHaveFocus();
 	await userEvent.keyboard(kbd.ARROW_RIGHT);
@@ -53,6 +55,7 @@ it.skip("should return focus to the menu trigger when closed via `ESC`", async (
 	const t = setup();
 	const trigger = t.getTrigger("1");
 	(trigger.element() as HTMLElement).focus();
+	await expect.element(trigger).toHaveFocus();
 	await userEvent.keyboard(kbd.ARROW_DOWN);
 	const content1 = t.getContent("1");
 	await expectExists(content1);
@@ -65,6 +68,7 @@ it("should navigate between menus when using the arrow keys and focus is within 
 	const t = setup();
 	const trigger = t.getTrigger("1");
 	(trigger.element() as HTMLElement).focus();
+	await expect.element(trigger).toHaveFocus();
 	await userEvent.keyboard(kbd.ARROW_DOWN);
 	const content1 = t.getContent("1");
 	await expectExists(content1);
@@ -81,6 +85,7 @@ it("should close the menu and focus the next tabbable element when `TAB` is pres
 	const t = setup();
 	const trigger = t.getTrigger("1");
 	(trigger.element() as HTMLElement).focus();
+	await expect.element(trigger).toHaveFocus();
 	await userEvent.keyboard(kbd.ARROW_DOWN);
 	const content1 = t.getContent("1");
 	await expectExists(content1);
@@ -94,6 +99,7 @@ it("should close the menu and focus the previous tabbable element when `SHIFT+TA
 	const t = setup();
 	const trigger = t.getTrigger("1");
 	(trigger.element() as HTMLElement).focus();
+	await expect.element(trigger).toHaveFocus();
 	await userEvent.keyboard(kbd.ARROW_DOWN);
 	const content1 = t.getContent("1");
 	await expectExists(content1);

--- a/tests/src/tests/popover/popover.browser.test.ts
+++ b/tests/src/tests/popover/popover.browser.test.ts
@@ -7,7 +7,12 @@ import PopoverForceMountTest, {
 	type PopoverForceMountTestProps,
 } from "./popover-force-mount-test.svelte";
 import PopoverSiblingsTest from "./popover-siblings-test.svelte";
-import { expectExists, expectNotExists, observeTransitionAttrs } from "../browser-utils";
+import {
+	expectExists,
+	expectNotExists,
+	observeTransitionAttrs,
+	waitForDismissibleLayer,
+} from "../browser-utils";
 import { page, userEvent } from "@vitest/browser/context";
 import PopoverMultipleTriggersTest from "./popover-multiple-triggers-test.svelte";
 import PopoverOverlayTest from "./popover-overlay-test.svelte";
@@ -40,6 +45,7 @@ async function open(props: PopoverTestProps = {}, openWith: "click" | (string & 
 		await userEvent.keyboard(openWith);
 	}
 	await expectExists(t.getContent());
+	await waitForDismissibleLayer(t.getContent());
 	const content = page.getByTestId("content");
 	return { content, ...t };
 }
@@ -156,6 +162,7 @@ it("should close before content visibly jumps to viewport origin when outside in
 
 	await page.getByTestId("trigger").click();
 	await expectExists(page.getByTestId("content"));
+	await waitForDismissibleLayer(page.getByTestId("content"));
 	await expect.element(page.getByTestId("open-binding")).toHaveTextContent("true");
 
 	const content = page.getByTestId("content").element() as HTMLElement;
@@ -365,9 +372,11 @@ it("should correctly handle focus when closing one popover by clicking another p
 	render(PopoverSiblingsTest);
 	await page.getByTestId("open-1").click();
 	await expectExists(page.getByTestId("content-1"));
+	await waitForDismissibleLayer(page.getByTestId("content-1"));
 	await page.getByTestId("open-2").click();
 	await expectNotExists(page.getByTestId("content-1"));
 	await expectExists(page.getByTestId("content-2"));
+	await waitForDismissibleLayer(page.getByTestId("content-2"));
 	await expect.element(page.getByTestId("close-2")).toHaveFocus();
 	await page.getByTestId("open-3").click();
 	await expectNotExists(page.getByTestId("content-2"));

--- a/tests/src/tests/select/select.browser.test.ts
+++ b/tests/src/tests/select/select.browser.test.ts
@@ -14,7 +14,12 @@ import SelectValueChildTest from "./select-value-child-test.svelte";
 import type { SelectValueChildrenMultiTestProps } from "./select-value-children-multi-test.svelte";
 import SelectValueChildrenMultiTest from "./select-value-children-multi-test.svelte";
 import SelectViewportTest from "./select-viewport-test.svelte";
-import { expectExists, expectNotExists, observeTransitionAttrs } from "../browser-utils";
+import {
+	expectExists,
+	expectNotExists,
+	observeTransitionAttrs,
+	waitForDismissibleLayer,
+} from "../browser-utils";
 import SelectScrollJumpTest from "./select-scroll-jump-test.svelte";
 import { page, userEvent } from "@vitest/browser/context";
 
@@ -187,6 +192,7 @@ async function openSingle(
 		await userEvent.keyboard(openWith);
 	}
 	await expectExists(t.getContent());
+	await waitForDismissibleLayer(t.getContent());
 	const content = t.getContent();
 	const group = page.getByTestId("group");
 	const groupHeading = page.getByTestId("group-label");
@@ -213,6 +219,7 @@ async function openMultiple(
 		await userEvent.keyboard(openWith);
 	}
 	await expectExists(t.getContent());
+	await waitForDismissibleLayer(t.getContent());
 	const content = t.getContent();
 	return {
 		...t,
@@ -253,6 +260,7 @@ describe("select - single", () => {
 
 		await t.trigger.click();
 		await vi.waitFor(() => expect(observer.history.some((entry) => entry.starting)).toBe(true));
+		await waitForDismissibleLayer(t.getContent());
 
 		await t.outside.click({ force: true });
 		await vi.waitFor(() => expect(observer.history.some((entry) => entry.ending)).toBe(true));


### PR DESCRIPTION
The `Test - Chromium` job fails on `main` roughly half the time. Two races account for what I've been able to observe; this fixes both. CI is green on this branch.

## 1. Outside-click dismissal (the frequent one)

`DismissibleLayerState` attaches its document `pointerdown` listeners on a deferred callback (`afterSleep(1)`), so the interaction that opened the layer can't immediately dismiss it. A `pointerdown` dispatched before that callback runs is silently dropped — the layer never sees it, and nothing re-delivers it.

So content being in the DOM is not enough to assert on outside-click dismissal. Every affected test does:

```ts
await trigger.click();
await expectExists(content);      // resolves as soon as the node is in the DOM
await outside.click();            // can beat the deferred attach
await expectNotExists(content);   // fails
```

On a loaded runner the renderer defers that 1ms timer past the incoming click. And because the load persists for the whole job, all four `retry` attempts fail identically — which is why these show up as hard failures rather than a flake that retries away.

**Fix.** `waitForDismissibleLayer()` in `browser-utils.ts` waits on `globalThis.bitsDismissableLayers`, the same registry `isResponsibleLayer` reads, populated in the deferred callback immediately before the listeners are attached. It's called wherever a test opens a layer and then interacts outside it — mostly inside each suite's shared `open()` helper, so the whole file is covered. Waiting on the registry rather than sleeping a fixed amount means it stays correct however long attachment is delayed.

**Verification.** Raising the deferral from 1ms to 300ms turns the race into a deterministic failure, which makes this measurable rather than a matter of re-running until green:

| | 300ms deferral | 1ms (as shipped) |
|---|---|---|
| before | **16 failed** | 1270 passed |
| after | 1270 passed | 1270 passed |

The 16 span alert-dialog, context-menu (6), date-picker, date-range-picker, dropdown-menu (2), popover (3), and select (2) — a superset of what CI has actually failed on, so the less-tight cases are covered too before they start flaking.

## 2. Keys sent before focus settles (menubar)

With the above fixed, the next CI run failed on two menubar tests instead: `Cannot find element with locator: getByTestId('1-content')` — a menu that never opened.

Those tests call `.focus()` on the trigger and dispatch a key on the very next line. `focus()` is applied in-page, but Playwright routes the key to whatever the browser considers focused, so on a slow runner the key can land before that has settled. Asserting focus first is what `dropdown-menu`'s `openWithKbd` and others already do; this applies the same pattern to the six menubar sites.

I can't reproduce this one locally the way I can the first, so the reasoning is from the failure signature plus existing convention rather than a demonstrated before/after. It is strictly a tightening either way.

---

Tests only; no library code changed.

**One thing worth a maintainer's call.** The deferred attach is a real, if narrow, product weakness: on a janky page the 1ms timer can stretch, and during that window a user's click outside genuinely does not dismiss the layer. Arming on the event rather than the clock would remove the race at the source and let these waits go away — but it risks reintroducing self-dismissal on open, so I left the behavior alone here.

Two unrelated failures I saw while working on this and did **not** touch: `date-field` → "should prevent interaction when `disabled`" and a handful of WebKit-only focus tests in `dialog` (WebKit isn't in CI). Both look like plain timeouts under load rather than either race.