### PR TITLE
docs: Add missing type import to Slider example

### DIFF
--- a/docs/content/components/slider.md
+++ b/docs/content/components/slider.md
@@ -39,7 +39,7 @@ Here's an example of how you might create a reusable `MySlider` component.
 ```svelte title="MyMultiSlider.svelte"
 <script lang="ts">
   import type { ComponentProps } from "svelte";
-  import { Slider } from "bits-ui";
+  import { Slider, type WithoutChildren } from "bits-ui";
 
   type Props = WithoutChildren<ComponentProps<typeof Slider.Root>>;
 


### PR DESCRIPTION
This PR adds `type WithoutChildren` to the import for the Slider component docs' "Reusable Components" section, so that if this code block is copy/pasted there will be no sad red squiggles.

(I checked for other missing imports in the rest of the component docs and did not notice any others.)

Reproduction steps (on main):
- Copy and paste the Reusable Component example from the Slider docs into a code editor in a repo with bits-ui installed
- Observe the sad red squiggle (`Cannot find name WithoutChildren`)

Reproduction steps (in this branch):
- Copy and paste the Reusable Component example from the Slider docs into a code editor in a repo with bits-ui installed
- Observe the lack of sad red squiggle