### PR TITLE
fix(TextSelectionLayer): avoid reading destroyed `ref` box on document pointerdown

### DIFF
--- a/.changeset/spotty-jars-punch.md
+++ b/.changeset/spotty-jars-punch.md
@@ -1,0 +1,5 @@
+---
+"bits-ui": patch
+---
+
+fix(TextSelectionLayer): don't read the `ref` box in `#pointerdown` before the enabled check, which emitted `derived_inert` on every document pointerdown when a leaked listener outlived its component

--- a/packages/bits-ui/src/lib/bits/utilities/text-selection-layer/use-text-selection-layer.svelte.ts
+++ b/packages/bits-ui/src/lib/bits/utilities/text-selection-layer/use-text-selection-layer.svelte.ts
@@ -85,9 +85,14 @@ export class TextSelectionLayerState {
 	};
 
 	#pointerdown = (e: PointerEvent) => {
+		// Check the plain-boolean snapshot BEFORE reading `this.opts.ref.current`.
+		// If this document listener outlives its component, that box is a `$derived`
+		// owned by a destroyed effect, and reading it emits `derived_inert` on every
+		// pointerdown anywhere in the document, forever.
+		if (!this.#enabledSnapshot) return;
 		const node = this.opts.ref.current;
 		const target = e.target;
-		if (!isHTMLElement(node) || !isHTMLElement(target) || !this.#enabledSnapshot) return;
+		if (!isHTMLElement(node) || !isHTMLElement(target)) return;
 		/**
 		 * We only lock user-selection overflow if layer is the top most layer and
 		 * pointerdown occurred inside the node. You are still allowed to select text

--- a/tests/src/tests/dialog/dialog.browser.test.ts
+++ b/tests/src/tests/dialog/dialog.browser.test.ts
@@ -806,3 +806,53 @@ describe("DismissibleLayer teardown (derived_inert / #2080)", () => {
 		}
 	});
 });
+
+/**
+ * TextSelectionLayer leaks a document `pointerdown` listener when a layer is
+ * rapidly toggled open/closed. `#pointerdown` read `this.opts.ref.current` — a
+ * writable `box` backed by a `$derived` owned by the (now destroyed) Content
+ * component — as its first statement, before any enabled/target check. Every
+ * document pointerdown then re-executed a destroyed derived and warned, for any
+ * click target anywhere in the app, forever.
+ *
+ * NB: `derived_inert` was added after the svelte version this repo pins, so this
+ * assertion only bites once the pinned svelte is new enough to emit it.
+ */
+describe("TextSelectionLayer teardown (derived_inert)", () => {
+	function installCounter() {
+		const counts = { inert: 0 };
+		const orig = console.warn.bind(console);
+		console.warn = (...args: unknown[]) => {
+			if (args.map(String).join(" ").includes("derived_inert")) counts.inert += 1;
+			orig(...args);
+		};
+		return {
+			counts,
+			restore: () => {
+				console.warn = orig;
+			},
+		};
+	}
+
+	it("should not emit derived_inert on document pointerdown after teardown", async () => {
+		const counter = installCounter();
+		try {
+			const t = render(DialogTest, { open: false });
+			for (let i = 0; i < 6; i++) {
+				await t.rerender({ open: i % 2 === 0 });
+				await new Promise((r) => setTimeout(r, 3));
+			}
+			await t.unmount();
+			await new Promise((r) => setTimeout(r, 100));
+
+			counter.counts.inert = 0;
+			document.body.dispatchEvent(
+				new PointerEvent("pointerdown", { bubbles: true, cancelable: true, button: 0 })
+			);
+			await new Promise((r) => setTimeout(r, 50));
+			expect(counter.counts.inert).toBe(0);
+		} finally {
+			counter.restore();
+		}
+	});
+});


### PR DESCRIPTION
`TextSelectionLayerState.#pointerdown` read `this.opts.ref.current` as its **first statement**, before the enabled check.

That box is a `$derived` owned by the Content component. When the document `pointerdown` listener outlives its component (reproducible by rapidly toggling a Dialog/Popover open/closed), every pointerdown *anywhere in the document* re-executes a destroyed derived and emits `derived_inert` — permanently, for any click target.

Fix: check the plain-boolean `#enabledSnapshot` first. Same logical condition; a leaked listener no longer touches the destroyed derived.

### Notes
- Distinct from #2080 / #2087 (`DismissibleLayer`). Here `bitsTextSelectionLayers` is correctly emptied — only the listener leaks — so #2087 does not cover it.
- Each leaked listener emits exactly **1** warning per pointerdown, synchronously. #2087's `DismissibleLayer` case emits 6 (3 + 3, split by the 10ms debounce).
- Verified on Chromium and WebKit: 2 warnings → 0.
- Does **not** address #2050, #2083, #2103, #2106.
- The underlying `removeEventListener` leak is still unresolved and worth a separate issue; this guard makes it harmless.

Related: #2080, #2105