### PR TITLE
fix(Select): keep the user's scroll position when the scroll down button remounts

### DIFF
--- a/.changeset/quiet-moons-repeat.md
+++ b/.changeset/quiet-moons-repeat.md
@@ -1,0 +1,5 @@
+---
+"bits-ui": patch
+---
+
+fix(Select): keep the user's scroll position when the scroll down button remounts. The button unmounts at the bottom of the list and remounts as soon as the viewport leaves it, and its mount effect realigned the viewport onto the highlighted item, so a small scroll up from the bottom jumped back to the highlighted item.

--- a/packages/bits-ui/src/lib/bits/select/select.svelte.ts
+++ b/packages/bits-ui/src/lib/bits/select/select.svelte.ts
@@ -5,6 +5,7 @@ import {
 	onDestroyEffect,
 	attachRef,
 	DOMContext,
+	executeCallbacks,
 	type ReadableBoxedValues,
 	type WritableBoxedValues,
 	type Box,
@@ -995,6 +996,9 @@ export class SelectContentState {
 	readonly root: SelectRoot;
 	readonly attachment: RefAttachment;
 	isPositioned = $state(false);
+	// set when the user scrolls the viewport by hand (wheel, touch, or holding a
+	// scroll button) and reset on close; shared by both scroll buttons
+	userHasScrolled = false;
 	domContext: DOMContext;
 
 	constructor(opts: SelectContentStateOpts, root: SelectRoot) {
@@ -1019,6 +1023,7 @@ export class SelectContentState {
 				if (this.root.opts.open.current) return;
 				this.root.contentIsPositioned = false;
 				this.isPositioned = false;
+				this.userHasScrolled = false;
 			}
 		);
 
@@ -1422,11 +1427,8 @@ export class SelectScrollButtonImplState {
 		this.attachment = attachRef(opts.ref);
 
 		watch([() => this.mounted], () => {
-			if (!this.mounted) {
-				this.isUserScrolling = false;
-				return;
-			}
-			if (this.isUserScrolling) return;
+			if (this.mounted) return;
+			this.isUserScrolling = false;
 		});
 
 		$effect(() => {
@@ -1455,6 +1457,7 @@ export class SelectScrollButtonImplState {
 
 	onpointerdown(_: BitsPointerEvent) {
 		if (this.autoScrollTimer !== null) return;
+		this.content.userHasScrolled = true;
 		const autoScroll = (tick: number) => {
 			this.onAutoScroll();
 			this.autoScrollTimer = this.content.domContext.setTimeout(
@@ -1511,10 +1514,21 @@ export class SelectScrollDownButtonState {
 		this.scrollButtonState.onAutoScroll = this.handleAutoScroll;
 
 		watch([() => this.root.viewportNode, () => this.content.isPositioned], () => {
-			if (!this.root.viewportNode || !this.content.isPositioned) return;
+			const viewport = this.root.viewportNode;
+			if (!viewport || !this.content.isPositioned) return;
 			this.handleScroll(true);
 
-			return on(this.root.viewportNode, "scroll", () => this.handleScroll());
+			const onUserScroll = () => {
+				this.content.userHasScrolled = true;
+			};
+
+			// not `scroll`: the realign below scrolls the viewport itself, so `scroll`
+			// fires for our own writes and cannot tell the user's gesture from ours
+			return executeCallbacks(
+				on(viewport, "scroll", () => this.handleScroll()),
+				on(viewport, "wheel", onUserScroll, { passive: true }),
+				on(viewport, "touchmove", onUserScroll, { passive: true })
+			);
 		});
 
 		/**
@@ -1541,6 +1555,9 @@ export class SelectScrollDownButtonState {
 					clearTimeout(this.scrollIntoViewTimer);
 				}
 				this.scrollIntoViewTimer = afterSleep(5, () => {
+					// this button remounts whenever the viewport leaves the bottom, which
+					// would otherwise realign onto the highlighted item mid-gesture
+					if (this.content.userHasScrolled) return;
 					const activeItem = this.root.highlightedNode;
 					if (!activeItem) return;
 					this.root.scrollHighlightedNodeIntoView(activeItem);

--- a/tests/src/tests/select/select-scroll-buttons-test.svelte
+++ b/tests/src/tests/select/select-scroll-buttons-test.svelte
@@ -1,0 +1,64 @@
+<script lang="ts">
+	import "../../app.css";
+	import { Select } from "bits-ui";
+
+	const items = Array.from({ length: 60 }, (_, i) => ({
+		value: `${i}`,
+		label: `Item ${i}`,
+	}));
+
+	let {
+		value = $bindable(""),
+		overlayScrollButtons = false,
+	}: { value?: string; overlayScrollButtons?: boolean } = $props();
+	let open = $state(false);
+
+	const buttonStyle = { height: "20px", backgroundColor: "white" } as const;
+	// overlaid scroll buttons are outside the flex flow, so mounting and unmounting
+	// them leaves the viewport's own scroll geometry alone
+	const overlayStyle = { position: "absolute", left: "0", right: "0" } as const;
+
+	const upStyle = $derived(
+		overlayScrollButtons ? { ...buttonStyle, ...overlayStyle, top: "0" } : buttonStyle
+	);
+	const downStyle = $derived(
+		overlayScrollButtons ? { ...buttonStyle, ...overlayStyle, bottom: "0" } : buttonStyle
+	);
+</script>
+
+<main data-testid="main">
+	<Select.Root bind:value bind:open type="single">
+		<Select.Trigger data-testid="trigger">{value || "Open Listbox"}</Select.Trigger>
+		<Select.Portal>
+			<Select.Content
+				data-testid="content"
+				preventScroll={false}
+				style={{
+					width: "220px",
+					height: "200px",
+					position: "relative",
+					backgroundColor: "white",
+				}}
+			>
+				<Select.ScrollUpButton data-testid="scroll-up-button" style={upStyle}>
+					up
+				</Select.ScrollUpButton>
+				<Select.Viewport data-testid="viewport">
+					{#each items as item (item.value)}
+						<Select.Item
+							value={item.value}
+							label={item.label}
+							data-testid={`item-${item.value}`}
+							style={{ height: "40px" }}
+						>
+							{item.label}
+						</Select.Item>
+					{/each}
+				</Select.Viewport>
+				<Select.ScrollDownButton data-testid="scroll-down-button" style={downStyle}>
+					down
+				</Select.ScrollDownButton>
+			</Select.Content>
+		</Select.Portal>
+	</Select.Root>
+</main>

--- a/tests/src/tests/select/select.browser.test.ts
+++ b/tests/src/tests/select/select.browser.test.ts
@@ -21,6 +21,7 @@ import {
 	waitForDismissibleLayer,
 } from "../browser-utils";
 import SelectScrollJumpTest from "./select-scroll-jump-test.svelte";
+import SelectScrollButtonsTest from "./select-scroll-buttons-test.svelte";
 import { page, userEvent } from "@vitest/browser/context";
 
 const kbd = getTestKbd();
@@ -230,6 +231,12 @@ async function openMultiple(
 function nextFrame() {
 	return new Promise<void>((resolve) => {
 		window.requestAnimationFrame(() => resolve());
+	});
+}
+
+function sleep(ms: number) {
+	return new Promise<void>((resolve) => {
+		window.setTimeout(() => resolve(), ms);
 	});
 }
 
@@ -702,6 +709,54 @@ describe("select - single", () => {
 
 		expect(maxDrift).toBeLessThanOrEqual(1);
 		expect(Math.abs(window.scrollY - baselineY)).toBeLessThanOrEqual(1);
+	});
+
+	it("should keep the user's scroll position when the scroll down button remounts", async () => {
+		render(SelectScrollButtonsTest, { overlayScrollButtons: true });
+
+		await page.getByTestId("trigger").click();
+		await expectExists(page.getByTestId("content"));
+
+		const viewport = page.getByTestId("viewport").element() as HTMLElement;
+
+		// let the content finish positioning and settle onto the highlighted item
+		await sleep(100);
+
+		// at the bottom of the list the scroll down button unmounts
+		viewport.scrollTop = viewport.scrollHeight;
+		await expectNotExists(page.getByTestId("scroll-down-button"));
+
+		const bottom = viewport.scrollTop;
+		expect(bottom).toBeGreaterThan(0);
+
+		// scrolling back up by a few pixels remounts the button, whose mount effect
+		// used to realign the viewport onto the highlighted item, which here is the
+		// first item at the very top of the list
+		viewport.dispatchEvent(new WheelEvent("wheel", { deltaY: -5, bubbles: true }));
+		viewport.scrollTop = bottom - 5;
+		await expectExists(page.getByTestId("scroll-down-button"));
+
+		await sleep(100);
+
+		expect(viewport.scrollTop).toBeGreaterThanOrEqual(bottom - 20);
+	});
+
+	it("should still scroll the selected item into view when opening", async () => {
+		render(SelectScrollButtonsTest, { value: "55" });
+
+		await page.getByTestId("trigger").click();
+		await expectExists(page.getByTestId("content"));
+
+		const viewport = page.getByTestId("viewport").element() as HTMLElement;
+		const selected = page.getByTestId("item-55").element() as HTMLElement;
+
+		await sleep(100);
+
+		const viewportRect = viewport.getBoundingClientRect();
+		const selectedRect = selected.getBoundingClientRect();
+
+		expect(selectedRect.top).toBeGreaterThanOrEqual(viewportRect.top);
+		expect(selectedRect.bottom).toBeLessThanOrEqual(viewportRect.bottom);
 	});
 });
 


### PR DESCRIPTION
### The problem

Scrolling a `Select` (or `Combobox`) list back up from the bottom snaps the viewport onto the highlighted item.

`SelectScrollDownButtonState` realigns the viewport onto the highlighted item on every `mounted` transition of the scroll down button:

```ts
watch(
	() => this.scrollButtonState.mounted,
	() => {
		if (!this.scrollButtonState.mounted) return;
		if (this.scrollIntoViewTimer) clearTimeout(this.scrollIntoViewTimer);
		this.scrollIntoViewTimer = afterSleep(5, () => {
			const activeItem = this.root.highlightedNode;
			if (!activeItem) return;
			this.root.scrollHighlightedNodeIntoView(activeItem);
		});
	}
);
```

That button renders under `{#if canScrollDown}`, and `canScrollDown` goes false at the bottom of the list and true again as soon as the viewport leaves the bottom by more than its `paddingTop`. So the button unmounts at the bottom and remounts on the user's very first scroll back up — and the realign fires straight into their gesture.

The highlighted item is wherever it was put when the list opened, which for a pointer-driven scroll (no keyboard, cursor never over an item) is the first item. So "align onto the highlight" means "jump to the top".

### Repro

1. Render a `Select` with a `Select.ScrollDownButton` and enough items to scroll — the demo on the docs site reproduces it.
2. Open it with a click. Do not hover an item or use the keyboard, so the highlight stays on the first item.
3. Scroll to the bottom of the list.
4. Scroll up by a few pixels.

The viewport jumps back to the top instead of moving a few pixels.

The test added here measures it: from `scrollTop` 2195 of a 2200 maxScroll, a 5px scroll up leaves the viewport at **0**. Where I first hit this — a 25-option list in a 262px viewport, maxScroll 878 — a 5px wheel up from the bottom landed at 124 instead of 873, and a 30px wheel up also landed at 124. With this change they land at 873 and 848.

### Relationship to existing fixes

This looks like the same family as two recent ones:

- **#2005 (`fix(Select): scroll jumping`)** introduced `contentIsPositioned` and routed this exact `afterSleep` through the new `scrollHighlightedNodeIntoView` guard. But that guard only checks `viewportNode && contentIsPositioned`, and both stay true the whole time the content is open — so the remount realign survived it. This is the path that fix did not close.
- **#2087 (`fix(DismissibleLayer)`)** was an `afterSleep` whose callback ran without a condition that was still true when it fired. Same shape here: by the time the 5ms timer runs, "the button just mounted" no longer implies "the content is still settling".

### The fix

`SelectContentState` gains a `userHasScrolled` latch. It is set when the user scrolls the viewport by hand — `wheel` or `touchmove` on the viewport, or holding a scroll button — and reset when the content closes. The remount realign returns early once it is set.

The realign therefore stays free to converge while the content is settling, and stops the moment the user takes the scroll position over.

**Why not `isUserScrolling`?** That flag already exists on `SelectScrollButtonImplState` and reusing it looked like the obvious one-line fix. It does kill this bug — but it also breaks the settle it is guarding, and the second test here demonstrates that in this repo.

`isUserScrolling` is set from the `scroll` listener, and the realign scrolls the viewport itself, so the content's own programmatic scrolls set the flag too. When the scroll buttons sit in the flex flow (as they do in the docs demo), mounting and unmounting them resizes the viewport under the alignment, so the open-time settle needs more than one pass — and with `isUserScrolling` as the guard the later passes are suppressed by the earlier one's own scroll. Opening a select whose selected item sits far down the list then leaves that item short of fully visible: swapping the guard makes `should still scroll the selected item into view when opening` fail with `expected 244 to be less than or equal to 204`, the item sitting exactly one item-height below the fold, while the remount test still passes.

`wheel` and `touchmove` are the signals only a person can produce, which is why the latch listens for those rather than for `scroll`.

### What this deliberately does not change

- Keyboard navigation still scrolls the highlighted item into view — that goes through `setHighlightedNode`, untouched.
- The open-time settle is untouched. Nothing latches until the user actually scrolls, so a select that opens scrolled to its selection still does.
- The scroll buttons' auto-scroll still works; holding one just also marks the position as the user's, so releasing it does not snap back.
- `SelectScrollUpButtonState` needed no change — it has no realign-on-mount watch.
- Dragging a scrollbar is not treated as a user scroll, because the select viewport hides its scrollbar (`scrollbar-width: none`), so there is none to drag. If that ever changes, `scrollend` detection would be the thing to add.

One extra line: the `watch` in `SelectScrollButtonImplState` ended with a bare `if (this.isUserScrolling) return;` as its final statement, which does nothing. Removed, since it reads like the guard this bug needed and is not one.

### Tests

Two tests in `select.browser.test.ts`, sharing a new `select-scroll-buttons-test.svelte` harness:

- `should keep the user's scroll position when the scroll down button remounts` — the regression. Against the unpatched build it fails `expected 0 to be greater than or equal to 2180`, deterministically across all retries.
- `should still scroll the selected item into view when opening` — pins the settle this fix must not break, and is what rules out the `isUserScrolling` variant above.

The existing scroll coverage (`select-scroll-jump-test.svelte`, from #2005) measures *page* scroll on open and does not mount the scroll buttons at all — no select harness in the repo does, which is probably why this path stayed uncovered.

The harness takes an `overlayScrollButtons` flag. The remount test overlays the buttons so their flapping does not change the viewport's scroll geometry, which keeps that test deterministic; in the flow they resize the viewport as they flap and the list settles ~24px short of the bottom. The settle test leaves them in the flow, which is the docs-demo layout and the one where the extra alignment pass matters.

`pnpm -F tests test:browser --run src/tests/select` passes 74/74 on both chromium and webkit. The rest of the browser suite has some pre-existing failures on my machine (webkit focus-management timeouts, mostly), unchanged by this branch and in components this does not touch.

Happy to rename anything or move the latch if you would rather it live on a different state.
