### PR TITLE
fix(DismissibleLayer): make #resetState synchronous

### DIFF
--- a/.changeset/quiet-parrots-shave.md
+++ b/.changeset/quiet-parrots-shave.md
@@ -1,0 +1,11 @@
+---
+"bits-ui": patch
+---
+
+fix(DismissibleLayer): outside clicks shortly after a layer opens no longer fail to dismiss it
+
+`DismissibleLayerState` reset its per-interaction state through a 20ms debounce. Because the
+layer's `watch` runs its cleanup once on every open, each layer scheduled a reset 20ms into its
+own lifetime. An outside `pointerdown` landing 10-20ms after that cleanup had its
+"responsible layer" flag cleared by the stale reset before the debounced interact-outside
+handler ran, so the handler bailed and the layer stayed open. The reset is now synchronous.

--- a/packages/bits-ui/src/lib/bits/utilities/dismissible-layer/use-dismissable-layer.svelte.ts
+++ b/packages/bits-ui/src/lib/bits/utilities/dismissible-layer/use-dismissable-layer.svelte.ts
@@ -98,7 +98,7 @@ export class DismissibleLayerState {
 		onDestroyEffect(() => {
 			destroyed = true;
 			clearPendingTimer();
-			this.#resetState.destroy();
+			this.#resetState();
 			globalThis.bitsDismissableLayers.delete(this);
 			this.#handleInteractOutside.destroy();
 			this.#unsubClickListener();
@@ -217,12 +217,25 @@ export class DismissibleLayerState {
 		return isOrContainsTarget(this.opts.ref.current, target);
 	};
 
-	#resetState = debounce(() => {
+	/**
+	 * Resets the per-interaction state. Must stay synchronous.
+	 *
+	 * This was a `debounce(..., 20)` from when it was also wired to a capture-phase
+	 * interaction-end listener and had to land after the 10ms `#handleInteractOutside`
+	 * debounce. That listener is gone, but the debounce stayed on the `cleanup()` path —
+	 * and because `watch` runs `cleanup()` once per open (`ref` goes null -> node), every
+	 * layer scheduled a reset 20ms into its own lifetime. An outside `pointerdown` landing
+	 * 10-20ms after that cleanup would have its `#isResponsibleLayer` flag cleared by the
+	 * stale reset in the gap before the debounced `#handleInteractOutside` ran, which then
+	 * bailed and left the layer open. `cleanup()` destroys `#handleInteractOutside` anyway,
+	 * so nothing is left in flight that needs to observe the pre-reset state.
+	 */
+	#resetState = () => {
 		for (const eventType in this.#interceptedEvents) {
 			this.#interceptedEvents[eventType] = false;
 		}
 		this.#isResponsibleLayer = false;
-	}, 20);
+	};
 
 	#isAnyEventIntercepted() {
 		const i = Object.values(this.#interceptedEvents).some(Boolean);

--- a/tests/src/tests/dismissible-layer/outside-click-timing.browser.test.ts
+++ b/tests/src/tests/dismissible-layer/outside-click-timing.browser.test.ts
@@ -1,0 +1,48 @@
+import { page } from "@vitest/browser/context";
+import { describe, it } from "vitest";
+import { render } from "vitest-browser-svelte";
+import ComboboxTest, { type Item } from "../combobox/combobox-test.svelte";
+import { expectExists, expectNotExists, waitForDismissibleLayer } from "../browser-utils";
+
+/**
+ * An outside click must dismiss the layer no matter how soon after the layer registered
+ * it happens.
+ *
+ * Regression guard for a stale timer scheduled by `DismissibleLayerState`'s watch cleanup:
+ * it fired ~20ms into the layer's own lifetime and cleared the `isResponsibleLayer` flag
+ * that the outside `pointerdown` had just set, in the window before the debounced
+ * interact-outside handler ran. Clicks landing roughly 4-14ms after registration hit that
+ * window, so the delay sweep below is what makes the bug reproducible instead of a ~1-in-100
+ * CI flake.
+ */
+
+const items: Item[] = [
+	{ value: "1", label: "A" },
+	{ value: "2", label: "B" },
+	{ value: "3", label: "C" },
+	{ value: "4", label: "D" },
+];
+
+const DELAYS_MS = [0, 2, 4, 6, 8, 10, 12, 14, 16, 20];
+const REPS = 2;
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+describe("dismissible layer - outside click timing", () => {
+	for (const delay of DELAYS_MS) {
+		for (let rep = 0; rep < REPS; rep++) {
+			it(`should close on an outside click ${delay}ms after the layer registers (rep ${rep})`, async () => {
+				render(ComboboxTest, { name: "test", items });
+
+				await page.getByTestId("trigger").click({ force: true });
+				await expectExists(page.getByTestId("content"));
+				await waitForDismissibleLayer(page.getByTestId("content"));
+
+				await sleep(delay);
+
+				await page.getByTestId("outside").click({ force: true });
+				await expectNotExists(page.getByTestId("content"));
+			});
+		}
+	}
+});


### PR DESCRIPTION
Fixes the intermittent `should close on outside click` failures in combobox/select/menubar.

### Problem

`#resetState` clears `#isResponsibleLayer` behind a `debounce(..., 20)`, and is only called from `cleanup()`. Since `watch([enabled, ref])` runs `cleanup()` once on every open (`ref.current` goes `null -> node`), every layer schedules a state wipe 20ms into its own lifetime, ~1.5ms before it attaches its listeners.

An outside `pointerdown` schedules `#handleInteractOutside` on a 10ms debounce, so a click landing 10-20ms after that cleanup gets the stale reset in between:

```
t+0.0   cleanup()             -> schedules resetState at t+20
t+1.5   attach listeners
t+10.5  pointerdown capture   -> isResponsibleLayer = true
t+10.7  pointerdown bubble    -> schedules handleInteractOutside at t+20.7
t+20.5  resetState (stale)    -> isResponsibleLayer = false
t+20.7  handleInteractOutside -> responsible=false -> bail, layer stays open
```

The debounce is vestigial: #785 removed the capture-phase interaction-end listener it was wired to (where landing after the 10ms handler debounce was the point) but left the timing on the `cleanup()` path.

### Fix

Make `#resetState` synchronous. `cleanup()` destroys `#handleInteractOutside` in the same breath, so nothing in flight needs the pre-reset state.

### Test

`tests/src/tests/dismissible-layer/outside-click-timing.browser.test.ts` sweeps the outside-click delay after layer registration. Fails 4-5 of 20 without the fix, passes 20/20 with it.

Other verification, chromium `--retry=0`:

| | before | after |
| --- | --- | --- |
| delay sweep (11 delays x 10 reps) | 22/110 failed, band 4-14ms | 0/110 |
| unguided repro, 300 rounds x combobox single/multi + select single | 2/900 failed | 0/1500; 0/900 under 16x CPU load |
| 10 interaction-heavy files x 10 runs | 12 outside-click failures | 0 |
| full browser suite x 3 | | 3/3 clean |