### PR TITLE
fix: allow undefined Calendar bindings

### DIFF
--- a/.changeset/calm-calendars-bind.md
+++ b/.changeset/calm-calendars-bind.md
@@ -1,0 +1,5 @@
+---
+"bits-ui": patch
+---
+
+fix(Calendar): accept undefined for optional bindable props

--- a/packages/bits-ui/src/lib/bits/calendar/types.ts
+++ b/packages/bits-ui/src/lib/bits/calendar/types.ts
@@ -26,7 +26,7 @@ type CalendarBaseRootPropsWithoutHTML = {
 	 *
 	 * @default the current date
 	 */
-	placeholder?: DateValue;
+	placeholder?: DateValue | undefined;
 
 	/**
 	 * A callback function called when the placeholder value
@@ -224,7 +224,7 @@ export type CalendarSingleRootPropsWithoutHTML = {
 	/**
 	 * The value of the selected date in the calendar.
 	 */
-	value?: DateValue;
+	value?: DateValue | undefined;
 
 	/**
 	 * A callback function called when the value changes.
@@ -243,7 +243,7 @@ export type CalendarMultipleRootPropsWithoutHTML = {
 	/**
 	 * The value of the selected dates in the calendar.
 	 */
-	value?: DateValue[];
+	value?: DateValue[] | undefined;
 
 	/**
 	 * A callback function called when the value changes.

--- a/packages/bits-ui/src/lib/bits/range-calendar/types.ts
+++ b/packages/bits-ui/src/lib/bits/range-calendar/types.ts
@@ -14,7 +14,7 @@ export type RangeCalendarRootPropsWithoutHTML = WithChild<
 		 * The value of the selected date range.
 		 * @bindable
 		 */
-		value?: DateRange;
+		value?: DateRange | undefined;
 
 		/**
 		 * A callback function called when the value changes.
@@ -27,7 +27,7 @@ export type RangeCalendarRootPropsWithoutHTML = WithChild<
 		 *
 		 * @default the current date
 		 */
-		placeholder?: DateValue;
+		placeholder?: DateValue | undefined;
 
 		/**
 		 * A callback function called when the placeholder value


### PR DESCRIPTION
`Calendar.Root` and `RangeCalendar.Root` already treat `undefined` as a valid initial value for their bindable `value` and `placeholder` props. They initialize those props internally before using them.

The public types only marked the props as optional. With `exactOptionalPropertyTypes` enabled, that rejects bindable values typed as `T | undefined`, even though the components support them at runtime.

This change explicitly includes `undefined` in those prop types. The runtime implementation is unchanged.

Tested with:

- `pnpm check`
- `pnpm lint`
