### PR TITLE
fix: prevent ScrollArea resize work after teardown

### DIFF
--- a/.changeset/quiet-scrollbars-rest.md
+++ b/.changeset/quiet-scrollbars-rest.md
@@ -1,0 +1,5 @@
+---
+"bits-ui": patch
+---
+
+fix(ScrollArea): prevent resize work from reading destroyed state after unmount

--- a/packages/bits-ui/src/lib/bits/scroll-area/scroll-area.svelte.ts
+++ b/packages/bits-ui/src/lib/bits/scroll-area/scroll-area.svelte.ts
@@ -345,13 +345,13 @@ export class ScrollAreaScrollbarAutoState {
 		this.scrollbar = scrollbar;
 		this.root = scrollbar.root;
 
-		const handleResize = useDebounce(() => {
+		const handleResize = () => {
 			const viewportNode = this.root.viewportNode;
 			if (!viewportNode) return;
 			const isOverflowX = viewportNode.offsetWidth < viewportNode.scrollWidth;
 			const isOverflowY = viewportNode.offsetHeight < viewportNode.scrollHeight;
 			this.isVisible = this.scrollbar.isHorizontal ? isOverflowX : isOverflowY;
-		}, 10);
+		};
 
 		new SvelteResizeObserver(() => this.root.viewportNode, handleResize);
 		new SvelteResizeObserver(() => this.root.contentNode, handleResize);
@@ -718,7 +718,7 @@ export class ScrollAreaScrollbarSharedState {
 		this.root = scrollbarState.root;
 		this.scrollbarVis = scrollbarState.scrollbarVis;
 		this.scrollbar = scrollbarState.scrollbarVis.scrollbar;
-		this.handleResize = useDebounce(() => this.scrollbarState.onResize(), 10);
+		this.handleResize = () => this.scrollbarState.onResize();
 		this.handleThumbPositionChange = this.scrollbarState.onThumbPositionChange;
 		this.handleWheelScroll = this.scrollbarState.onWheelScroll;
 		this.handleThumbPointerDown = this.scrollbarState.onThumbPointerDown;

--- a/tests/src/tests/scroll-area/scroll-area.browser.test.ts
+++ b/tests/src/tests/scroll-area/scroll-area.browser.test.ts
@@ -1,11 +1,42 @@
+import { page, userEvent } from "@vitest/browser/context";
 import { expect, it, vi, describe } from "vitest";
 import { render } from "vitest-browser-svelte";
+
+import { expectExists, expectNotExists } from "../browser-utils";
 import { getTestKbd } from "../utils.js";
 import ScrollAreaTest, { type ScrollAreaTestProps } from "./scroll-area-test.svelte";
-import { expectExists, expectNotExists } from "../browser-utils";
-import { page, userEvent } from "@vitest/browser/context";
 
 const kbd = getTestKbd();
+
+class ControlledResizeObserver implements ResizeObserver {
+	static observers: ControlledResizeObserver[] = [];
+	readonly #callback: ResizeObserverCallback;
+
+	constructor(callback: ResizeObserverCallback) {
+		this.#callback = callback;
+		ControlledResizeObserver.observers.push(this);
+	}
+
+	disconnect() {}
+	observe() {}
+	unobserve() {}
+
+	trigger() {
+		this.#callback([], this);
+	}
+
+	static reset() {
+		ControlledResizeObserver.observers.length = 0;
+	}
+
+	static triggerAll() {
+		for (const observer of ControlledResizeObserver.observers) observer.trigger();
+	}
+}
+
+async function waitForAnimationFrame() {
+	await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+}
 
 function setup(props: ScrollAreaTestProps = {}) {
 	render(ScrollAreaTest, { ...props });
@@ -207,6 +238,51 @@ describe("ScrollArea", () => {
 
 		await expectExists(t.getScrollbarY());
 	});
+
+	it.each(["always", "auto"] as const)(
+		"should not schedule resize work that can outlive a %s ScrollArea",
+		async (type) => {
+			const warnings: unknown[][] = [];
+			ControlledResizeObserver.reset();
+			vi.stubGlobal("ResizeObserver", ControlledResizeObserver);
+			const consoleWarn = vi
+				.spyOn(console, "warn")
+				.mockImplementation((...args: unknown[]) => {
+					warnings.push(args);
+				});
+			const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
+
+			try {
+				const rendered = render(ScrollAreaTest, {
+					type,
+					height: 5,
+					numParagraphs: 10,
+					wrapText: false,
+				});
+
+				await waitForAnimationFrame();
+				expect(ControlledResizeObserver.observers.length).toBeGreaterThan(0);
+
+				setTimeoutSpy.mockClear();
+				ControlledResizeObserver.triggerAll();
+				await waitForAnimationFrame();
+				await rendered.unmount();
+
+				expect(setTimeoutSpy.mock.calls.some(([, delay]) => delay === 10)).toBe(false);
+				await new Promise<void>((resolve) => setTimeout(resolve, 20));
+				expect(
+					warnings.some((args) =>
+						args.some((argument) => String(argument).includes("derived_inert"))
+					)
+				).toBe(false);
+			} finally {
+				setTimeoutSpy.mockRestore();
+				consoleWarn.mockRestore();
+				vi.unstubAllGlobals();
+				ControlledResizeObserver.reset();
+			}
+		}
+	);
 
 	it("should allow wheel scrolling", async () => {
 		if (navigator.userAgent.includes("WebKit")) {


### PR DESCRIPTION
## Summary

- remove the two uncancelled 10 ms resize debounces in `ScrollArea`
- retain the existing `SvelteResizeObserver` animation-frame scheduling and cleanup
- cover teardown in both `always` and `auto` modes
- add a patch changeset

## Root cause

Each affected callback is already invoked from `SvelteResizeObserver` through `requestAnimationFrame`. The additional Runed debounce creates a separate timeout after that frame; the timeout is not owned by the observer effect and can therefore read component-owned reactive state after unmount.

The regression uses a controlled `ResizeObserver`. On the unchanged implementation, `always` schedules the shared-state timer and `auto` also schedules the auto-state timer. Removing both wrappers leaves no deferred 10 ms work, while the observer's existing frame-level coalescing remains intact.

Two observers can still invoke their shared callback once each in the same frame. If cross-observer coalescing is required, I can replace the direct callbacks with a lifecycle-owned shared scheduler instead.

## Validation

- `pnpm check`
- `pnpm lint`
- `pnpm test:utils` (122 tests)
- `pnpm test:browser:chromium` (1,274 passed, 2 skipped, 1 todo)
- targeted Chromium regression (21 tests)
- Prettier check and changeset status

Closes #2121
