### PR TITLE
fix(DateField): apply date segments in year/month/day order

### DIFF
--- a/.changeset/olive-moons-repeat.md
+++ b/.changeset/olive-moons-repeat.md
@@ -1,0 +1,5 @@
+---
+"bits-ui": patch
+---
+
+fix(DateField): apply date segments in year/month/day order so a valid day isn't clamped by the placeholder's month in day-first locales

--- a/packages/bits-ui/src/lib/internal/date-time/field/helpers.test.ts
+++ b/packages/bits-ui/src/lib/internal/date-time/field/helpers.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "vitest";
+import { CalendarDate, CalendarDateTime } from "@internationalized/date";
+import { getValueFromSegments } from "./helpers.js";
+import type { SegmentValueObj } from "./types.js";
+
+/**
+ * Builds a field node whose segments appear in the given order, mimicking the
+ * order the segments are rendered in for a given locale.
+ */
+function createFieldNode(parts: string[]) {
+	const field = document.createElement("div");
+	for (const part of parts) {
+		const segment = document.createElement("div");
+		segment.dataset.segment = part;
+		field.appendChild(segment);
+	}
+	return field;
+}
+
+describe("getValueFromSegments", () => {
+	it("applies the day-first (en-GB) segment order without clamping the day to the dateRef's month", () => {
+		const fieldNode = createFieldNode(["day", "literal", "month", "literal", "year"]);
+		const segmentObj = { day: "31", month: "08", year: "2026" } as SegmentValueObj;
+
+		// the placeholder/dateRef sits in a 30-day month (November)
+		const value = getValueFromSegments({
+			segmentObj,
+			fieldNode,
+			dateRef: new CalendarDate(2024, 11, 1),
+		});
+
+		expect(value.toString()).toBe("2026-08-31");
+	});
+
+	it("applies the month-first (en-US) segment order", () => {
+		const fieldNode = createFieldNode(["month", "literal", "day", "literal", "year"]);
+		const segmentObj = { day: "31", month: "08", year: "2026" } as SegmentValueObj;
+
+		const value = getValueFromSegments({
+			segmentObj,
+			fieldNode,
+			dateRef: new CalendarDate(2024, 11, 1),
+		});
+
+		expect(value.toString()).toBe("2026-08-31");
+	});
+
+	it("resolves february 29th against the entered year and not the dateRef's year", () => {
+		const fieldNode = createFieldNode(["day", "literal", "month", "literal", "year"]);
+		const segmentObj = { day: "29", month: "02", year: "2024" } as SegmentValueObj;
+
+		const value = getValueFromSegments({
+			segmentObj,
+			fieldNode,
+			dateRef: new CalendarDate(2025, 2, 1),
+		});
+
+		expect(value.toString()).toBe("2024-02-29");
+	});
+
+	it("keeps the time segments when the field has a time granularity", () => {
+		const fieldNode = createFieldNode([
+			"day",
+			"literal",
+			"month",
+			"literal",
+			"year",
+			"hour",
+			"literal",
+			"minute",
+			"dayPeriod",
+		]);
+		const segmentObj = {
+			day: "31",
+			month: "08",
+			year: "2026",
+			hour: "13",
+			minute: "45",
+			second: null,
+			dayPeriod: "PM",
+		} as unknown as SegmentValueObj;
+
+		const value = getValueFromSegments({
+			segmentObj,
+			fieldNode,
+			dateRef: new CalendarDateTime(2024, 11, 1, 0, 0),
+		});
+
+		expect(value.toString()).toBe("2026-08-31T13:45:00");
+	});
+
+	it("ignores segments that have not been filled in yet", () => {
+		const fieldNode = createFieldNode(["day", "literal", "month", "literal", "year"]);
+		const segmentObj = { day: "15", month: null, year: null } as unknown as SegmentValueObj;
+
+		const value = getValueFromSegments({
+			segmentObj,
+			fieldNode,
+			dateRef: new CalendarDate(2024, 11, 1),
+		});
+
+		expect(value.toString()).toBe("2024-11-15");
+	});
+});

--- a/packages/bits-ui/src/lib/internal/date-time/field/helpers.ts
+++ b/packages/bits-ui/src/lib/internal/date-time/field/helpers.ts
@@ -296,9 +296,27 @@ type GetValueFromSegments = {
 	dateRef: DateValue;
 };
 
+/**
+ * The order the segments are applied in when building a date from them.
+ *
+ * Setting a part on a `DateValue` constrains the result immediately, so the day
+ * has to be applied after the year and month it belongs to. Applying it in the
+ * order the segments are displayed clamps the day to the number of days in the
+ * `dateRef`'s month in day-first locales (e.g. `31/08` entered in `en-GB` with a
+ * `dateRef` in November would resolve to the 30th).
+ */
+const SEGMENT_APPLY_ORDER = ["year", "month", "day", "hour", "minute", "second", "dayPeriod"];
+
+function getSegmentApplyOrder(part: EditableSegmentPart) {
+	const index = SEGMENT_APPLY_ORDER.indexOf(part);
+	return index === -1 ? SEGMENT_APPLY_ORDER.length : index;
+}
+
 export function getValueFromSegments(props: GetValueFromSegments) {
 	const { segmentObj, fieldNode, dateRef } = props;
-	const usedSegments = getUsedSegments(fieldNode);
+	const usedSegments = getUsedSegments(fieldNode).sort(
+		(a, b) => getSegmentApplyOrder(a) - getSegmentApplyOrder(b)
+	);
 	let date = dateRef;
 
 	for (const part of usedSegments) {

--- a/tests/src/tests/date-range-field/date-range-field.browser.test.ts
+++ b/tests/src/tests/date-range-field/date-range-field.browser.test.ts
@@ -263,3 +263,21 @@ it("should allow valid days in end month when a value is prepopulated", async ()
 	await userEvent.keyboard(kbd.ARROW_DOWN);
 	await expect.element(seg).toHaveTextContent("30");
 });
+
+it("should allow valid days in the end month with a day-first locale", async () => {
+	const t = setup({
+		locale: "en-GB",
+		value: {
+			// start sits in a 30-day month, end in a 31-day one
+			start: new CalendarDate(2024, 11, 1),
+			end: new CalendarDate(2026, 8, 30),
+		},
+	});
+
+	await t.end.day.click();
+	await userEvent.keyboard("31");
+
+	await expect.element(t.end.day).toHaveTextContent("31");
+	await expect.element(t.end.value).toHaveTextContent("2026-08-31");
+	await expect.element(t.start.value).toHaveTextContent("2024-11-01");
+});


### PR DESCRIPTION
Closes #2120

## Root cause

`getValueFromSegments` builds the value by applying each segment onto a reference date **in the order the segments are displayed**:

```ts
const usedSegments = getUsedSegments(fieldNode); // display order
let date = dateRef;
for (const part of usedSegments) date = date.set({ [part]: segmentObj[part] });
```

`DateValue.set` constrains the result on every call, so applying the day before its month/year clamps it to the number of days in the *reference* date's month.

In `mm/dd/yyyy` locales the month lands first and the day is then constrained correctly. In day-first locales (`en-GB` and friends) the day is applied against `dateRef`'s month instead of the one the user typed, so `31/08/2026` entered while `dateRef` sits in November resolves to `2026-08-30`. The value is then synced back to the segments, so the day visibly changes to `30` with no feedback.

The reference date is the placeholder, which is why the range field/picker is where this shows up most: both inputs share a placeholder that is kept in sync with the **start** value, so the end field's day is limited by the start date's month. The same clamping also applies to a standalone `DateField` whose placeholder month differs from what is being typed (e.g. an empty field with a November placeholder), and to Feb 29 when the placeholder's year is not the entered one.

## Fix

Apply the parts in a fixed `year → month → day → hour → minute → second → dayPeriod` order rather than display order; the display order still drives everything the user sees and interacts with.

## Tests

- `packages/bits-ui/src/lib/internal/date-time/field/helpers.test.ts` — unit tests for `getValueFromSegments`: day-first and month-first orders, Feb 29 against the entered year, time granularity, and unfilled segments.
- `tests/src/tests/date-range-field/date-range-field.browser.test.ts` — regression test typing `31` into the end day with `locale="en-GB"` and a start date in a 30-day month.

Both fail on `main` (`2026-08-30`) and pass with the fix. The full `bits-ui` unit suite plus the `date-field`, `date-range-field`, `date-picker`, `date-range-picker`, `calendar` and `range-calendar` browser suites pass.
