### PR TITLE
fix(DismissibleLayer): guard the deferred focus handler against teardown

### DIFF
--- a/.changeset/olive-doors-shake.md
+++ b/.changeset/olive-doors-shake.md
@@ -1,0 +1,5 @@
+---
+"bits-ui": patch
+---
+
+fix(DismissibleLayer): guard the deferred focus handler against teardown - #2080

--- a/packages/bits-ui/src/lib/bits/utilities/dismissible-layer/use-dismissable-layer.svelte.ts
+++ b/packages/bits-ui/src/lib/bits/utilities/dismissible-layer/use-dismissable-layer.svelte.ts
@@ -46,6 +46,14 @@ export class DismissibleLayerState {
 	#documentObj = undefined as unknown as Document;
 	#onFocusOutside: DismissibleLayerStateOpts["onFocusOutside"];
 	#unsubClickListener = noop;
+	/**
+	 * Set once the layer is torn down. Deferred work scheduled before teardown can
+	 * still run afterwards, so every such callback must short-circuit on this
+	 * before reading `this.opts.ref.current` — reading a destroyed `$derived`
+	 * triggers Svelte's `derived_inert` warning. A class field rather than a
+	 * constructor local so the class-field handlers below can see it too.
+	 */
+	#destroyed = false;
 
 	constructor(opts: DismissibleLayerStateOpts) {
 		this.opts = opts;
@@ -64,7 +72,6 @@ export class DismissibleLayerState {
 		// destroyed $derived (`ref.current`) → `derived_inert` (and can re-attach document
 		// listeners to a dead instance). See https://github.com/huntabyte/bits-ui/issues/2080
 		let pendingTimer: ReturnType<typeof afterSleep> | null = null;
-		let destroyed = false;
 		const clearPendingTimer = () => {
 			if (pendingTimer != null) {
 				clearTimeout(pendingTimer);
@@ -85,8 +92,8 @@ export class DismissibleLayerState {
 			clearPendingTimer();
 			pendingTimer = afterSleep(1, () => {
 				pendingTimer = null;
-				// `destroyed` must short-circuit before any `this.opts.ref.current` read.
-				if (destroyed || !this.opts.ref.current) return;
+				// `#destroyed` must short-circuit before any `this.opts.ref.current` read.
+				if (this.#destroyed || !this.opts.ref.current) return;
 				globalThis.bitsDismissableLayers.set(this, this.#behaviorType);
 
 				unsubEvents();
@@ -96,7 +103,7 @@ export class DismissibleLayerState {
 		});
 
 		onDestroyEffect(() => {
-			destroyed = true;
+			this.#destroyed = true;
 			clearPendingTimer();
 			this.#resetState.destroy();
 			globalThis.bitsDismissableLayers.delete(this);
@@ -108,8 +115,12 @@ export class DismissibleLayerState {
 
 	#handleFocus = (event: FocusEvent) => {
 		if (event.defaultPrevented) return;
-		if (!this.opts.ref.current) return;
+		if (this.#destroyed || !this.opts.ref.current) return;
 		afterTick(() => {
+			// The layer can be destroyed between the focus event and this tick — a
+			// focus change is frequently what closes it. `#destroyed` must
+			// short-circuit before any `this.opts.ref.current` read.
+			if (this.#destroyed) return;
 			if (!this.opts.ref.current || this.#isTargetWithinLayer(event.target as HTMLElement))
 				return;
 

--- a/tests/src/tests/dialog/dialog.browser.test.ts
+++ b/tests/src/tests/dialog/dialog.browser.test.ts
@@ -779,6 +779,40 @@ describe("DismissibleLayer teardown (derived_inert / #2080)", () => {
 		};
 	}
 
+	/**
+	 * `#handleFocus` defers its `ref.current` read with `afterTick`, and a focus
+	 * change is frequently the very thing that closes a layer. #2080's fix guarded
+	 * the `afterSleep` timer with a constructor-local `destroyed`, which a class
+	 * field handler like `#handleFocus` cannot reference, so this path stayed open.
+	 *
+	 * Honest caveat: like the sibling cases below, this is a smoke test — it does
+	 * not fail against the unguarded source. `derived_inert` only fires when the
+	 * derived is *dirty* and its parent is destroyed but `is_destroying_effect` is
+	 * no longer set, a window this harness does not reliably hit. The guard is
+	 * verified by inspection; the failing case came from production telemetry.
+	 */
+	it("should survive a focus change that closes the layer in the same tick", async () => {
+		const counter = installDerivedInertCounter();
+		const outside = document.createElement("button");
+		try {
+			const t = render(DialogTest, { open: true });
+			await expectExists(page.getByTestId("content"));
+
+			document.body.appendChild(outside);
+			counter.counts.inert = 0;
+
+			outside.focus();
+			await t.rerender({ open: false });
+			await expectNotExists(page.getByTestId("content"));
+
+			await new Promise((r) => setTimeout(r, 50));
+			expect(counter.counts.inert).toBe(0);
+		} finally {
+			outside.remove();
+			counter.restore();
+		}
+	});
+
 	it("should not emit derived_inert when unmounted while open", async () => {
 		const counter = installDerivedInertCounter();
 		try {

--- a/tests/src/tests/dialog/dialog.browser.test.ts
+++ b/tests/src/tests/dialog/dialog.browser.test.ts
@@ -1,7 +1,7 @@
 import { userEvent, page } from "@vitest/browser/context";
 import { expect, it, vi, describe } from "vitest";
 import { render } from "vitest-browser-svelte";
-import type { Component } from "svelte";
+import { tick, type Component } from "svelte";
 import { getTestKbd } from "../utils.js";
 import DialogTest, { type DialogTestProps } from "./dialog-test.svelte";
 import DialogNestedTest from "./dialog-nested-test.svelte";
@@ -779,37 +779,41 @@ describe("DismissibleLayer teardown (derived_inert / #2080)", () => {
 		};
 	}
 
-	/**
-	 * `#handleFocus` defers its `ref.current` read with `afterTick`, and a focus
-	 * change is frequently the very thing that closes a layer. #2080's fix guarded
-	 * the `afterSleep` timer with a constructor-local `destroyed`, which a class
-	 * field handler like `#handleFocus` cannot reference, so this path stayed open.
-	 *
-	 * Honest caveat: like the sibling cases below, this is a smoke test — it does
-	 * not fail against the unguarded source. `derived_inert` only fires when the
-	 * derived is *dirty* and its parent is destroyed but `is_destroying_effect` is
-	 * no longer set, a window this harness does not reliably hit. The guard is
-	 * verified by inspection; the failing case came from production telemetry.
-	 */
-	it("should survive a focus change that closes the layer in the same tick", async () => {
-		const counter = installDerivedInertCounter();
-		const outside = document.createElement("button");
+	it("should not read the layer ref from pending focus work after unmount", async () => {
+		const t = await open();
+		const content = page.getByTestId("content").element();
+		const layers = (
+			globalThis as {
+				bitsDismissableLayers?: Map<
+					{ opts: { ref: { current: HTMLElement | null } } },
+					unknown
+				>;
+			}
+		).bitsDismissableLayers!;
+		const layer = [...layers.keys()].find((layer) => layer.opts.ref.current === content)!;
+		const originalRef = layer.opts.ref;
+		const readRef = vi.fn(() => originalRef.current);
+		layer.opts.ref = {
+			get current() {
+				return readRef();
+			},
+			set current(value) {
+				originalRef.current = value;
+			},
+		};
+
 		try {
-			const t = render(DialogTest, { open: true });
-			await expectExists(page.getByTestId("content"));
+			content.dispatchEvent(new FocusEvent("focusin", { bubbles: true }));
+			expect(readRef).toHaveBeenCalled();
+			// Unmount synchronously before the focus handler's afterTick callback runs.
+			t.unmount();
+			expect(layers.has(layer)).toBe(false);
+			readRef.mockClear();
 
-			document.body.appendChild(outside);
-			counter.counts.inert = 0;
-
-			outside.focus();
-			await t.rerender({ open: false });
-			await expectNotExists(page.getByTestId("content"));
-
-			await new Promise((r) => setTimeout(r, 50));
-			expect(counter.counts.inert).toBe(0);
+			await tick();
+			expect(readRef).not.toHaveBeenCalled();
 		} finally {
-			outside.remove();
-			counter.restore();
+			layer.opts.ref = originalRef;
 		}
 	});
 


### PR DESCRIPTION
## The bug

`#2087` fixed the `afterSleep(1)` attach timer for #2080 by short-circuiting on a `destroyed` flag. That flag is a **constructor-local `let`**, so a class field arrow function like `#handleFocus` cannot reference it — the focus path was structurally out of reach of that fix and stayed open.

`#handleFocus` defers its `this.opts.ref.current` read with `afterTick`:

```ts
#handleFocus = (event: FocusEvent) => {
    if (event.defaultPrevented) return;
    if (!this.opts.ref.current) return;
    afterTick(() => {
        if (!this.opts.ref.current || this.#isTargetWithinLayer(...)) return;   // ← here
```

A focus change is frequently the very thing that closes a layer, so the tick routinely lands after the layer is destroyed. The read then hits a derived whose owning effect is gone, and Svelte logs `derived_inert`.

## The fix

Promote `destroyed` to a `#destroyed` class field so both the constructor's timer callback and the class field handlers can see it, then short-circuit on it inside the `afterTick` before any `ref.current` read. No behaviour change for a live layer.

## Evidence

We hit this in production on **2.19.0** (which does contain #2087 — verified in the published `dist`). Two Sentry issues, ~140 events across 19 users, all with the same frame:

```
bits-ui/dist/bits/utilities/dismissible-layer/use-dismissable-layer.svelte.js:86
  → svelte/internal/client/runtime.js:692 (get)
  → svelte/internal/client/reactivity/deriveds.js:394 (execute_derived)
  → deriveds.js:351 → w.derived_inert()
```

Line 86 is inside the `afterTick` callback. Our layers are popovers/dropdowns in long lists, which is a heavy focus-churn surface.

## About the test

I added one to the existing `DismissibleLayer teardown (derived_inert / #2080)` describe, but **I want to be upfront: it is a smoke test and does not fail against the unguarded source.**

I tried two repro shapes (unmount-while-open, and close-in-the-same-tick-as-focus) and both passed pre-fix. `derived_inert` only fires when the derived is *dirty* **and** its parent is destroyed **and** `is_destroying_effect` is no longer set — a window this harness doesn't reliably hit. For what it's worth, I also checked out the pre-#2087 source and the existing tests in that describe pass against it too, so this seems inherent to testing this warning rather than anything specific to my case.

So the guard is verified by inspection and by the production telemetry above, not by a failing test. Happy to drop the test entirely if you'd rather not carry one that can't fail — or to try a different approach if you know a harness shape that reliably catches this.

---

Part of the broader `derived_inert` cluster (#2083, #2103, #2106, #2112, #2121, #2050) — same shape, deferred work reading `ref.current` after teardown. I have production stacks for the Accordion and Avatar instances too and will send those as separate PRs per the contributing guide.
