### PR TITLE
fix(Accordion): cancel deferred content work on destroy

### DIFF
--- a/.changeset/tidy-moons-repeat.md
+++ b/.changeset/tidy-moons-repeat.md
@@ -1,0 +1,5 @@
+---
+"bits-ui": patch
+---
+
+fix(Accordion): cancel deferred content work on destroy to avoid `derived_inert`

--- a/packages/bits-ui/src/lib/bits/accordion/accordion.svelte.ts
+++ b/packages/bits-ui/src/lib/bits/accordion/accordion.svelte.ts
@@ -2,6 +2,7 @@ import {
 	afterTick,
 	attachRef,
 	boxWith,
+	onDestroyEffect,
 	type Box,
 	type ReadableBoxedValues,
 	type WritableBoxedValues,
@@ -295,6 +296,14 @@ export class AccordionContentState {
 	#originalStyles: { transitionDuration: string; animationName: string } | undefined = undefined;
 	#isMountAnimationPrevented = false;
 	#dimensions = $state({ width: 0, height: 0 });
+	/**
+	 * Set once the content is torn down. Work deferred before teardown can still
+	 * run afterwards, so it must short-circuit on this before touching
+	 * `this.opts.ref.current` or `this.item` — reading a destroyed `$derived`
+	 * triggers Svelte's `derived_inert` warning.
+	 */
+	#destroyed = false;
+	#beforeMatchFrame: number | null = null;
 
 	readonly open = $derived.by(() => {
 		if (this.opts.hiddenUntilFound.current) return this.item.isActive;
@@ -324,17 +333,39 @@ export class AccordionContentState {
 					// we need to defer opening until after browser completes search highlighting
 					// otherwise the browser will immediately open the accordion
 					// and the search highlighting will not be visible
-					requestAnimationFrame(() => {
+					if (this.#beforeMatchFrame !== null) {
+						cancelAnimationFrame(this.#beforeMatchFrame);
+					}
+					this.#beforeMatchFrame = requestAnimationFrame(() => {
+						this.#beforeMatchFrame = null;
+						if (this.#destroyed) return;
 						this.item.updateValue();
 					});
 				};
 
-				return on(node, "beforematch", handleBeforeMatch);
+				const unsubBeforeMatch = on(node, "beforematch", handleBeforeMatch);
+				return () => {
+					// Removing the listener does not cancel a frame already scheduled
+					// by it, which would then read `this.item` after teardown.
+					if (this.#beforeMatchFrame !== null) {
+						cancelAnimationFrame(this.#beforeMatchFrame);
+						this.#beforeMatchFrame = null;
+					}
+					unsubBeforeMatch();
+				};
 			}
 		);
 
 		// Handle dimension updates
 		watch([() => this.open, () => this.opts.ref.current], this.#updateDimensions);
+
+		onDestroyEffect(() => {
+			this.#destroyed = true;
+			if (this.#beforeMatchFrame !== null) {
+				cancelAnimationFrame(this.#beforeMatchFrame);
+				this.#beforeMatchFrame = null;
+			}
+		});
 	}
 
 	static create(props: AccordionContentStateOpts): AccordionContentState {
@@ -345,6 +376,9 @@ export class AccordionContentState {
 		if (!node) return;
 
 		afterTick(() => {
+			// The content can be destroyed between the watch firing and this tick.
+			// `#destroyed` must short-circuit before any `this.opts.ref.current` read.
+			if (this.#destroyed) return;
 			const element = this.opts.ref.current;
 			if (!element) return;
 


### PR DESCRIPTION
## The bug

`AccordionContentState` defers two pieces of work that can outlive the content's effect. Neither was guarded:

**1. `#updateDimensions` reads `ref.current` inside `afterTick`**

```ts
#updateDimensions = ([_, node]) => {
    if (!node) return;
    afterTick(() => {
        const element = this.opts.ref.current;   // ← may be destroyed by now
```

Closing or unmounting an item between the watch firing and that tick leaves the read landing on a derived whose owning effect is gone → `derived_inert`.

**2. `handleBeforeMatch` schedules an `rAF` that is never cancelled**

```ts
const handleBeforeMatch = () => {
    if (this.item.isActive) return;
    requestAnimationFrame(() => {
        this.item.updateValue();     // ← never cancelled
    });
};
return on(node, "beforematch", handleBeforeMatch);
```

Returning the listener unsubscriber does **not** cancel a frame the listener already scheduled, so the callback still runs against a dead item.

Worth noting the mount-animation `rAF` a few lines above *does* cancel correctly (`return () => cancelAnimationFrame(rAF)`) — these two just missed the same treatment.

## The fix

A `#destroyed` flag set in `onDestroyEffect`, short-circuiting the `afterTick` body before any `ref.current` read; and the beforematch frame tracked so both teardown and a subsequent match can cancel it. Mirrors the existing guard in DismissibleLayer from #2087.

## Evidence

Production stacks on **2.19.0** point at the compiled `#updateDimensions` `afterTick`:

```
bits-ui/dist/bits/accordion/accordion.svelte.js:213
  → svelte/internal/client/runtime.js:692 (get)
  → deriveds.js:394 (execute_derived)
  → deriveds.js:351 → w.derived_inert()
```

## Testing

`pnpm test:browser --browser chromium accordion` — **56 passed**, including the `hiddenUntilFound` / beforematch cases that exercise the path I changed. Lint clean.

I did **not** add a `derived_inert` regression test. I tried on the sibling DismissibleLayer PR (#2126) and could not get one to fail against the unguarded source: the warning needs the derived to be *dirty* **and** its parent destroyed **and** `is_destroying_effect` no longer set, which the browser harness doesn't reliably hit. Rather than add a test that passes either way, I've left the existing suite as the behavioural guard. Glad to add one if you know a shape that catches this reliably.

---

Part of the `derived_inert` cluster (#2080, #2083, #2103, #2106, #2112, #2121, #2050). Sibling PR for DismissibleLayer: #2126. Avatar (#2050) to follow.
