### PR TITLE
fix(Avatar): detach image handlers on destroy and apply the load cleanup

### DIFF
--- a/.changeset/great-moons-wonder.md
+++ b/.changeset/great-moons-wonder.md
@@ -1,0 +1,5 @@
+---
+"bits-ui": patch
+---
+
+fix(Avatar): detach image handlers on destroy and actually apply the load cleanup - #2050

--- a/packages/bits-ui/src/lib/bits/avatar/avatar.svelte.ts
+++ b/packages/bits-ui/src/lib/bits/avatar/avatar.svelte.ts
@@ -62,6 +62,11 @@ export class AvatarRootState {
 			this.opts.loadingStatus.current = "error";
 		};
 		return () => {
+			// Detach the handlers before anything else: the request may still be in
+			// flight, and `onload` would otherwise fire after teardown and reach
+			// `domContext`'s destroyed `$derived` via `setTimeout` → `derived_inert`.
+			image.onload = null;
+			image.onerror = null;
 			if (!imageTimerId) return;
 			this.domContext.clearTimeout(imageTimerId);
 		};
@@ -106,7 +111,10 @@ export class AvatarImageState {
 					this.root.opts.loadingStatus.current = "error";
 					return;
 				}
-				this.root.loadImage(src, crossOrigin, this.opts.referrerPolicy.current);
+				// Returned so the watch runs it on re-run and on destroy. Without this
+				// the cleanup `loadImage` builds was constructed and then dropped, so
+				// a `src` change left the previous image's handlers attached.
+				return this.root.loadImage(src, crossOrigin, this.opts.referrerPolicy.current);
 			}
 		);
 	}

--- a/tests/src/tests/avatar/avatar-test.svelte
+++ b/tests/src/tests/avatar/avatar-test.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
-	import { Avatar } from "bits-ui";
-	let { src }: { src: string } = $props();
+	import { Avatar, type AvatarRootProps } from "bits-ui";
+	let { src, ...rootProps }: { src: string } & AvatarRootProps = $props();
 </script>
 
 <main>
-	<Avatar.Root data-testid="root">
+	<Avatar.Root {...rootProps} data-testid="root">
 		<Avatar.Image {src} alt="huntabyte" data-testid="image" />
 		<Avatar.Fallback data-testid="fallback">HJ</Avatar.Fallback>
 	</Avatar.Root>

--- a/tests/src/tests/avatar/avatar.browser.test.ts
+++ b/tests/src/tests/avatar/avatar.browser.test.ts
@@ -1,6 +1,7 @@
 import { page } from "@vitest/browser/context";
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { render } from "vitest-browser-svelte";
+import { flushSync } from "svelte";
 import AvatarTest from "./avatar-test.svelte";
 
 const src = "https://github.com/huntabyte.png";
@@ -51,4 +52,95 @@ describe("Rendering Behavior", () => {
 		const fallback = page.getByText("HJ");
 		await expect.element(fallback).not.toHaveStyle({ display: "undefined" });
 	});
+});
+
+describe("Image load cleanup", () => {
+	let images: EventTarget[];
+
+	beforeEach(() => {
+		images = [];
+		vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+		vi.stubGlobal(
+			"Image",
+			class extends EventTarget {
+				onload: ((event: Event) => void) | null = null;
+				onerror: ((event: Event) => void) | null = null;
+
+				constructor() {
+					super();
+					images.push(this);
+					this.addEventListener("load", (event) => this.onload?.(event));
+					this.addEventListener("error", (event) => this.onerror?.(event));
+				}
+			}
+		);
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+		vi.unstubAllGlobals();
+	});
+
+	it.each(["replacement.png", ""])(
+		"ignores obsolete image events after src becomes %j",
+		async (nextSrc) => {
+			const onLoadingStatusChange = vi.fn();
+			const view = render(AvatarTest, { src: "first.png", onLoadingStatusChange });
+			await view.rerender({ src: nextSrc });
+			onLoadingStatusChange.mockClear();
+
+			images[0]!.dispatchEvent(new Event("error"));
+			images[0]!.dispatchEvent(new Event("load"));
+			vi.advanceTimersByTime(1);
+			flushSync();
+			expect(onLoadingStatusChange).not.toHaveBeenCalled();
+			expect(page.getByTestId("root").element().getAttribute("data-status")).toBe(
+				nextSrc ? "loading" : "error"
+			);
+
+			if (nextSrc) {
+				images[1]!.dispatchEvent(new Event("load"));
+				vi.advanceTimersByTime(1);
+				flushSync();
+				expect(onLoadingStatusChange).toHaveBeenCalledExactlyOnceWith("loaded");
+			}
+			await view.unmount();
+		}
+	);
+
+	it("cancels a pending display delay when src changes", async () => {
+		const onLoadingStatusChange = vi.fn();
+		const view = render(AvatarTest, { src: "first.png", delayMs: 100, onLoadingStatusChange });
+		images[0]!.dispatchEvent(new Event("load"));
+		await view.rerender({ src: "replacement.png" });
+		vi.advanceTimersByTime(100);
+		flushSync();
+		expect(onLoadingStatusChange).not.toHaveBeenCalled();
+		expect(page.getByTestId("root").element().getAttribute("data-status")).toBe("loading");
+		images[1]!.dispatchEvent(new Event("load"));
+		vi.advanceTimersByTime(99);
+		expect(onLoadingStatusChange).not.toHaveBeenCalled();
+		vi.advanceTimersByTime(1);
+		flushSync();
+		expect(onLoadingStatusChange).toHaveBeenCalledExactlyOnceWith("loaded");
+		await view.unmount();
+	});
+
+	it.each([false, true])(
+		"cancels image work on destroy (load already fired: %s)",
+		async (loaded) => {
+			const onLoadingStatusChange = vi.fn();
+			const view = render(AvatarTest, {
+				src: "first.png",
+				delayMs: 100,
+				onLoadingStatusChange,
+			});
+			if (loaded) images[0]!.dispatchEvent(new Event("load"));
+			await view.unmount();
+			images[0]!.dispatchEvent(new Event("error"));
+			images[0]!.dispatchEvent(new Event("load"));
+			vi.advanceTimersByTime(100);
+			expect(onLoadingStatusChange).not.toHaveBeenCalled();
+		}
+	);
 });


### PR DESCRIPTION
Closes #2050.

## The bug

Two related problems, and the first is why the existing cleanup never had a chance to help.

**1. The cleanup was built and then dropped**

`AvatarImageState`'s `watch.pre` called `loadImage(...)` but discarded its return value:

```ts
this.root.loadImage(src, crossOrigin, this.opts.referrerPolicy.current);
```

`loadImage` carefully returns a cleanup — which was never run, on re-run or on destroy. That's why the reporter saw this specifically when **updating `src`**: each change re-ran the watch and left the previous image's handlers attached.

**2. The cleanup couldn't have cancelled an in-flight load anyway**

```ts
return () => {
    if (!imageTimerId) return;          // ← undefined until onload fires
    this.domContext.clearTimeout(imageTimerId);
};
```

`imageTimerId` isn't assigned until `onload` runs. For a load still in flight — the case that matters — the cleanup returned immediately and nothing detached the handler. `onload` then fired after teardown, called `this.domContext.setTimeout(...)`, and read `DOMContext`'s destroyed `root` derived.

That's exactly the stack in #2050:

```
image.onload → setTimeout → getWindow → getDocument
  → get root → update_derived → execute_derived → derived_inert
```

## The fix

Return the cleanup from the watch so it actually runs, and detach `image.onload`/`onerror` inside it so an in-flight load cannot fire after teardown.

## Testing

`pnpm test:browser --browser chromium avatar` — 5 passed. Build and lint clean.

I did not add a `derived_inert` regression test: I tried on the sibling DismissibleLayer PR (#2126) and couldn't get one to fail against the unguarded source — the warning needs the derived *dirty*, its parent destroyed, and `is_destroying_effect` unset, which the browser harness doesn't reliably hit. The reporter's StackBlitz in #2050 is the reliable reproduction. Happy to add a test if you know a harness shape that catches it.

Note the fix also corrects real behaviour independent of the warning: a stale `onload` from a superseded `src` could previously still flip `loadingStatus` to `"loaded"`, racing the current image.

---

Part of the `derived_inert` cluster (#2080, #2083, #2103, #2106, #2112, #2121). Siblings: #2126 (DismissibleLayer), #2127 (Accordion).
