### PR TITLE
fix(Combobox): Avoid race condition between highlighting and filtering items

### DIFF
--- a/.changeset/tidy-combobox-highlighting.md
+++ b/.changeset/tidy-combobox-highlighting.md
@@ -1,0 +1,5 @@
+---
+"bits-ui": patch
+---
+
+fix(Combobox): highlight the first matching item after custom filtering updates the rendered items.

--- a/packages/bits-ui/src/lib/bits/select/select.svelte.ts
+++ b/packages/bits-ui/src/lib/bits/select/select.svelte.ts
@@ -636,7 +636,10 @@ export class SelectInputState {
 
 	oninput(e: BitsEvent<Event, HTMLInputElement>) {
 		this.root.opts.inputValue.current = e.currentTarget.value;
-		this.root.setHighlightedToFirstCandidate();
+		afterTick(() => {
+			if (!this.root.opts.open.current) return;
+			this.root.setHighlightedToFirstCandidate();
+		});
 	}
 
 	readonly props = $derived.by(

--- a/tests/src/tests/combobox/combobox-multi-test.svelte
+++ b/tests/src/tests/combobox/combobox-multi-test.svelte
@@ -42,7 +42,7 @@
 	const filteredItems = $derived(
 		searchValue === ""
 			? items
-			: items.filter((item) => item.label.includes(searchValue.toLowerCase()))
+			: items.filter((item) => item.label.toLowerCase().includes(searchValue.toLowerCase()))
 	);
 </script>
 

--- a/tests/src/tests/combobox/combobox-test.svelte
+++ b/tests/src/tests/combobox/combobox-test.svelte
@@ -37,7 +37,7 @@
 	const filteredItems = $derived(
 		searchValue === ""
 			? items
-			: items.filter((item) => item.label.includes(searchValue.toLowerCase()))
+			: items.filter((item) => item.label.toLowerCase().includes(searchValue.toLowerCase()))
 	);
 
 	const inputValue = $derived.by(() => {

--- a/tests/src/tests/combobox/combobox.browser.test.ts
+++ b/tests/src/tests/combobox/combobox.browser.test.ts
@@ -762,7 +762,7 @@ describe("combobox - multiple", () => {
 	});
 
 	it("should not move highlight to first item when clicking a non-first item in multi-select", async () => {
-		const t = await openMultiple();
+		await openMultiple();
 		const [item1, , , item4] = getItems(page.getByTestId);
 		await item4.hover();
 		await expectHighlighted(item4);

--- a/tests/src/tests/combobox/combobox.browser.test.ts
+++ b/tests/src/tests/combobox/combobox.browser.test.ts
@@ -382,6 +382,28 @@ describe("combobox - single", () => {
 		await expectNotHighlighted(item2);
 	});
 
+	it("items are not shown when filtering has no match", async () => {
+		const t = await openSingle();
+		await t.user.type(t.input, "z");
+		await expectNotExists(page.getByTestId("1"));
+		await expectNotExists(page.getByTestId("2"));
+	});
+
+	it("should highlight the first filtered item after typing in the input", async () => {
+		const t = await openSingle();
+		await t.user.type(t.input, "b");
+		await expectHighlighted(page.getByTestId("2")); // B
+	});
+
+	it("should select the highlighted filtered item with Enter after typing", async () => {
+		const t = await openSingle();
+		await t.user.type(t.input, "b");
+		await expectHighlighted(page.getByTestId("2")); // B
+		await t.user.keyboard(kbd.ENTER);
+		await expect.element(t.input).toHaveValue("B");
+		await expect.element(t.getHiddenInput()).toHaveValue("2");
+	});
+
 	it("should select a default item when provided", async () => {
 		const t = await openSingle({
 			value: "2",
@@ -714,6 +736,29 @@ describe("combobox - multiple", () => {
 		await item2.hover();
 		await expectHighlighted(item2);
 		await expectNotHighlighted(item1);
+	});
+
+	it("items are not shown when filtering has no match", async () => {
+		const t = await openMultiple();
+		await t.user.type(t.input, "z");
+		await expectNotExists(page.getByTestId("1"));
+		await expectNotExists(page.getByTestId("2"));
+	});
+
+	it("should highlight the first filtered item after typing in the input", async () => {
+		const t = await openMultiple();
+		await t.user.type(t.input, "b");
+		await expectHighlighted(page.getByTestId("2")); // B
+	});
+
+	it("should select the highlighted filtered item with Enter after typing", async () => {
+		const t = await openMultiple();
+		await t.user.type(t.input, "b");
+		await expectHighlighted(page.getByTestId("2")); // B
+		await t.user.keyboard(kbd.ENTER);
+		await expect.element(t.input).toHaveValue("B");
+		expect(t.getHiddenInputs()).toHaveLength(1);
+		await expect.element(t.getHiddenInputs()[0]).toHaveValue("2");
 	});
 
 	it("should select a default item when provided", async () => {

--- a/tests/src/tests/combobox/combobox.browser.test.ts
+++ b/tests/src/tests/combobox/combobox.browser.test.ts
@@ -761,6 +761,16 @@ describe("combobox - multiple", () => {
 		await expect.element(t.getHiddenInputs()[0]).toHaveValue("2");
 	});
 
+	it("should not move highlight to first item when clicking a non-first item in multi-select", async () => {
+		const t = await openMultiple();
+		const [item1, , , item4] = getItems(page.getByTestId);
+		await item4.hover();
+		await expectHighlighted(item4);
+		await item4.click();
+		await expectHighlighted(item4);
+		await expectNotHighlighted(item1);
+	});
+
 	it("should select a default item when provided", async () => {
 		const t = await openMultiple({
 			value: ["2"],


### PR DESCRIPTION
Bug fix for https://github.com/huntabyte/bits-ui/issues/2124.

If a Combobox filters the child `Item` nodes, then this races against highlighting. When typing in `<Combobox.Input>` the following happens:

1. `setHighlightedToFirstCandidate()` is called synchronously inside `oninput`, immediately after setting `inputValue`.
2. `getCandidateNodes()` finds matching DOM nodes, picking one to be highlighted.
3. Svelte re-renders, filtering applies to the `Item` nodes, removing any that don't match.

Steps 2 and 3 race: if `getCandidateNodes()` picks an `Item` that is then removed by the filter, the highlighted node is detached from the DOM. `data-highlighted` and keyboard navigation then fails.

Deferring `setHighlightedToFirstCandidate()` with `afterTick` ensures it runs after Svelte flushes the filtered list first (step 3), so `getCandidateNodes()` returns the correct post-filter items (step 2) and the first filtered item is highlighted as expected.

The guard on `this.root.opts.open.current` prevents a no-op if the menu closes before the tick resolves.

[Disclaimer: AI was used to create this PR.]
