### PR TITLE
fix(Tabs): respect explicit content tabindex

### DIFF
--- a/.changeset/tidy-tabs-focus.md
+++ b/.changeset/tidy-tabs-focus.md
@@ -1,0 +1,5 @@
+---
+"bits-ui": patch
+---
+
+fix: respect an explicit `Tabs.Content` tabindex while preserving the default panel tab stop

--- a/docs/content/components/tabs.md
+++ b/docs/content/components/tabs.md
@@ -103,4 +103,16 @@ When set to `'manual'`, the user will need to activate the tab by pressing the t
 </Tabs.Root>
 ```
 
+## Panel Focus
+
+`Tabs.Content` defaults to `tabindex="0"`, so keyboard users can focus the panel. Keep this default when the panel has no focusable elements or its first meaningful content is not focusable, even if a button or link appears later.
+
+When the first meaningful content is focusable, set `tabindex={-1}` to let Tab move directly to that element. Choose this based on your content, following the [WAI-ARIA tabs pattern](https://www.w3.org/WAI/ARIA/apg/patterns/tabs/).
+
+```svelte
+<Tabs.Content value="settings" tabindex={-1}>
+  <button>Update settings</button>
+</Tabs.Content>
+```
+
 <APISection {schemas} />

--- a/packages/bits-ui/src/lib/bits/tabs/components/tabs-content.svelte
+++ b/packages/bits-ui/src/lib/bits/tabs/components/tabs-content.svelte
@@ -12,11 +12,13 @@
 		id = createId(uid),
 		ref = $bindable(null),
 		value,
+		tabindex = 0,
 		...restProps
 	}: TabsContentProps = $props();
 
 	const contentState = TabsContentState.create({
 		value: boxWith(() => value),
+		tabindex: boxWith(() => tabindex ?? 0),
 		id: boxWith(() => id),
 		ref: boxWith(
 			() => ref,

--- a/packages/bits-ui/src/lib/bits/tabs/tabs.svelte.ts
+++ b/packages/bits-ui/src/lib/bits/tabs/tabs.svelte.ts
@@ -226,6 +226,7 @@ interface TabsContentStateOpts
 	extends WithRefOpts,
 		ReadableBoxedValues<{
 			value: string;
+			tabindex: number;
 		}> {}
 
 export class TabsContentState {
@@ -257,7 +258,7 @@ export class TabsContentState {
 				id: this.opts.id.current,
 				role: "tabpanel",
 				hidden: boolToTrueOrUndef(!this.#isActive),
-				tabindex: 0,
+				tabindex: this.opts.tabindex.current,
 				"data-value": this.opts.value.current,
 				"data-state": getTabDataState(this.#isActive),
 				"aria-labelledby": this.#ariaLabelledBy,

--- a/tests/src/tests/tabs/tabs-test.svelte
+++ b/tests/src/tests/tabs/tabs-test.svelte
@@ -7,11 +7,19 @@
 
 	export type TabsTestProps = WithoutChildrenOrChild<Tabs.RootProps> & {
 		items: Item[];
+		contentTabindex?: number;
+		contentLayout?: "text" | "button" | "text-button";
 	};
 </script>
 
 <script lang="ts">
-	let { value = "1", items, ...restProps }: TabsTestProps = $props();
+	let {
+		value = "1",
+		items,
+		contentTabindex,
+		contentLayout = "text",
+		...restProps
+	}: TabsTestProps = $props();
 </script>
 
 <main>
@@ -24,8 +32,13 @@
 			{/each}
 		</Tabs.List>
 		{#each items as { value } (value)}
-			<Tabs.Content {value} data-testid="content-{value}">
-				{value}
+			<Tabs.Content {value} tabindex={contentTabindex} data-testid="content-{value}">
+				{#if contentLayout !== "button"}
+					<p>{value}</p>
+				{/if}
+				{#if contentLayout !== "text"}
+					<button tabindex="0" data-testid="content-button-{value}">Action</button>
+				{/if}
 			</Tabs.Content>
 		{/each}
 	</Tabs.Root>

--- a/tests/src/tests/tabs/tabs.browser.test.ts
+++ b/tests/src/tests/tabs/tabs.browser.test.ts
@@ -28,6 +28,26 @@ function setup(props: Partial<TabsTestProps> = {}) {
 }
 
 describe("Tabs", () => {
+	it.each(["text", "text-button"] as const)(
+		"should tab to the panel when its first content is not focusable (%s)",
+		async (contentLayout) => {
+			setup({ contentLayout });
+			await page.getByTestId("trigger-1").click();
+			await userEvent.tab();
+			await expect.element(page.getByTestId("content-1")).toHaveFocus();
+		}
+	);
+
+	it("should allow skipping the panel when its first content is focusable", async () => {
+		setup({ contentLayout: "button", contentTabindex: -1 });
+		await page.getByTestId("trigger-1").click();
+		await expect.element(page.getByTestId("content-1")).toHaveAttribute("tabindex", "-1");
+		await userEvent.tab();
+		await expect.element(page.getByTestId("content-button-1")).toHaveFocus();
+		await userEvent.tab({ shift: true });
+		await expect.element(page.getByTestId("trigger-1")).toHaveFocus();
+	});
+
 	it("should have bits data attrs", async () => {
 		render(TabsTest, {
 			items: [items[0] as Item],


### PR DESCRIPTION
`Tabs.Content` previously overwrote an explicit `tabindex` with `0`. Respect the supplied prop so panels whose first meaningful content is focusable can use `tabindex={-1}`, while retaining `0` as the default.

Includes panel-focus documentation, keyboard regression coverage, and a patch changeset.

Validation: 22 tabs tests pass across headless Chromium and WebKit; package build/publint, package and test Svelte checks, formatting, and `git diff --check` pass.

Fixes: #2113
