### PR TITLE
fix: capture document for delayed body scroll cleanup

### DIFF
--- a/.changeset/tidy-documents-restore.md
+++ b/.changeset/tidy-documents-restore.md
@@ -1,0 +1,5 @@
+---
+"bits-ui": patch
+---
+
+fix: restore body styles on the captured document when delayed scroll-lock cleanup runs after the global document is torn down or replaced

--- a/packages/bits-ui/src/lib/internal/body-scroll-lock.svelte.test.ts
+++ b/packages/bits-ui/src/lib/internal/body-scroll-lock.svelte.test.ts
@@ -1,0 +1,54 @@
+import { flushSync, tick } from "svelte";
+import { describe, expect, it, vi } from "vitest";
+import { BodyScrollLock } from "./body-scroll-lock.svelte.js";
+
+describe("BodyScrollLock", () => {
+	it.each(["unavailable", "replaced"])(
+		"restores the original body when the global document is %s before delayed cleanup",
+		async (scenario) => {
+			const originalDocument = document;
+			const originalStyle = document.body.getAttribute("style");
+			const replacementDocument = document.implementation.createHTMLDocument();
+			replacementDocument.body.style.color = "blue";
+			const replacementStyle = replacementDocument.body.getAttribute("style");
+			originalDocument.body.style.cssText = "color: red; overflow: auto;";
+			const initialStyle = originalDocument.body.getAttribute("style");
+			let destroy: (() => void) | undefined;
+
+			try {
+				destroy = $effect.root(() => {
+					new BodyScrollLock(true);
+				});
+				flushSync();
+				await tick();
+				expect(originalDocument.body.style.overflow).toBe("hidden");
+
+				vi.useFakeTimers();
+				const setTimeout = vi.spyOn(window, "setTimeout");
+				destroy();
+				destroy = undefined;
+				const cleanup = setTimeout.mock.calls.find(([, delay]) => delay === 24)?.[0];
+				expect(cleanup).toBeTypeOf("function");
+				if (typeof cleanup !== "function") throw new Error("Missing delayed cleanup");
+				vi.clearAllTimers();
+				vi.stubGlobal(
+					"document",
+					scenario === "unavailable" ? undefined : replacementDocument
+				);
+
+				expect(() => cleanup()).not.toThrow();
+				expect(originalDocument.body.getAttribute("style")).toBe(initialStyle);
+				expect(originalDocument.body.style.getPropertyValue("--scrollbar-width")).toBe("");
+				expect(replacementDocument.body.getAttribute("style")).toBe(replacementStyle);
+			} finally {
+				vi.unstubAllGlobals();
+				destroy?.();
+				vi.clearAllTimers();
+				vi.restoreAllMocks();
+				vi.useRealTimers();
+				if (originalStyle === null) originalDocument.body.removeAttribute("style");
+				else originalDocument.body.setAttribute("style", originalStyle);
+			}
+		}
+	);
+});

--- a/packages/bits-ui/src/lib/internal/body-scroll-lock.svelte.ts
+++ b/packages/bits-ui/src/lib/internal/body-scroll-lock.svelte.ts
@@ -43,10 +43,10 @@ const anyLocked = boxWith(() => {
 let cleanupScheduledAt: number | null = null;
 
 const bodyLockStackCount = new SharedState(() => {
-	function resetBodyStyle() {
+	function resetBodyStyle(documentObj: Document) {
 		if (!BROWSER) return;
-		document.body.setAttribute("style", initialBodyStyle ?? "");
-		document.body.style.removeProperty("--scrollbar-width");
+		documentObj.body.setAttribute("style", initialBodyStyle ?? "");
+		documentObj.body.style.removeProperty("--scrollbar-width");
 		isIOS && stopTouchMoveListener?.();
 		// reset initialBodyStyle so next locker captures the correct styles
 		initialBodyStyle = null;
@@ -227,6 +227,7 @@ export class BodyScrollLock {
 			if (isAnyLocked(this.#countState.lockMap)) return;
 
 			const restoreScrollDelay = this.#restoreScrollDelay();
+			const documentObj = document;
 
 			/**
 			 * We schedule the cleanup to run after a delay to handle same-tick
@@ -235,7 +236,7 @@ export class BodyScrollLock {
 			 * reference: https://github.com/huntabyte/bits-ui/issues/1639
 			 */
 			this.#countState.scheduleCleanupIfNoNewLocks(restoreScrollDelay, () => {
-				this.#countState.resetBodyStyle();
+				this.#countState.resetBodyStyle(documentObj);
 			});
 		});
 	}


### PR DESCRIPTION
Delayed body scroll-lock cleanup reads the global `document` after teardown. If it becomes unavailable, cleanup throws; if it is replaced, the original body stays locked. Capture the document before scheduling restoration and pass it to `resetBodyStyle`, preserving the existing delay and lock coordination.

Adds jsdom regression coverage for unavailable and replaced documents, asserting that the original body styles are restored and the replacement document is untouched. Both cases failed before the fix and passed afterward. Includes a patch changeset.

Validation: 129 package tests and 45 dropdown-menu tests in headless Chromium passed; package typecheck, build/publint, targeted ESLint, Prettier, and `git diff --check` passed.

Fixes #2115.
