### PR TITLE
fix(Select): expose combobox semantics and listbox relationship

### DIFF
--- a/.changeset/tidy-select-semantics.md
+++ b/.changeset/tidy-select-semantics.md
@@ -1,0 +1,5 @@
+---
+"bits-ui": patch
+---
+
+Give Select triggers the combobox role and connect them to their mounted listbox with aria-controls.

--- a/packages/bits-ui/src/lib/bits/select/select.svelte.ts
+++ b/packages/bits-ui/src/lib/bits/select/select.svelte.ts
@@ -970,6 +970,8 @@ export class SelectTriggerState {
 				disabled: this.root.opts.disabled.current ? true : undefined,
 				"aria-haspopup": "listbox",
 				"aria-expanded": boolToStr(this.root.opts.open.current),
+				role: "combobox",
+				"aria-controls": this.root.contentNode?.id,
 				"aria-activedescendant": this.root.highlightedId,
 				"data-state": getDataOpenClosed(this.root.opts.open.current),
 				"data-disabled": boolToEmptyStrOrUndef(this.root.opts.disabled.current),

--- a/tests/src/tests/select/select-aria.browser.test.ts
+++ b/tests/src/tests/select/select-aria.browser.test.ts
@@ -1,0 +1,33 @@
+import { expect, it } from "vitest";
+import { page, userEvent } from "@vitest/browser/context";
+import { render } from "vitest-browser-svelte";
+import SelectTest from "./select-test.svelte";
+import SelectMultiTest from "./select-multi-test.svelte";
+
+it.each(["single", "multiple"] as const)(
+	"exposes the %s select as a combobox controlling its listbox",
+	async (type) => {
+		const props = {
+			items: [{ value: "apple", label: "Apple" }],
+			contentProps: { id: "fruit-options" },
+		};
+		if (type === "single") render(SelectTest, { ...props, type });
+		else render(SelectMultiTest, { ...props, type });
+
+		const trigger = page.getByTestId("trigger");
+		await expect.element(trigger).toHaveRole("combobox");
+		await expect.element(trigger).toHaveAttribute("aria-expanded", "false");
+		await expect.element(trigger).not.toHaveAttribute("aria-controls");
+
+		await trigger.click();
+		const content = page.getByRole("listbox");
+		await expect.element(content).toHaveAttribute("id", "fruit-options");
+		await expect.element(trigger).toHaveAttribute("aria-expanded", "true");
+		await expect.element(trigger).toHaveAttribute("aria-controls", "fruit-options");
+
+		await userEvent.keyboard("{Escape}");
+		await expect.element(trigger).toHaveAttribute("aria-expanded", "false");
+		await expect.element(content).not.toBeInTheDocument();
+		await expect.element(trigger).not.toHaveAttribute("aria-controls");
+	}
+);


### PR DESCRIPTION
Fixes #2134.

`Select.Trigger` exposes `aria-expanded` and `aria-activedescendant` but renders with the button role and no relationship to its listbox. Add `role="combobox"` and derive `aria-controls` from the mounted content ID. The relationship disappears when content unmounts.

The regression test covers single and multiple selection, a custom content ID, and opening/closing. Both cases fail against upstream main and pass with this change. Includes a patch changeset.

Validation:

- `pnpm build:packages` — passed, including publint.
- `pnpm -F tests test:browser --run --browser chromium src/tests/select --retry 0` — 76 tests passed.
- Library and test `svelte-check` — 0 errors and 0 warnings.
- `pnpm lint` — passed.
