### PR TITLE
fix(FocusScope): preserve existing focus during opening

### DIFF
--- a/.changeset/calm-dialog-focus.md
+++ b/.changeset/calm-dialog-focus.md
@@ -1,0 +1,5 @@
+---
+"bits-ui": patch
+---
+
+Preserve focus already inside a Focus Scope when its deferred opening autofocus runs.

--- a/packages/bits-ui/src/lib/bits/utilities/focus-scope/focus-scope.svelte.ts
+++ b/packages/bits-ui/src/lib/bits/utilities/focus-scope/focus-scope.svelte.ts
@@ -87,6 +87,12 @@ export class FocusScope {
 		if (!event.defaultPrevented) {
 			requestAnimationFrame(() => {
 				if (!this.#container) return;
+				const activeElement = this.#container.ownerDocument
+					.activeElement as HTMLElement | null;
+				if (activeElement && this.#container.contains(activeElement)) {
+					this.#manager.setFocusMemory(this, activeElement);
+					return;
+				}
 				const firstTabbable = this.#getFirstTabbable();
 				if (firstTabbable) {
 					firstTabbable.focus();

--- a/tests/src/tests/dialog/dialog.browser.test.ts
+++ b/tests/src/tests/dialog/dialog.browser.test.ts
@@ -129,6 +129,22 @@ describe("Focus Management", () => {
 		}
 	);
 
+	it.each(["content", "open-focus-override"])(
+		"should preserve focus placed on %s during opening",
+		async (testId) => {
+			await open({
+				contentProps: {
+					onOpenAutoFocus: () => {
+						const target = page.getByTestId(testId).element() as HTMLElement;
+						target.focus();
+					},
+				},
+			});
+			await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+			await expect.element(page.getByTestId(testId)).toHaveFocus();
+		}
+	);
+
 	it("should respect `onOpenAutoFocus` prop", async () => {
 		await open({
 			contentProps: {


### PR DESCRIPTION
Fixes #2135.

Focus Scope's opening animation frame moves focus to its first tabbable even when focus is already inside the scope. Check the container's current active element before applying the fallback autofocus, and record existing focus in the scope manager.

The new dialog tests focus either the container or a later button during `onOpenAutoFocus` without canceling the event. Both fail against upstream main, where focus jumps to the close button, and pass with this change. Includes a patch changeset.

Validation:

- `pnpm build:packages` — passed, including publint.
- Chromium dialog suite — 47 tests passed, 1 existing todo.
- WebKit — both new regressions passed. Four existing close/restore-focus tests fail identically on untouched upstream main (`f041ec83`) and with this fix.
- Library and test `svelte-check` — 0 errors and 0 warnings.
- `pnpm lint` — passed.
