### PR TITLE
fix(AlertDialog): capture content for delayed autofocus

### DIFF
--- a/.changeset/steady-alert-focus.md
+++ b/.changeset/steady-alert-focus.md
@@ -1,0 +1,5 @@
+---
+"bits-ui": patch
+---
+
+Capture the original Alert Dialog content for delayed autofocus and skip it after removal, so pending focus work cannot focus replacement content or read a destroyed ref.

--- a/packages/bits-ui/src/lib/bits/alert-dialog/components/alert-dialog-content.svelte
+++ b/packages/bits-ui/src/lib/bits/alert-dialog/components/alert-dialog-content.svelte
@@ -51,7 +51,8 @@
 			onOpenAutoFocus(e);
 			if (e.defaultPrevented) return;
 			e.preventDefault();
-			afterSleep(0, () => contentState.opts.ref.current?.focus());
+			const content = contentState.opts.ref.current;
+			afterSleep(0, () => content?.isConnected && content.focus());
 		}}
 	>
 		{#snippet focusScope({ props: focusScopeProps })}

--- a/tests/src/tests/alert-dialog/alert-dialog-delayed-focus.browser.test.ts
+++ b/tests/src/tests/alert-dialog/alert-dialog-delayed-focus.browser.test.ts
@@ -1,0 +1,61 @@
+import { expect, it, vi } from "vitest";
+import { page } from "@vitest/browser/context";
+import { render } from "vitest-browser-svelte";
+import AlertDialogReplaceContentTest from "./alert-dialog-replace-content-test.svelte";
+
+it.each(["connected", "removed", "replaced"] as const)(
+	"handles delayed autofocus when the original content is %s",
+	async (scenario) => {
+		const originalSetTimeout = globalThis.setTimeout;
+		let captureNextTimeout = false;
+		let pendingFocus: (() => void) | undefined;
+		let timer: ReturnType<typeof setTimeout> | undefined;
+		const timeoutSpy = vi
+			.spyOn(globalThis, "setTimeout")
+			.mockImplementation((fn, delay, ...args) => {
+				if (captureNextTimeout && delay === 0 && typeof fn === "function") {
+					captureNextTimeout = false;
+					pendingFocus = () => fn(...args);
+					timer = originalSetTimeout(() => {}, 60_000);
+					return timer;
+				}
+				return originalSetTimeout(fn, delay, ...args);
+			});
+		const onOpenAutoFocus = vi.fn((event: Event) => {
+			if (pendingFocus) event.preventDefault();
+			else captureNextTimeout = true;
+		});
+
+		try {
+			const rendered = render(AlertDialogReplaceContentTest, { onOpenAutoFocus });
+			await expect.poll(() => pendingFocus).toBeTypeOf("function");
+			if (!pendingFocus) throw new Error("Missing delayed autofocus callback");
+			const originalContent = page.getByTestId("content").element() as HTMLElement;
+			const focus = vi.spyOn(originalContent, "focus");
+
+			if (scenario === "removed") await rendered.unmount();
+			if (scenario === "replaced") {
+				await rendered.rerender({ version: 1 });
+				await expect.poll(() => onOpenAutoFocus.mock.calls.length).toBe(2);
+			}
+
+			pendingFocus();
+
+			if (scenario === "connected") {
+				expect(focus).toHaveBeenCalledOnce();
+				expect(document.activeElement).toBe(originalContent);
+			} else {
+				expect(originalContent.isConnected).toBe(false);
+				expect(focus).not.toHaveBeenCalled();
+				if (scenario === "replaced") {
+					expect(page.getByTestId("content").element()).not.toBe(originalContent);
+					expect(document.activeElement).not.toBe(page.getByTestId("content").element());
+				}
+			}
+		} finally {
+			if (timer !== undefined) clearTimeout(timer);
+			timeoutSpy.mockRestore();
+			vi.restoreAllMocks();
+		}
+	}
+);

--- a/tests/src/tests/alert-dialog/alert-dialog-replace-content-test.svelte
+++ b/tests/src/tests/alert-dialog/alert-dialog-replace-content-test.svelte
@@ -1,0 +1,27 @@
+<script lang="ts">
+	import { AlertDialog } from "bits-ui";
+
+	let {
+		version = 0,
+		onOpenAutoFocus,
+	}: {
+		version?: number;
+		onOpenAutoFocus: (event: Event) => void;
+	} = $props();
+</script>
+
+<AlertDialog.Root open>
+	<AlertDialog.Content {onOpenAutoFocus} trapFocus={false} preventScroll={false}>
+		{#snippet child({ props })}
+			{#key version}
+				<div {...props} data-testid="content">
+					<AlertDialog.Title>Confirm action</AlertDialog.Title>
+					<AlertDialog.Description
+						>This action needs confirmation.</AlertDialog.Description
+					>
+					<AlertDialog.Cancel>Cancel</AlertDialog.Cancel>
+				</div>
+			{/key}
+		{/snippet}
+	</AlertDialog.Content>
+</AlertDialog.Root>


### PR DESCRIPTION
Fixes #2136.

Alert Dialog's delayed autofocus reads `contentState.opts.ref.current` when its timer fires. If a keyed child replaces the content first, the old timer focuses the replacement even when the replacement's opening autofocus was canceled.

Capture the original content before scheduling the timer and focus it only while connected. This also avoids reading a reactive ref after its owner is destroyed. The regression tests cover connected, removed, and replaced nodes; the replacement case fails against upstream main. Includes a patch changeset.

Validation:

- `pnpm build:packages` — passed, including publint.
- Chromium Alert Dialog tests — 33 passed, including all 3 new cases.
- WebKit — all 3 new cases passed.
- Library and test `svelte-check` — 0 errors and 0 warnings.
- `pnpm lint` — passed.
