### PR TITLE
fix: resolve animation refs after content mounts

### DIFF
--- a/.changeset/ready-animation-refs.md
+++ b/.changeset/ready-animation-refs.md
@@ -1,0 +1,5 @@
+---
+"bits-ui": patch
+---
+
+Resolve animation refs in the scheduled frame so onOpenChangeComplete runs when content mounts on demand.

--- a/packages/bits-ui/src/lib/internal/animations-complete.svelte.test.ts
+++ b/packages/bits-ui/src/lib/internal/animations-complete.svelte.test.ts
@@ -1,0 +1,118 @@
+import { flushSync, tick } from "svelte";
+import { simpleBox } from "svelte-toolbelt";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { AnimationsComplete } from "./animations-complete.js";
+
+describe("AnimationsComplete", () => {
+	let destroy: (() => void) | undefined;
+
+	afterEach(() => {
+		destroy?.();
+		destroy = undefined;
+		vi.useRealTimers();
+	});
+
+	function setup(afterTick: boolean, node: HTMLElement | null = null) {
+		vi.useFakeTimers();
+		const ref = simpleBox(node);
+		let complete: AnimationsComplete | undefined;
+		destroy = $effect.root(() => {
+			complete = new AnimationsComplete({ ref, afterTick: simpleBox(afterTick) });
+		});
+		flushSync();
+		if (!complete) throw new Error("AnimationsComplete was not initialized");
+		return { ref, complete };
+	}
+
+	async function advanceFrames() {
+		vi.advanceTimersToNextFrame();
+		vi.advanceTimersToNextFrame();
+		await tick();
+	}
+
+	it.each([true, false])(
+		"resolves a ref mounted after run (afterTick: %s)",
+		async (afterTick) => {
+			const { ref, complete } = setup(afterTick);
+			const callback = vi.fn();
+			complete.run(callback);
+			const node = document.createElement("div");
+			node.getAnimations = vi.fn(() => []);
+			ref.current = node;
+			await advanceFrames();
+			expect(node.getAnimations).toHaveBeenCalledOnce();
+			expect(callback).toHaveBeenCalledOnce();
+		}
+	);
+
+	it("checks the current ref when content is replaced before the frame", async () => {
+		const original = document.createElement("div");
+		original.getAnimations = vi.fn(() => []);
+		const replacement = document.createElement("div");
+		replacement.getAnimations = vi.fn(() => []);
+		const { ref, complete } = setup(false, original);
+		const callback = vi.fn();
+		complete.run(callback);
+		ref.current = replacement;
+		await advanceFrames();
+		expect(original.getAnimations).not.toHaveBeenCalled();
+		expect(replacement.getAnimations).toHaveBeenCalledOnce();
+		expect(callback).toHaveBeenCalledOnce();
+	});
+
+	it("waits for starting styles to clear on newly mounted content", async () => {
+		const { ref, complete } = setup(true);
+		const callback = vi.fn();
+		complete.run(callback);
+		const node = document.createElement("div");
+		node.getAnimations = vi.fn(() => []);
+		node.setAttribute("data-starting-style", "");
+		ref.current = node;
+		await advanceFrames();
+		expect(callback).not.toHaveBeenCalled();
+		node.removeAttribute("data-starting-style");
+		await tick();
+		await advanceFrames();
+		expect(callback).toHaveBeenCalledOnce();
+	});
+
+	it("skips completion if the ref is still absent at the frame", async () => {
+		const { complete } = setup(true);
+		const callback = vi.fn();
+		complete.run(callback);
+		await advanceFrames();
+		expect(callback).not.toHaveBeenCalled();
+	});
+
+	it("supports newly mounted elements without getAnimations", async () => {
+		const { ref, complete } = setup(false);
+		const callback = vi.fn();
+		complete.run(callback);
+		ref.current = document.createElement("div");
+		await advanceFrames();
+		expect(callback).toHaveBeenCalledOnce();
+	});
+
+	it("cancels a pending run when another run starts", async () => {
+		const { ref, complete } = setup(false);
+		const previous = vi.fn();
+		const current = vi.fn();
+		complete.run(previous);
+		ref.current = document.createElement("div");
+		complete.run(current);
+		await advanceFrames();
+		expect(previous).not.toHaveBeenCalled();
+		expect(current).toHaveBeenCalledOnce();
+	});
+
+	it("cancels a pending run on destruction", async () => {
+		const { ref, complete } = setup(false);
+		const callback = vi.fn();
+		complete.run(callback);
+		ref.current = document.createElement("div");
+		destroy?.();
+		destroy = undefined;
+		await advanceFrames();
+		expect(callback).not.toHaveBeenCalled();
+	});
+});

--- a/packages/bits-ui/src/lib/internal/animations-complete.ts
+++ b/packages/bits-ui/src/lib/internal/animations-complete.ts
@@ -30,14 +30,6 @@ export class AnimationsComplete {
 	run(fn: () => void | Promise<void>): void {
 		this.#cleanup();
 
-		const node = this.#opts.ref.current;
-		if (!node) return;
-
-		if (typeof node.getAnimations !== "function") {
-			this.#executeCallback(fn);
-			return;
-		}
-
 		const runId = this.#runId;
 
 		const executeIfCurrent = (): void => {
@@ -45,8 +37,12 @@ export class AnimationsComplete {
 			this.#executeCallback(fn);
 		};
 
-		const waitForAnimations = (): void => {
+		const waitForAnimations = (node: HTMLElement): void => {
 			if (runId !== this.#runId) return;
+			if (typeof node.getAnimations !== "function") {
+				executeIfCurrent();
+				return;
+			}
 			const animations = node.getAnimations();
 
 			if (animations.length === 0) {
@@ -66,7 +62,7 @@ export class AnimationsComplete {
 					);
 
 					if (hasRunningAnimations) {
-						waitForAnimations();
+						waitForAnimations(node);
 						return;
 					}
 
@@ -77,7 +73,9 @@ export class AnimationsComplete {
 		const requestWaitForAnimations = (): void => {
 			this.#currentFrame = window.requestAnimationFrame(() => {
 				this.#currentFrame = null;
-				waitForAnimations();
+				const node = this.#opts.ref.current;
+				if (!node) return;
+				waitForAnimations(node);
 			});
 		};
 
@@ -88,6 +86,8 @@ export class AnimationsComplete {
 
 		this.#currentFrame = window.requestAnimationFrame(() => {
 			this.#currentFrame = null;
+			const node = this.#opts.ref.current;
+			if (!node) return;
 			const startingStyleAttr = "data-starting-style";
 
 			if (!node.hasAttribute(startingStyleAttr)) {

--- a/tests/src/tests/dialog/dialog-open-complete.browser.test.ts
+++ b/tests/src/tests/dialog/dialog-open-complete.browser.test.ts
@@ -1,0 +1,22 @@
+import { expect, it, vi } from "vitest";
+import { page, userEvent } from "@vitest/browser/context";
+import { render } from "vitest-browser-svelte";
+import DialogTest from "./dialog-test.svelte";
+import DropdownMenuTest from "../dropdown-menu/dropdown-menu-test.svelte";
+
+it.each(["dialog", "dropdown menu"] as const)(
+	"reports open and close completion when %s content mounts on demand",
+	async (component) => {
+		const onOpenChangeComplete = vi.fn();
+		if (component === "dialog") render(DialogTest, { onOpenChangeComplete });
+		else render(DropdownMenuTest, { onOpenChangeComplete });
+
+		await expect.element(page.getByTestId("content")).not.toBeInTheDocument();
+		await page.getByTestId("trigger").click();
+		await expect.poll(() => onOpenChangeComplete.mock.calls).toEqual([[true]]);
+
+		await userEvent.keyboard("{Escape}");
+		await expect.poll(() => onOpenChangeComplete.mock.calls).toEqual([[true], [false]]);
+		await expect.element(page.getByTestId("content")).not.toBeInTheDocument();
+	}
+);


### PR DESCRIPTION
Fixes #2058. Related to #2006 for the missing `onOpenChangeComplete(true)` callback.

When opening content that mounts on demand, `AnimationsComplete.run()` can execute before the content ref attaches. It returns early, so opening completion never fires. Closing works because the content already exists.

Resolve the ref in the scheduled animation frame, including before observing `data-starting-style`. Pass the resolved node through animation waits and cancellation retries. Existing run cancellation remains in place.

The browser regressions open and close a Dialog and Dropdown Menu and assert one completion callback per state change. Both fail against upstream main. Unit coverage includes refs attached after `run`, replacement refs, starting styles, missing refs, the `getAnimations` fallback, superseded runs, and destruction. Includes a patch changeset.

Validation:

- `pnpm build:packages` — passed, including publint.
- `pnpm -F bits-ui test --run` — 137 passed, including 8 new animation tests. Five of those new cases fail against upstream main.
- Dialog and Dropdown Menu completion regressions — passed in Chromium and WebKit.
- Library and test `svelte-check` — 0 errors and 0 warnings.
- `pnpm lint` — passed.
