### PR TITLE
fix: restore body style through the CSSOM after scroll lock (CSP)

### DIFF
--- a/.changeset/quiet-lamps-restore.md
+++ b/.changeset/quiet-lamps-restore.md
@@ -1,0 +1,5 @@
+---
+"bits-ui": patch
+---
+
+fix: restore the body style through the CSSOM when the last scroll lock is released, so a Content-Security-Policy without `style-src 'unsafe-inline'` no longer leaves the page unscrollable and unclickable after closing a Dialog / Menu / Popover

--- a/packages/bits-ui/src/lib/internal/body-scroll-lock.svelte.test.ts
+++ b/packages/bits-ui/src/lib/internal/body-scroll-lock.svelte.test.ts
@@ -51,4 +51,49 @@ describe("BodyScrollLock", () => {
 			}
 		}
 	);
+
+	it("restores the body through the CSSOM so a CSP without style-src 'unsafe-inline' cannot block it", async () => {
+		const originalStyle = document.body.getAttribute("style");
+		document.body.style.cssText = "color: red;";
+		const initialStyle = document.body.getAttribute("style");
+		// Under such a CSP, `setAttribute("style", ...)` is silently ignored (and
+		// reported as a violation) while CSSOM writes still apply. Emulate that.
+		const setAttribute = vi.spyOn(document.body, "setAttribute").mockImplementation(function (
+			this: HTMLElement,
+			name: string,
+			value: string
+		) {
+			if (name === "style") return;
+			return HTMLElement.prototype.setAttribute.call(this, name, value);
+		});
+		let destroy: (() => void) | undefined;
+
+		try {
+			vi.useFakeTimers();
+			destroy = $effect.root(() => {
+				new BodyScrollLock(true);
+			});
+			flushSync();
+			await vi.runAllTimersAsync();
+			expect(document.body.style.overflow).toBe("hidden");
+			expect(document.body.style.pointerEvents).toBe("none");
+
+			destroy();
+			destroy = undefined;
+			await vi.runAllTimersAsync();
+
+			expect(setAttribute).not.toHaveBeenCalledWith("style", expect.anything());
+			expect(document.body.style.overflow).toBe("");
+			expect(document.body.style.pointerEvents).toBe("");
+			expect(document.body.getAttribute("style")).toBe(initialStyle);
+			expect(document.body.style.getPropertyValue("--scrollbar-width")).toBe("");
+		} finally {
+			destroy?.();
+			vi.clearAllTimers();
+			vi.restoreAllMocks();
+			vi.useRealTimers();
+			if (originalStyle === null) document.body.removeAttribute("style");
+			else document.body.setAttribute("style", originalStyle);
+		}
+	});
 });

--- a/packages/bits-ui/src/lib/internal/body-scroll-lock.svelte.ts
+++ b/packages/bits-ui/src/lib/internal/body-scroll-lock.svelte.ts
@@ -45,7 +45,12 @@ let cleanupScheduledAt: number | null = null;
 const bodyLockStackCount = new SharedState(() => {
 	function resetBodyStyle(documentObj: Document) {
 		if (!BROWSER) return;
-		documentObj.body.setAttribute("style", initialBodyStyle ?? "");
+		// Restore through the CSSOM, not `setAttribute("style", ...)`: a CSP without
+		// `style-src 'unsafe-inline'` treats setAttribute as an inline style and
+		// blocks it, which left the body stuck with `overflow: hidden` and
+		// `pointer-events: none` after the last lock was released. CSSOM writes
+		// (like every other style change in this module) are never CSP-governed.
+		documentObj.body.style.cssText = initialBodyStyle ?? "";
 		documentObj.body.style.removeProperty("--scrollbar-width");
 		isIOS && stopTouchMoveListener?.();
 		// reset initialBodyStyle so next locker captures the correct styles


### PR DESCRIPTION
## Problem

When the last `BodyScrollLock` is released, `resetBodyStyle` restores the body with:

```ts
documentObj.body.setAttribute("style", initialBodyStyle ?? "");
```

Under a Content-Security-Policy that has no `style-src 'unsafe-inline'` (hash- or nonce-based `style-src` / `style-src-attr`, as Astro 6, SvelteKit's `csp` option and hand-rolled strict policies produce), the browser treats that `setAttribute("style", …)` as an inline style attribute and **silently ignores it** (reporting a `style-src-attr` violation). The body therefore keeps the lock's `overflow: hidden; pointer-events: none; padding-right: …` after the Dialog / Menu / Popover closes, and the page is left unscrollable and unclickable.

Related: #1995. The report there attributes the violation to the `style.overflow = …` writes, but those are CSSOM writes and CSP does not govern them — the maintainer's pushback is right. The one call in this module that a strict CSP *does* block is the `setAttribute` restore above; it is also the only `setAttribute("style", …)` in the package.

## Fix

Restore through the CSSOM, like every other style change in the module:

```ts
documentObj.body.style.cssText = initialBodyStyle ?? "";
```

Same DOM result as the attribute write (a `style` attribute holding exactly the captured text, or an empty one), but it cannot be blocked by CSP.

## Test

New case in `body-scroll-lock.svelte.test.ts` emulates the CSP by neutering `document.body.setAttribute("style", …)` (no-op, as the browser does) and asserts that after the lock is released the body's `overflow` / `pointer-events` are cleared, the original `style` attribute text is back, `--scrollbar-width` is gone, and `setAttribute` was never called with `"style"`. It fails on the previous code with:

```
AssertionError: expected "setAttribute" to not be called with arguments: [ 'style', Anything ]
```

and passes with the fix.

## Verification

- `vitest run src/lib/internal/body-scroll-lock.svelte.test.ts` — 3 passed (the two existing delayed-cleanup cases unchanged).
- `svelte-check` on `packages/bits-ui` — 0 errors, 0 warnings; prettier + eslint clean; the package's own vitest suite (10 files, 130 tests) and the `tests` workspace's Dialog / DropdownMenu / Popover browser suites on Chromium (166 tests) pass.
- Reproduced end-to-end in a SvelteKit app served with `style-src 'self' 'unsafe-hashes' 'sha256-…'; style-src-elem 'self'; style-src-attr 'unsafe-hashes' 'sha256-…'` (no `unsafe-inline`): before this change, closing any Dialog left `document.body.style.overflow === "hidden"` and `pointer-events: none`; with it, the body is restored to `""` and scrolling/clicking work again.

Changeset: patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AFhDCyG2hHGeiCNmCbuPvZ
