### PR TITLE
fix: DismissibleLayer outside clicks during opening

### DIFF
--- a/.changeset/tidy-menus-listen.md
+++ b/.changeset/tidy-menus-listen.md
@@ -1,0 +1,5 @@
+---
+"bits-ui": patch
+---
+
+Fix outside clicks being lost while dismissible content such as DropdownMenu is opening.

--- a/packages/bits-ui/src/lib/bits/utilities/dismissible-layer/use-dismissable-layer.svelte.ts
+++ b/packages/bits-ui/src/lib/bits/utilities/dismissible-layer/use-dismissable-layer.svelte.ts
@@ -1,13 +1,13 @@
 import {
 	type ReadableBox,
 	type WritableBox,
-	afterSleep,
 	afterTick,
 	executeCallbacks,
 	onDestroyEffect,
 	type ReadableBoxedValues,
 } from "svelte-toolbelt";
 import { watch } from "runed";
+import { untrack } from "svelte";
 import { on } from "svelte/events";
 import type { DismissibleLayerImplProps, InteractOutsideBehaviorType } from "./types.js";
 import { type EventCallback } from "$lib/internal/events.js";
@@ -42,6 +42,7 @@ export class DismissibleLayerState {
 		pointerdown: false,
 	};
 	#isResponsibleLayer = false;
+	#capturedPointerDown: PointerEvent | null = null;
 	#isFocusInsideDOMTree = false;
 	#documentObj = undefined as unknown as Document;
 	#onFocusOutside: DismissibleLayerStateOpts["onFocusOutside"];
@@ -62,54 +63,34 @@ export class DismissibleLayerState {
 		this.#interactOutsideProp = opts.onInteractOutside;
 		this.#onFocusOutside = opts.onFocusOutside;
 
-		$effect(() => {
-			this.#documentObj = getOwnerDocument(this.opts.ref.current);
-		});
-
 		let unsubEvents = noop;
-		// Track the deferred afterSleep timer so teardown can cancel it. Without this,
-		// a layer destroyed within the 1ms window still fires the callback and reads a
-		// destroyed $derived (`ref.current`) → `derived_inert` (and can re-attach document
-		// listeners to a dead instance). See https://github.com/huntabyte/bits-ui/issues/2080
-		let pendingTimer: ReturnType<typeof afterSleep> | null = null;
-		const clearPendingTimer = () => {
-			if (pendingTimer != null) {
-				clearTimeout(pendingTimer);
-				pendingTimer = null;
-			}
-		};
+		let registeredNode: HTMLElement | null = null;
 
 		const cleanup = () => {
-			clearPendingTimer();
-			this.#resetState();
-			globalThis.bitsDismissableLayers.delete(this);
-			this.#handleInteractOutside.destroy();
-			unsubEvents();
-		};
-
-		watch([() => this.opts.enabled.current, () => this.opts.ref.current], () => {
-			if (!this.opts.enabled.current || !this.opts.ref.current) return;
-			clearPendingTimer();
-			pendingTimer = afterSleep(1, () => {
-				pendingTimer = null;
-				// `#destroyed` must short-circuit before any `this.opts.ref.current` read.
-				if (this.#destroyed || !this.opts.ref.current) return;
-				globalThis.bitsDismissableLayers.set(this, this.#behaviorType);
-
-				unsubEvents();
-				unsubEvents = this.#addEventListeners();
-			});
-			return cleanup;
-		});
-
-		onDestroyEffect(() => {
-			this.#destroyed = true;
-			clearPendingTimer();
+			registeredNode = null;
 			this.#resetState();
 			globalThis.bitsDismissableLayers.delete(this);
 			this.#handleInteractOutside.destroy();
 			this.#unsubClickListener();
 			unsubEvents();
+		};
+
+		watch([() => this.opts.enabled.current, () => this.opts.ref.current], ([enabled, node]) => {
+			const nextNode = enabled ? node : null;
+			// Ref boxes can invalidate without changing the DOM node during opening.
+			// Keep an in-flight interaction when this is still the same registration.
+			if (registeredNode === nextNode) return;
+			cleanup();
+			if (!nextNode) return;
+			registeredNode = nextNode;
+			this.#documentObj = getOwnerDocument(nextNode);
+			globalThis.bitsDismissableLayers.set(this, this.#behaviorType);
+			unsubEvents = this.#addEventListeners();
+		});
+
+		onDestroyEffect(() => {
+			this.#destroyed = true;
+			cleanup();
 		});
 	}
 
@@ -131,36 +112,32 @@ export class DismissibleLayerState {
 	};
 
 	#addEventListeners() {
+		const document = this.#documentObj;
+		const onPointerDownCapture = (event: PointerEvent) => {
+			untrack(() => {
+				this.#markInterceptedEvent(event);
+				this.#markResponsibleLayer(event);
+			});
+		};
+		const onPointerDown = (event: PointerEvent) => {
+			// Ignore stopped events and bubble-only events such as the opening pointerdown.
+			// It can resume bubbling after a nested early outside click has been captured.
+			if (event.cancelBubble || event !== this.#capturedPointerDown) return;
+			this.#markNonInterceptedEvent(event);
+			this.#handleInteractOutside(event);
+		};
+
+		// `svelte/events.on` defers pointer listener attachment to a microtask, leaving
+		// a gap even without a registration timer. Document is already connected, so
+		// attach immediately. Only layers present at capture can own this interaction;
+		// a layer opened by its target/bubble handlers must not dismiss itself.
+		document.addEventListener("pointerdown", onPointerDownCapture, true);
+		document.addEventListener("pointerdown", onPointerDown);
+
 		return executeCallbacks(
-			/**
-			 * CAPTURE INTERACTION START
-			 * mark interaction-start event as intercepted.
-			 * mark responsible layer during interaction start
-			 * to avoid checking if is responsible layer during interaction end
-			 * when a new floating element may have been opened.
-			 */
-			on(
-				this.#documentObj,
-				"pointerdown",
-				executeCallbacks(this.#markInterceptedEvent, this.#markResponsibleLayer),
-				{ capture: true }
-			),
-
-			/**
-			 * BUBBLE INTERACTION START
-			 * Mark interaction-start event as non-intercepted. Debounce `onInteractOutsideStart`
-			 * to avoid prematurely checking if other events were intercepted.
-			 */
-			on(
-				this.#documentObj,
-				"pointerdown",
-				executeCallbacks(this.#markNonInterceptedEvent, this.#handleInteractOutside)
-			),
-
-			/**
-			 * HANDLE FOCUS OUTSIDE
-			 */
-			on(this.#documentObj, "focusin", this.#handleFocus)
+			() => document.removeEventListener("pointerdown", onPointerDownCapture, true),
+			() => document.removeEventListener("pointerdown", onPointerDown),
+			on(document, "focusin", this.#handleFocus)
 		);
 	}
 
@@ -218,7 +195,8 @@ export class DismissibleLayerState {
 		this.#interceptedEvents[e.type] = false;
 	};
 
-	#markResponsibleLayer = () => {
+	#markResponsibleLayer = (event: PointerEvent) => {
+		this.#capturedPointerDown = event;
 		if (!this.opts.ref.current) return;
 		this.#isResponsibleLayer = isResponsibleLayer(this.opts.ref.current);
 	};
@@ -246,6 +224,7 @@ export class DismissibleLayerState {
 			this.#interceptedEvents[eventType] = false;
 		}
 		this.#isResponsibleLayer = false;
+		this.#capturedPointerDown = null;
 	};
 
 	#isAnyEventIntercepted() {

--- a/tests/src/tests/browser-utils.ts
+++ b/tests/src/tests/browser-utils.ts
@@ -89,17 +89,9 @@ export async function expectExists(loc: Locator) {
 type RegisteredLayer = { opts: { ref: { current: HTMLElement | null } } };
 
 /**
- * Waits until `loc`'s dismissible layer has attached its document listeners.
- *
- * `DismissibleLayerState` defers attachment by a tick so the interaction that opened the
- * layer can't immediately dismiss it, so a `pointerdown` dispatched before that runs is
- * silently ignored — the layer never sees it and nothing re-delivers it. Content being in
- * the DOM is therefore not enough to assert on outside-click dismissal: on a loaded CI
- * machine the deferred callback can land after the test's click, and the assertion fails
- * for every retry because the load persists.
- *
- * Waits on the layer registry the implementation itself reads, so it stays correct however
- * long attachment is delayed.
+ * Waits until `loc` has an active dismissible layer registration. Use this when
+ * inspecting a registered layer or measuring time from registration; opening-click
+ * regressions intentionally dispatch before waiting on this helper.
  */
 export async function waitForDismissibleLayer(loc: Locator) {
 	const node = loc.element() as HTMLElement;

--- a/tests/src/tests/dismissible-layer/opening-dropdown-menu-test.svelte
+++ b/tests/src/tests/dismissible-layer/opening-dropdown-menu-test.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+	import { DropdownMenu } from "bits-ui";
+	import "../../app.css";
+
+	let {
+		onInteractOutside,
+		onSelect,
+	}: {
+		onInteractOutside: (event: PointerEvent) => void;
+		onSelect: () => void;
+	} = $props();
+</script>
+
+<DropdownMenu.Root>
+	<DropdownMenu.Trigger data-testid="trigger">Actions</DropdownMenu.Trigger>
+	<DropdownMenu.Portal>
+		<DropdownMenu.Content data-testid="content" {onInteractOutside}>
+			<DropdownMenu.Item {onSelect}>Action</DropdownMenu.Item>
+		</DropdownMenu.Content>
+	</DropdownMenu.Portal>
+</DropdownMenu.Root>

--- a/tests/src/tests/dismissible-layer/opening-outside-click.browser.test.ts
+++ b/tests/src/tests/dismissible-layer/opening-outside-click.browser.test.ts
@@ -1,0 +1,87 @@
+import { page } from "@vitest/browser/context";
+import { describe, expect, it, vi } from "vitest";
+import { render } from "vitest-browser-svelte";
+import DropdownMenuTest from "./opening-dropdown-menu-test.svelte";
+import ComboboxTest from "../combobox/combobox-test.svelte";
+import { expectNotExists, waitForDismissibleLayer } from "../browser-utils";
+
+function outsideClick() {
+	for (const type of ["pointerdown", "mousedown", "pointerup", "mouseup", "click"]) {
+		const EventType = type.startsWith("pointer") ? PointerEvent : MouseEvent;
+		document.documentElement.dispatchEvent(
+			new EventType(type, {
+				bubbles: true,
+				composed: true,
+				cancelable: true,
+				clientX: window.innerWidth - 1,
+				clientY: 1,
+				button: 0,
+				buttons: type.endsWith("down") ? 1 : 0,
+				pointerType: "mouse",
+			})
+		);
+	}
+}
+
+describe("dismissible layer - opening outside click", () => {
+	for (const component of ["DropdownMenu", "Combobox"] as const) {
+		it(`${component} dismisses an outside click during opening and immediate reopen`, async () => {
+			const onInteractOutside = vi.fn();
+			const onSelect = vi.fn();
+			const contentProps = { onInteractOutside };
+			if (component === "DropdownMenu") {
+				render(DropdownMenuTest, { onInteractOutside, onSelect });
+			} else {
+				render(ComboboxTest, { items: [{ value: "1", label: "One" }], contentProps });
+			}
+
+			for (let attempt = 1; attempt <= 2; attempt++) {
+				let clickedDuringOpening = false;
+				// Dispatch in the first DOM-observer turn, before delayed registration can
+				// run. DropdownMenu must still have Presence's public opening marker.
+				const observer = new MutationObserver(() => {
+					const selector =
+						component === "DropdownMenu"
+							? '[data-testid="content"][data-starting-style]'
+							: '[data-testid="content"]';
+					if (!document.querySelector(selector)) return;
+					observer.disconnect();
+					clickedDuringOpening = true;
+					outsideClick();
+				});
+				observer.observe(document.body, {
+					childList: true,
+					subtree: true,
+					attributes: true,
+				});
+
+				try {
+					await page.getByTestId("trigger").click({ force: true });
+					await expect
+						.poll(() => clickedDuringOpening, { message: `opening attempt ${attempt}` })
+						.toBe(true);
+					await expect.poll(() => onInteractOutside.mock.calls.length).toBe(attempt);
+					expect(onInteractOutside.mock.lastCall?.[0].target).toBe(
+						document.documentElement
+					);
+					await expectNotExists(page.getByTestId("content"));
+					expect(onSelect).not.toHaveBeenCalled();
+					if (component === "Combobox") {
+						await expect
+							.element(page.getByTestId("value-binding"))
+							.toHaveTextContent("empty");
+					}
+				} finally {
+					observer.disconnect();
+					// On a broken implementation, verify the identical sequence dismisses
+					// later. This also leaves the next fixture free of an open modal layer.
+					if (document.querySelector('[data-testid="content"]')) {
+						await waitForDismissibleLayer(page.getByTestId("content"));
+						outsideClick();
+						await expectNotExists(page.getByTestId("content"));
+					}
+				}
+			}
+		});
+	}
+});

--- a/tests/src/tests/dismissible-layer/registration-lifecycle-test.svelte
+++ b/tests/src/tests/dismissible-layer/registration-lifecycle-test.svelte
@@ -1,0 +1,61 @@
+<script lang="ts">
+	import { flushSync } from "svelte";
+	import { DropdownMenu } from "bits-ui";
+
+	let { mode = "single" }: { mode?: "single" | "opening" } = $props();
+
+	let open = $state(mode !== "opening");
+	let revision = $state(0);
+	let contentVersion = $state(0);
+	let dismissals = $state(0);
+
+	function rerenderDuringOutsidePointerdown() {
+		revision += 1;
+		flushSync();
+	}
+
+	function openDuringPointerdown() {
+		open = true;
+		flushSync();
+	}
+</script>
+
+<button data-testid="open-during-pointerdown" onpointerdown={openDuringPointerdown}> open </button>
+<DropdownMenu.Root bind:open>
+	<DropdownMenu.Portal>
+		<DropdownMenu.Content
+			style={`--registration-revision: ${revision}`}
+			onInteractOutside={() => (dismissals += 1)}
+		>
+			{#snippet child({ props })}
+				{#key contentVersion}
+					<div {...props} data-testid="layer">
+						<button
+							data-testid="replace-ref"
+							onpointerdown={() => (contentVersion += 1)}
+						>
+							replace
+						</button>
+						<output data-testid="revision">{revision}</output>
+					</div>
+				{/key}
+			{/snippet}
+		</DropdownMenu.Content>
+	</DropdownMenu.Portal>
+</DropdownMenu.Root>
+<button data-testid="rerender-outside" onpointerdown={rerenderDuringOutsidePointerdown}>
+	rerender outside
+</button>
+<button data-testid="intercepted-outside" onpointerdown={(event) => event.stopPropagation()}>
+	intercepted outside
+</button>
+<button data-testid="outside">outside</button>
+<button
+	data-testid="disable"
+	onclick={() => {
+		open = false;
+		flushSync();
+	}}>disable</button
+>
+<output data-testid="dismissals">{dismissals}</output>
+<output data-testid="revision-count">{revision}</output>

--- a/tests/src/tests/dismissible-layer/registration-lifecycle.browser.test.ts
+++ b/tests/src/tests/dismissible-layer/registration-lifecycle.browser.test.ts
@@ -1,0 +1,139 @@
+import { page } from "@vitest/browser/context";
+import { tick } from "svelte";
+import { describe, expect, it, vi } from "vitest";
+import { render } from "vitest-browser-svelte";
+import RegistrationLifecycleTest from "./registration-lifecycle-test.svelte";
+import { expectExists } from "../browser-utils";
+
+const waitForDismissal = async (testId = "dismissals") => {
+	await vi.waitFor(() => expect(page.getByTestId(testId).element().textContent).toBe("1"));
+};
+
+function dispatchPointerdown(target: HTMLElement, pointerType = "mouse") {
+	target.dispatchEvent(
+		new PointerEvent("pointerdown", {
+			bubbles: true,
+			cancelable: true,
+			pointerType,
+			button: 0,
+			clientX: window.innerWidth - 1,
+			clientY: 1,
+		})
+	);
+}
+
+describe("dismissible layer registration lifecycle", () => {
+	it("keeps an in-flight outside interaction when the same ref rerenders", async () => {
+		render(RegistrationLifecycleTest);
+		await expectExists(page.getByTestId("layer"));
+
+		dispatchPointerdown(page.getByTestId("rerender-outside").element() as HTMLElement);
+		await waitForDismissal();
+		expect(page.getByTestId("revision-count").element().textContent).toBe("1");
+	});
+
+	it("registers the replacement ref after the previous node is removed", async () => {
+		render(RegistrationLifecycleTest);
+		const initialLayer = page.getByTestId("layer").element();
+
+		dispatchPointerdown(page.getByTestId("replace-ref").element() as HTMLElement);
+		await vi.waitFor(() => expect(page.getByTestId("layer").element()).not.toBe(initialLayer));
+
+		dispatchPointerdown(page.getByTestId("outside").element() as HTMLElement);
+		await waitForDismissal();
+	});
+
+	it("does not dismiss from the pointerdown that synchronously mounts the layer", async () => {
+		render(RegistrationLifecycleTest, { mode: "opening" });
+
+		dispatchPointerdown(page.getByTestId("open-during-pointerdown").element() as HTMLElement);
+		await expectExists(page.getByTestId("layer"));
+		await new Promise((resolve) => setTimeout(resolve, 20));
+		expect(page.getByTestId("dismissals").element().textContent).toBe("0");
+
+		dispatchPointerdown(page.getByTestId("outside").element() as HTMLElement);
+		await waitForDismissal();
+	});
+
+	it("does not leave a layer registered when it unmounts from the opening mutation", async () => {
+		const view = render(RegistrationLifecycleTest, { mode: "opening" });
+		type RegisteredLayer = { opts: { ref: { current: HTMLElement | null } } };
+		const layers = (
+			globalThis as {
+				bitsDismissableLayers?: Map<RegisteredLayer, unknown>;
+			}
+		).bitsDismissableLayers!;
+		let openedNode: HTMLElement | null = null;
+		let destroyedLayer: RegisteredLayer | undefined;
+		let originalRef: RegisteredLayer["opts"]["ref"] | undefined;
+		const readRef = vi.fn();
+		let unmounted = false;
+		const observer = new MutationObserver(() => {
+			const node = document.querySelector<HTMLElement>('[data-testid="layer"]');
+			if (!node) return;
+			observer.disconnect();
+			openedNode = node;
+			destroyedLayer = [...layers.keys()].find((layer) => layer.opts.ref.current === node);
+			if (destroyedLayer) {
+				originalRef = destroyedLayer.opts.ref;
+				destroyedLayer.opts.ref = {
+					get current() {
+						readRef();
+						return originalRef!.current;
+					},
+					set current(value) {
+						originalRef!.current = value;
+					},
+				};
+			}
+			view.unmount();
+			readRef.mockClear();
+			unmounted = true;
+		});
+
+		observer.observe(document.body, { childList: true, subtree: true });
+		try {
+			dispatchPointerdown(
+				page.getByTestId("open-during-pointerdown").element() as HTMLElement
+			);
+			await vi.waitFor(() => expect(unmounted).toBe(true));
+			await tick();
+			await new Promise((resolve) => setTimeout(resolve, 20));
+			expect([...layers].some(([layer]) => layer.opts.ref.current === openedNode)).toBe(
+				false
+			);
+			document.body.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true }));
+			expect(readRef).not.toHaveBeenCalled();
+		} finally {
+			observer.disconnect();
+			if (destroyedLayer && originalRef) destroyedLayer.opts.ref = originalRef;
+		}
+	});
+
+	it("does not dismiss an interaction whose delegated target stops propagation", async () => {
+		render(RegistrationLifecycleTest);
+		await expectExists(page.getByTestId("layer"));
+
+		dispatchPointerdown(page.getByTestId("intercepted-outside").element() as HTMLElement);
+		await new Promise((resolve) => setTimeout(resolve, 20));
+		expect(page.getByTestId("dismissals").element().textContent).toBe("0");
+
+		dispatchPointerdown(page.getByTestId("outside").element() as HTMLElement);
+		await waitForDismissal();
+	});
+
+	it("cancels a pending touch click when the layer is disabled", async () => {
+		render(RegistrationLifecycleTest);
+		await expectExists(page.getByTestId("layer"));
+
+		const outside = page.getByTestId("outside").element() as HTMLElement;
+		dispatchPointerdown(outside, "touch");
+		await new Promise((resolve) => setTimeout(resolve, 20));
+		(page.getByTestId("disable").element() as HTMLElement).click();
+		await tick();
+		outside.dispatchEvent(new MouseEvent("click", { bubbles: true, button: 0 }));
+		await new Promise((resolve) => setTimeout(resolve, 20));
+
+		expect(page.getByTestId("dismissals").element().textContent).toBe("0");
+	});
+});


### PR DESCRIPTION
## Summary

- Capture outside pointer interactions immediately while dismissible content opens.
- Preserve registration across rerenders and correctly handle replacement refs and teardown.
- Add regression coverage for DropdownMenu, Combobox, lifecycle, propagation, and touch interactions.
- Add a patch changeset for `bits-ui`.

## Testing

- Added browser tests for opening outside clicks and registration lifecycle behavior.
- Existing test suite not run.